### PR TITLE
Fix voting progress row and statement sequence number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .claude/
 notes.md
 tmp/
+.dev-session
 
 # Design handoff (local reference only)
 design_handoff_propose_and_arguments/

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DOCKER_DIR="$(cd "$SCRIPT_DIR/../particiapp-docker" && pwd)"
+FLASK_DIR="$SCRIPT_DIR/v2"
+SESSION_FILE="$SCRIPT_DIR/.dev-session"
+
+# ── Session file ──────────────────────────────────────────────────────────────
+# Create with defaults on first run; edit to change port assignments.
+
+if [ ! -f "$SESSION_FILE" ]; then
+  cat > "$SESSION_FILE" <<'EOF'
+POSTGRES_PORT=5432
+PARTICIAPI_PORT=8000
+POLIS_PORT=8001
+FLASK_PORT=5000
+EOF
+fi
+
+# shellcheck source=/dev/null
+source "$SESSION_FILE"
+
+session_set() {
+  local key="$1" val="$2"
+  if grep -q "^${key}=" "$SESSION_FILE" 2>/dev/null; then
+    sed -i '' "s|^${key}=.*|${key}=${val}|" "$SESSION_FILE"
+  else
+    echo "${key}=${val}" >> "$SESSION_FILE"
+  fi
+}
+
+# ── Docker stack ──────────────────────────────────────────────────────────────
+
+COMPOSE="docker compose \
+  -f $DOCKER_DIR/docker-compose.yaml \
+  -f $DOCKER_DIR/docker-compose.wiki-polis.yaml \
+  -f $DOCKER_DIR/docker-compose.local.yaml"
+
+stop_docker() {
+  echo ""
+  echo "Stopping Docker stack..."
+  $COMPOSE down
+  session_set POSTGRES_STATUS stopped
+  session_set PARTICIAPI_STATUS stopped
+  session_set FLASK_STATUS stopped
+}
+
+if docker ps --filter "name=particiapp-docker" --format "{{.Names}}" | grep -q .; then
+  echo "particiapp-docker stack already running — skipping docker compose up"
+else
+  echo "Starting Docker stack..."
+  POSTGRES_HOST_PORT=$POSTGRES_PORT $COMPOSE up -d
+  trap stop_docker EXIT
+fi
+
+session_set POSTGRES_STATUS waiting
+echo "Waiting for postgres on :$POSTGRES_PORT..."
+until docker exec particiapp-docker-postgres-1 pg_isready -U polis -q 2>/dev/null; do
+  sleep 2
+done
+session_set POSTGRES_STATUS ready
+
+session_set PARTICIAPI_STATUS waiting
+echo "Waiting for particiapi on :$PARTICIAPI_PORT..."
+until curl -o /dev/null -sf -w "%{http_code}" "http://127.0.0.1:$PARTICIAPI_PORT/" 2>/dev/null | grep -qE "^[2345]"; do
+  sleep 2
+done
+session_set PARTICIAPI_STATUS ready
+
+echo ""
+echo "Stack ready."
+echo "  Particiapi : http://127.0.0.1:$PARTICIAPI_PORT"
+echo "  Polis      : http://127.0.0.1:$POLIS_PORT"
+echo "  Flask app  : http://127.0.0.1:$FLASK_PORT  (starting now)"
+echo "  Dev login  : http://127.0.0.1:$FLASK_PORT/dev-login"
+echo ""
+
+# ── Flask ─────────────────────────────────────────────────────────────────────
+
+# Kill any stale Python processes on this port
+STALE=$(lsof -ti :"$FLASK_PORT" | xargs ps -p 2>/dev/null | grep -i python | awk '{print $1}' || true)
+if [ -n "$STALE" ]; then
+  echo "Killing stale Flask process(es): $STALE"
+  kill $STALE 2>/dev/null || true
+  sleep 1
+fi
+
+# Warn if AirPlay Receiver is still holding the port
+if lsof -i :"$FLASK_PORT" | grep -q ControlCe 2>/dev/null; then
+  echo "WARNING: AirPlay Receiver (ControlCenter) is using port $FLASK_PORT."
+  echo "  Disable: System Settings > General > AirDrop & Handoff > AirPlay Receiver"
+  echo ""
+fi
+
+session_set FLASK_STATUS running
+cd "$FLASK_DIR"
+exec uv run flask run --host 127.0.0.1 --port "$FLASK_PORT"

--- a/v2/app.py
+++ b/v2/app.py
@@ -346,7 +346,11 @@ def create_app(test_config: dict | None = None) -> Flask:
     _secret_key = (test_config or {}).get('SECRET_KEY') or _read_secret('secret-key')
     if not _secret_key:
         if not app.debug:
-            raise RuntimeError('secret-key is required in production — set SECRET_KEY env var or Kubernetes secret')
+            raise RuntimeError(
+                'SECRET_KEY is not set. '
+                'Generate one with: python -c "import secrets; print(secrets.token_hex(32))" '
+                'then set it as the "secret-key" Kubernetes secret or SECRET_KEY env var.'
+            )
         _secret_key = 'dev-insecure-key'
     app.config['SECRET_KEY'] = _secret_key
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False

--- a/v2/next_steps.md
+++ b/v2/next_steps.md
@@ -86,6 +86,7 @@ Security, code quality, and computational social science reviews conducted (2026
 - [x] Lazy nullification in conversation view: clears identity links at `cooldown + window` days post-close
 - [x] Minimum-N warning on results (< 25 participants): shown above public results, does not hide results
 - [x] Consent copy on accept page updated to reflect platform-wide pseudonym uniqueness and operator data retention
+- [ ] **TODO: open GitHub issue** — audit consistency of pseudonymity / vote privacy messaging across all user-facing surfaces (accept page, conversation view, results page, reveal flow). Ensure the platform's promises (votes are private, pseudonym is per-platform, identity reveal is opt-in post-close) are communicated clearly and consistently everywhere a participant might wonder.
 
 ---
 
@@ -126,8 +127,8 @@ Web component integration bugs found and fixed during browser testing:
 - [x] Propose affordance inside idle card: dashed amber button, margin-top 18px from vote buttons
 
 **Voting flow — remaining from design handoff**
-- [x] **Progress row not populated** (#2): `particiappstatementschange` listener added; derives `done`/`total` from `e.statements` Map position of `conv.statement`; populates bar and count. (PR #21)
-- [x] **Statement number missing** (#3): Same listener updates `.stmt-meta-label` to `STATEMENT · #N`. (PR #21)
+- [x] **Progress row not populated**: Fixed in PR #21. Listens to `particiappstatementschange` (poll cycles) and `particiappstatechange` `'loaded'` (initial load via `conv.client.statements`); builds `.vote-seg` elements and shows done/total counts.
+- [x] **Statement number removed**: `STATEMENT · #N` was dropped — statement order is session-specific and random (Fisher-Yates shuffle in `particiapp-web-client.js` → `#fetchStatements`, then re-sorted meta → seed → user-submitted), so a sequence number is meaningless across users. Label stays as plain `STATEMENT`. No information-gain routing is implemented yet (described aspirationally in `functional_design.md`).
 
 **Accept / join page**
 - [x] Rewritten as plain-English "how it works" intro — less legalistic

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -678,38 +678,28 @@
     var total = statements.size;
     if (total === 0) return;
 
-    var current = conv.statement; // null if all done
-    var done = total; // default: all done
-    if (current !== null) {
-      var pos = 0;
-      var found = false;
-      statements.forEach(function (stmt) {
-        if (!found) {
-          if (stmt.id === current.id) { done = pos; found = true; }
-          else { pos++; }
-        }
-      });
-    }
+    // Count votes from the server-persisted participant record so progress
+    // is accurate across sessions. Own submitted statements are auto-voted
+    // server-side and already included in participant.votes.
+    var votedIds = conv.client.participant.votes;
+    var done = 0;
+    statements.forEach(function (stmt, id) {
+      if (votedIds.has(id)) done++;
+    });
 
     // Show progress row and populate counts
     progressRow.style.display = '';
     votesDone.textContent = done;
     votesTotal.textContent = total;
 
-    // Rebuild segmented bar
-    var segs = [];
-    var i = 0;
-    statements.forEach(function () {
-      var seg = document.createElement('div');
-      seg.className = 'vote-seg ' + (i < done ? 'vote-seg--done' : i === done ? 'vote-seg--current' : 'vote-seg--queued');
-      segs.push(seg);
-      i++;
-    });
+    // Rebuild segmented bar: done segments first, then current (if any), then queued.
+    var current = conv.statement; // null if all done
     progressBar.innerHTML = '';
-    segs.forEach(function (seg) { progressBar.appendChild(seg); });
-
-    // Statement order is randomised per session; a sequence number would be
-    // misleading. Labels stay as the static "STATEMENT" text in the HTML.
+    for (var i = 0; i < total; i++) {
+      var seg = document.createElement('div');
+      seg.className = 'vote-seg ' + (i < done ? 'vote-seg--done' : (current !== null && i === done) ? 'vote-seg--current' : 'vote-seg--queued');
+      progressBar.appendChild(seg);
+    }
   }
 
   // particiappstatementschange only fires on poll cycles, not on initial load.

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -708,6 +708,10 @@
     updateProgress(e.statements);
   });
 
+  conv.addEventListener('particiappvotesubmitsuccess', function () {
+    updateProgress(conv.client.statements);
+  });
+
   // ── Error ─────────────────────────────────────────────────────────────────────
   conv.addEventListener('particiappstatechange', function (e) {
     if (e.state === 'error') {

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -674,8 +674,7 @@
   document.getElementById('propose-next').addEventListener('click', enterIdle);
 
   // ── Progress row + statement sequence number (issues #2 and #3) ──────────────
-  conv.addEventListener('particiappstatementschange', function (e) {
-    var statements = e.statements; // Map<number, Statement>
+  function updateProgress(statements) {
     var total = statements.size;
     if (total === 0) return;
 
@@ -709,13 +708,14 @@
     progressBar.innerHTML = '';
     segs.forEach(function (seg) { progressBar.appendChild(seg); });
 
-    // Update statement label (issue #3)
-    if (current !== null) {
-      var idx = done + 1; // 1-based index of current statement
-      stmtMetaLabels.forEach(function (el) {
-        el.textContent = 'STATEMENT · #' + idx;
-      });
-    }
+    // Statement order is randomised per session; a sequence number would be
+    // misleading. Labels stay as the static "STATEMENT" text in the HTML.
+  }
+
+  // particiappstatementschange only fires on poll cycles, not on initial load.
+  // We also call updateProgress from the 'loaded' state handler using conv.client.statements.
+  conv.addEventListener('particiappstatementschange', function (e) {
+    updateProgress(e.statements);
   });
 
   // ── Error ─────────────────────────────────────────────────────────────────────
@@ -725,6 +725,9 @@
       convErrorMsg.textContent = 'Could not connect to the voting server. Please refresh the page.';
     } else if (e.state === 'loaded' || e.state === 'loading') {
       convError.hidden = true;
+    }
+    if (e.state === 'loaded' && conv.client) {
+      updateProgress(conv.client.statements);
     }
   });
 }());

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -582,6 +582,11 @@
   var pvbSubmitStmt = document.getElementById('pvb-submit-stmt');
   var convError     = document.getElementById('conv-error');
   var convErrorMsg  = document.getElementById('conv-error-msg');
+  var progressRow   = document.getElementById('vote-progress-row');
+  var votesDone     = document.getElementById('votes-done');
+  var votesTotal    = document.getElementById('votes-total');
+  var progressBar   = document.getElementById('vote-progress-bar');
+  var stmtMetaLabels = document.querySelectorAll('.stmt-meta-label');
 
   var LABELS = { agree: 'AGREE', neutral: 'PASS', disagree: 'DISAGREE' };
   var originalStmtText = '';
@@ -667,6 +672,51 @@
 
   // ── Propose: next statement (manual fallback in submitted state) ──────────────
   document.getElementById('propose-next').addEventListener('click', enterIdle);
+
+  // ── Progress row + statement sequence number (issues #2 and #3) ──────────────
+  conv.addEventListener('particiappstatementschange', function (e) {
+    var statements = e.statements; // Map<number, Statement>
+    var total = statements.size;
+    if (total === 0) return;
+
+    var current = conv.statement; // null if all done
+    var done = total; // default: all done
+    if (current !== null) {
+      var pos = 0;
+      var found = false;
+      statements.forEach(function (stmt) {
+        if (!found) {
+          if (stmt.id === current.id) { done = pos; found = true; }
+          else { pos++; }
+        }
+      });
+    }
+
+    // Show progress row and populate counts
+    progressRow.style.display = '';
+    votesDone.textContent = done;
+    votesTotal.textContent = total;
+
+    // Rebuild segmented bar
+    var segs = [];
+    var i = 0;
+    statements.forEach(function () {
+      var seg = document.createElement('div');
+      seg.className = 'vote-seg ' + (i < done ? 'vote-seg--done' : i === done ? 'vote-seg--current' : 'vote-seg--queued');
+      segs.push(seg);
+      i++;
+    });
+    progressBar.innerHTML = '';
+    segs.forEach(function (seg) { progressBar.appendChild(seg); });
+
+    // Update statement label (issue #3)
+    if (current !== null) {
+      var idx = done + 1; // 1-based index of current statement
+      stmtMetaLabels.forEach(function (el) {
+        el.textContent = 'STATEMENT · #' + idx;
+      });
+    }
+  });
 
   // ── Error ─────────────────────────────────────────────────────────────────────
   conv.addEventListener('particiappstatechange', function (e) {


### PR DESCRIPTION
## Summary

- **Issue #2** — Progress row was always hidden (`display:none`). Now shows on load and updates correctly.
- **Issue #3** — `STATEMENT · #N` label dropped: statement order is randomised per session (Fisher-Yates in `particiapp-web-client.js`), so a sequence number is meaningless across users. Header stays as plain `STATEMENT`.

**Key fixes:**

1. **Initial load**: `particiappstatementschange` only fires on poll cycles, not on page load. Fixed by also calling `updateProgress()` from the `'loaded'` state handler via `conv.client.statements`.

2. **Cross-session accuracy**: `done` count was previously derived from position in the randomised statement map — resetting to 0 on each page load. Now reads from `conv.client.participant.votes` (server-persisted), so progress reflects all votes cast across sessions. Own submitted statements are auto-voted server-side and already included.

**Also included:**
- `dev.sh` — one-shot local dev launcher (Docker stack + Flask) with `.dev-session` port config file
- Improved `SECRET_KEY` missing error with generation one-liner
- `next_steps.md` updated with ordering rationale and pseudonymity messaging audit TODO

## Test plan

- [x] Load a conversation — progress bar appears immediately (not after first poll)
- [x] Verify `done / total` matches actual votes cast, including from previous sessions
- [x] Cast a vote — done count increments, segment turns `vote-seg--done`
- [ ] Vote through all — done equals total, all segments `vote-seg--done`
- [x] Statement header shows plain `STATEMENT` (no `#N`)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)