### PR TITLE
Polis client split, admin moderation, toast notifications

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -16,7 +16,7 @@ import coolname
 import nh3
 import requests
 from dotenv import load_dotenv
-from flask import (Flask, abort, current_app, g, jsonify, make_response,
+from flask import (Flask, abort, current_app, flash, g, jsonify, make_response,
                    redirect, render_template, request, session, url_for)
 from flask_migrate import Migrate
 from flask_session import Session
@@ -29,8 +29,8 @@ from sqlalchemy.orm import joinedload
 from db import (ACCESS_POLICIES, ADMIN_ROLES, AdminRole, Argument, ArgumentSideState,
                 ArgumentVote, Conversation, ConversationInvite, FeaturedStatement,
                 Participant, Participation, db)
-from polis_admin import (PolisAdminClient, PolisAdminError, PolisServerClient,
-                         PolisServerError, get_featured_candidates, get_polis_stats)
+from polis_admin import (PolisParticipantClient, PolisParticipantError,
+                         PolisServerClient, PolisServerError)
 
 load_dotenv(os.path.join(os.path.dirname(os.path.abspath(__file__)), '.env'))
 
@@ -199,6 +199,22 @@ def admin_required(f):
             abort(403)
         return f(*args, **kwargs)
     return wrapper
+
+
+def _polis_server_client() -> PolisServerClient:
+    """Return a PolisServerClient from config.
+
+    Always returns a client — DB-only methods (get_polis_stats,
+    get_featured_candidates) work with db_url alone.  HTTP admin methods
+    (moderate, add_seed, etc.) will raise PolisServerError at login if
+    POLIS_SERVER_URL / POLIS_ADMIN_EMAIL / POLIS_ADMIN_PASSWORD are absent.
+    """
+    return PolisServerClient(
+        current_app.config.get('POLIS_SERVER_URL', ''),
+        current_app.config.get('POLIS_ADMIN_EMAIL', ''),
+        current_app.config.get('POLIS_ADMIN_PASSWORD', ''),
+        db_url=current_app.config.get('POLIS_DATABASE_URL', ''),
+    )
 
 
 def _require_mod_for_conv(conv_id: int) -> 'Conversation':
@@ -725,7 +741,7 @@ def _register_routes(app: Flask) -> None:
 
         stmt_texts = {}
         try:
-            client = PolisAdminClient(current_app.config['PARTICIAPI_BASE'])
+            client = PolisParticipantClient(current_app.config['PARTICIAPI_BASE'])
             _, approved, _ = client.get_statements(conv.polis_id)
             stmt_texts = {s['tid']: s.get('txt', '') for s in approved}
         except Exception:
@@ -819,10 +835,9 @@ def _register_routes(app: Flask) -> None:
         results     = None
         polis_stats = None
         if conv.phase_public_results:
-            client      = PolisAdminClient(current_app.config['PARTICIAPI_BASE'])
-            results     = client.get_results(conv.polis_id)
-            polis_stats = get_polis_stats(conv.polis_id,
-                                          current_app.config['POLIS_DATABASE_URL'])
+            results      = PolisParticipantClient(
+                current_app.config['PARTICIAPI_BASE']).get_results(conv.polis_id)
+            polis_stats = _polis_server_client().get_polis_stats(conv.polis_id)
 
         # Reveal window state for closed conversations.
         reveal_state    = None
@@ -1261,7 +1276,7 @@ def _register_routes(app: Flask) -> None:
                                conversations=conversations,
                                participants=participants,
                                global_admins=global_admins,
-                               admin_error=request.args.get('error'))
+                               )
 
     @app.get('/admin/conversations/<int:conv_id>')
     @login_required
@@ -1274,8 +1289,7 @@ def _register_routes(app: Flask) -> None:
         participants      = Participant.query.order_by(Participant.mw_username).all()
         invite_count      = ConversationInvite.query.filter_by(conversation_id=conv_id).count()
         participant_count = Participation.query.filter_by(conversation_id=conv_id).count()
-        polis_stats       = get_polis_stats(conv.polis_id,
-                                            current_app.config['POLIS_DATABASE_URL'])
+        polis_stats       = _polis_server_client().get_polis_stats(conv.polis_id)
         return render_template('admin_conversation.html',
                                conversation=conv,
                                conv_roles=conv_roles,
@@ -1296,17 +1310,15 @@ def _register_routes(app: Flask) -> None:
         if not fields['title'] or not _valid_slug(slug):
             abort(400)
 
-        polis_url      = current_app.config.get('POLIS_SERVER_URL', '')
-        polis_email    = current_app.config.get('POLIS_ADMIN_EMAIL', '')
-        polis_password = current_app.config.get('POLIS_ADMIN_PASSWORD', '')
-
-        if polis_url and polis_email and polis_password:
+        polis_configured = all(current_app.config.get(k) for k in (
+            'POLIS_SERVER_URL', 'POLIS_ADMIN_EMAIL', 'POLIS_ADMIN_PASSWORD'))
+        if polis_configured:
             try:
-                client   = PolisServerClient(polis_url, polis_email, polis_password)
-                polis_id = client.create_conversation(fields['title'])
+                polis_id = _polis_server_client().create_conversation(fields['title'])
             except PolisServerError as exc:
                 current_app.logger.error('Polis conversation creation failed: %s', exc)
-                return redirect(url_for('admin', error=f'Could not create Polis conversation: {exc}'))
+                flash('Could not create the Polis conversation. Check server logs for details.', 'error')
+                return redirect(url_for('admin'))
         else:
             # Fallback: accept manually supplied polis_id (local dev / misconfigured prod)
             polis_id = request.form.get('polis_id', '').strip()
@@ -1379,10 +1391,12 @@ def _register_routes(app: Flask) -> None:
     def admin_global_admin_add():
         mw_username = (request.form.get('mw_username') or '').strip()
         if not mw_username:
-            return redirect(url_for('admin', error='Enter a Wikimedia username.'))
+            flash('Enter a Wikimedia username.', 'error')
+            return redirect(url_for('admin'))
         p = Participant.query.filter_by(mw_username=mw_username).first()
         if not p:
-            return redirect(url_for('admin', error=f'No account found for "{mw_username}". They must log in at least once first.'))
+            flash(f'No account found for "{mw_username}". They must log in at least once first.', 'error')
+            return redirect(url_for('admin'))
         p.is_global_admin = True
         db.session.commit()
         return redirect(url_for('admin'))
@@ -1482,22 +1496,21 @@ def _register_routes(app: Flask) -> None:
     @login_required
     def admin_conversation_statements(conv_id):
         conv   = _require_mod_for_conv(conv_id)
-        client = PolisAdminClient(current_app.config['PARTICIAPI_BASE'])
-        error  = request.args.get('error')
+        client = PolisParticipantClient(current_app.config['PARTICIAPI_BASE'])
         pending = approved = hidden = []
         settings = {}
         try:
             pending, approved, hidden = client.get_statements(conv.polis_id)
             settings = client.get_settings(conv.polis_id)
-        except PolisAdminError as exc:
-            error = str(exc)
+        except PolisParticipantError as exc:
+            current_app.logger.error('get_statements failed: %s', exc)
+            flash('Could not load statements from Particiapi. Check server logs.', 'error')
         return render_template('admin_statements.html',
                                conversation=conv,
                                pending=pending,
                                approved=approved,
                                hidden=hidden,
                                settings=settings,
-                               error=error,
                                polis_public_url=current_app.config.get('POLIS_PUBLIC_URL', 'https://pol.is'))
 
     @app.post('/admin/conversations/<int:conv_id>/statements/<int:tid>/moderate')
@@ -1507,13 +1520,12 @@ def _register_routes(app: Flask) -> None:
         mod  = request.form.get('mod', type=int)
         if mod not in (-1, 0, 1):
             abort(400)
-        client = PolisAdminClient(current_app.config['PARTICIAPI_BASE'])
         try:
-            client.moderate(conv.polis_id, tid, mod)
-        except PolisAdminError as exc:
+            _polis_server_client().moderate(conv.polis_id, tid, mod)
+        except PolisServerError as exc:
             current_app.logger.error('moderate failed: %s', exc)
-            return redirect(url_for('admin_conversation_statements',
-                                    conv_id=conv_id, error=str(exc)))
+            flash('Moderation action failed. Check server logs for details.', 'error')
+            return redirect(url_for('admin_conversation_statements', conv_id=conv_id))
         return redirect(url_for('admin_conversation_statements', conv_id=conv_id))
 
     @app.post('/admin/conversations/<int:conv_id>/statements/seed')
@@ -1524,13 +1536,11 @@ def _register_routes(app: Flask) -> None:
         text = nh3.clean(text, tags=frozenset())
         if not text or len(text) > 280:
             abort(400)
-        client = PolisAdminClient(current_app.config['PARTICIAPI_BASE'])
         try:
-            client.add_seed(conv.polis_id, text)
-        except PolisAdminError as exc:
+            _polis_server_client().add_seed(conv.polis_id, text)
+        except PolisServerError as exc:
             current_app.logger.error('add_seed failed: %s', exc)
-            return redirect(url_for('admin_conversation_statements',
-                                    conv_id=conv_id, error=str(exc)))
+            flash('Could not add seed statement. Check server logs for details.', 'error')
         return redirect(url_for('admin_conversation_statements', conv_id=conv_id))
 
     @app.post('/admin/conversations/<int:conv_id>/strict-moderation')
@@ -1538,11 +1548,11 @@ def _register_routes(app: Flask) -> None:
     def admin_conversation_strict_moderation(conv_id):
         conv    = _require_mod_for_conv(conv_id)
         enabled = request.form.get('strict_moderation') == '1'
-        client  = PolisAdminClient(current_app.config['PARTICIAPI_BASE'])
         try:
-            client.set_strict_moderation(conv.polis_id, enabled)
-        except PolisAdminError as exc:
+            _polis_server_client().set_strict_moderation(conv.polis_id, enabled)
+        except PolisServerError as exc:
             current_app.logger.error('set_strict_moderation failed: %s', exc)
+            flash('Could not update moderation settings. Check server logs for details.', 'error')
         return redirect(url_for('admin_conversation_statements', conv_id=conv_id))
 
     # ── Featured statements ───────────────────────────────────────────────────
@@ -1552,11 +1562,11 @@ def _register_routes(app: Flask) -> None:
         missing = [fs for fs in confirmed if not fs.statement_text]
         if not missing:
             return False
-        client = PolisAdminClient(current_app.config['PARTICIAPI_BASE'])
+        client = PolisParticipantClient(current_app.config['PARTICIAPI_BASE'])
         try:
             _, approved, _ = client.get_statements(conv.polis_id)
             text_by_tid = {s['tid']: (s.get('text') or s.get('txt', '')) for s in approved}
-        except PolisAdminError:
+        except PolisParticipantError:
             return False
         changed = False
         for fs in missing:
@@ -1577,8 +1587,7 @@ def _register_routes(app: Flask) -> None:
                        .order_by(FeaturedStatement.created_at).all())
         _backfill_statement_texts(conv, confirmed)
         confirmed_tids = {fs.polis_statement_id for fs in confirmed}
-        candidates  = get_featured_candidates(
-            conv.polis_id, current_app.config.get('POLIS_DATABASE_URL', ''))
+        candidates   = _polis_server_client().get_featured_candidates(conv.polis_id)
         if candidates is not None:
             candidates = [c for c in candidates if c['tid'] not in confirmed_tids]
         return render_template('admin_featured.html',
@@ -1587,13 +1596,13 @@ def _register_routes(app: Flask) -> None:
                                candidates=candidates)
 
     def _fetch_statement_text(conv_polis_id: str, tid: int) -> str:
-        client = PolisAdminClient(current_app.config['PARTICIAPI_BASE'])
+        client = PolisParticipantClient(current_app.config['PARTICIAPI_BASE'])
         try:
             _, approved, _ = client.get_statements(conv_polis_id)
             for s in approved:
                 if s.get('tid') == tid:
                     return s.get('text') or s.get('txt', '')
-        except PolisAdminError:
+        except PolisParticipantError:
             pass
         return ''
 

--- a/v2/app.py
+++ b/v2/app.py
@@ -315,7 +315,7 @@ def _proxy_to_particiapi(pa_path: str):
             timeout=10,
         )
     except requests.RequestException as exc:
-        current_app.logger.error('Particiapi proxy error: %s', exc)
+        current_app.logger.exception('Particiapi proxy error')
         abort(502)
 
     # Particiapi returns 403 on /results/ when math hasn't run yet (no clusters).
@@ -1316,7 +1316,7 @@ def _register_routes(app: Flask) -> None:
             try:
                 polis_id = _polis_server_client().create_conversation(fields['title'])
             except PolisServerError as exc:
-                current_app.logger.error('Polis conversation creation failed: %s', exc)
+                current_app.logger.exception('Polis conversation creation failed')
                 flash('Could not create the Polis conversation. Check server logs for details.', 'error')
                 return redirect(url_for('admin'))
         else:
@@ -1503,7 +1503,7 @@ def _register_routes(app: Flask) -> None:
             pending, approved, hidden = client.get_statements(conv.polis_id)
             settings = client.get_settings(conv.polis_id)
         except PolisParticipantError as exc:
-            current_app.logger.error('get_statements failed: %s', exc)
+            current_app.logger.exception('get_statements failed')
             flash('Could not load statements from Particiapi. Check server logs.', 'error')
         return render_template('admin_statements.html',
                                conversation=conv,
@@ -1511,7 +1511,7 @@ def _register_routes(app: Flask) -> None:
                                approved=approved,
                                hidden=hidden,
                                settings=settings,
-                               polis_public_url=current_app.config.get('POLIS_PUBLIC_URL', 'https://pol.is'))
+                               polis_public_url=current_app.config.get('POLIS_PUBLIC_URL') or 'https://pol.is')
 
     @app.post('/admin/conversations/<int:conv_id>/statements/<int:tid>/moderate')
     @login_required
@@ -1523,7 +1523,7 @@ def _register_routes(app: Flask) -> None:
         try:
             _polis_server_client().moderate(conv.polis_id, tid, mod)
         except PolisServerError as exc:
-            current_app.logger.error('moderate failed: %s', exc)
+            current_app.logger.exception('moderate failed')
             flash('Moderation action failed. Check server logs for details.', 'error')
             return redirect(url_for('admin_conversation_statements', conv_id=conv_id))
         return redirect(url_for('admin_conversation_statements', conv_id=conv_id))
@@ -1538,8 +1538,9 @@ def _register_routes(app: Flask) -> None:
             abort(400)
         try:
             _polis_server_client().add_seed(conv.polis_id, text)
+            flash('Seed statement added.', 'success')
         except PolisServerError as exc:
-            current_app.logger.error('add_seed failed: %s', exc)
+            current_app.logger.exception('add_seed failed')
             flash('Could not add seed statement. Check server logs for details.', 'error')
         return redirect(url_for('admin_conversation_statements', conv_id=conv_id))
 
@@ -1551,7 +1552,7 @@ def _register_routes(app: Flask) -> None:
         try:
             _polis_server_client().set_strict_moderation(conv.polis_id, enabled)
         except PolisServerError as exc:
-            current_app.logger.error('set_strict_moderation failed: %s', exc)
+            current_app.logger.exception('set_strict_moderation failed')
             flash('Could not update moderation settings. Check server logs for details.', 'error')
         return redirect(url_for('admin_conversation_statements', conv_id=conv_id))
 

--- a/v2/polis_admin.py
+++ b/v2/polis_admin.py
@@ -1,19 +1,17 @@
 """
 polis_admin.py — Server-side Particiapi and Polis admin operations.
 
-Particiapi calls (PolisAdminClient): use PARTICIAPI_BASE_URL (port 8000).
+Participant-facing calls (PolisParticipantClient): use PARTICIAPI_BASE_URL (port 8000).
 Auth disabled on Particiapi — no session cookie needed for these calls.
+Only participant-scoped reads: statements, settings, results.
 
-Polis direct calls (PolisServerClient): use POLIS_SERVER_URL (port 8001).
+Admin calls (PolisServerClient): use POLIS_SERVER_URL (port 8001).
 Requires a Polis system account (POLIS_ADMIN_EMAIL / POLIS_ADMIN_PASSWORD).
-Used only for admin operations not available via Particiapi — currently
-conversation creation only.
+Handles all privileged operations: conversation creation, statement moderation,
+strict-moderation toggle, seed statements, and conversation settings.
 
-Note on Particiapi feature parity:
-  Particiapi exposes a minimal API — conversation metadata, statements (read),
-  voting, and results. It does not expose moderation, seed-statement creation,
-  or strict-moderation settings; those remain Polis-only. Methods that cannot
-  be fulfilled raise PolisAdminError so callers can surface a clear message.
+Direct Postgres reads (also via PolisServerClient): use POLIS_DATABASE_URL.
+Used for featured candidates and stats — data not exposed by the Polis API.
 """
 
 import re
@@ -77,83 +75,14 @@ _POLIS_STATS_SQL = """
 """
 
 
-def get_featured_candidates(zinvite: str, db_url: str = '',
-                            max_statements: int = 20) -> list[dict] | None:
-    """Return candidate statements for featuring, or None if unavailable.
+# ── Participant client ────────────────────────────────────────────────────────
 
-    Each item: {tid, text, is_seed, n_agree, n_disagree, n_votes}.
-    Seeds always appear first; remainder ranked by agree rate.
-    Returns None when POLIS_DATABASE_URL is absent or the query fails.
-    """
-    if not db_url or not _SAFE_ZINVITE.match(zinvite or ''):
-        return None
-    try:
-        import psycopg2
-    except ImportError:
-        return None
-    try:
-        conn = psycopg2.connect(db_url)
-        try:
-            with conn.cursor() as cur:
-                cur.execute(_FEATURED_CANDIDATES_SQL, (zinvite, max_statements))
-                rows = cur.fetchall()
-        finally:
-            conn.close()
-    except Exception:
-        return None
-    return [
-        {'tid': r[0], 'text': r[1], 'is_seed': r[2],
-         'n_agree': r[3], 'n_disagree': r[4], 'n_votes': r[5]}
-        for r in rows
-    ]
-
-
-def get_polis_stats(zinvite: str, db_url: str = '') -> dict | None:
-    """Query Polis PostgreSQL directly for conversation stats.
-
-    Returns a dict with n_participants, n_votes, avg_votes, median_votes,
-    n_statements, n_seed — or None if unavailable (no db_url, connection error, etc.).
-    """
-    if not db_url or not _SAFE_ZINVITE.match(zinvite or ''):
-        return None
-
-    try:
-        import psycopg2
-    except ImportError:
-        return None
-
-    try:
-        conn = psycopg2.connect(db_url)
-        try:
-            with conn.cursor() as cur:
-                cur.execute(_POLIS_STATS_SQL, (zinvite,))
-                row = cur.fetchone()
-        finally:
-            conn.close()
-    except Exception:
-        return None
-
-    if not row or len(row) < 6:
-        return None
-
-    try:
-        return {
-            'n_participants': int(row[0]),
-            'n_votes':        int(row[1]),
-            'avg_votes':      float(row[2]),
-            'median_votes':   float(row[3]),
-            'n_statements':   int(row[4]),
-            'n_seed':         int(row[5]),
-        }
-    except (ValueError, IndexError):
-        return None
-
-
-class PolisAdminError(Exception):
+class PolisParticipantError(Exception):
     pass
 
 
-class PolisAdminClient:
+class PolisParticipantClient:
+    """Particiapi client — participant-facing reads only (port 8000)."""
 
     def __init__(self, particiapi_base: str):
         self._base = particiapi_base.rstrip('/')
@@ -163,12 +92,10 @@ class PolisAdminClient:
         try:
             resp = requests.request(method, url, timeout=10, **kwargs)
         except requests.RequestException as exc:
-            raise PolisAdminError(str(exc)) from exc
+            raise PolisParticipantError(str(exc)) from exc
         if not resp.ok:
-            raise PolisAdminError(f"HTTP {resp.status_code}: {resp.text[:300]}")
+            raise PolisParticipantError(f"HTTP {resp.status_code}: {resp.text[:300]}")
         return resp.json() if resp.content else {}
-
-    # ── Statements ────────────────────────────────────────────────────────────
 
     def get_statements(self, conversation_id: str) -> tuple[list, list, list]:
         """Return (pending, approved, hidden).
@@ -179,84 +106,26 @@ class PolisAdminClient:
         data = self._req('GET', f'api/conversations/{conversation_id}/statements/')
         if not isinstance(data, dict):
             return [], [], []
-        # Normalise to the {tid, txt, ...} shape the admin template expects.
         approved = [
             {'tid': int(tid), 'txt': s.get('text', ''), **s}
             for tid, s in data.items()
         ]
         return [], approved, []
 
-    def moderate(self, conversation_id: str, tid: int, mod: int) -> None:
-        """Not available — Particiapi has no moderation endpoint."""
-        raise PolisAdminError(
-            'Statement moderation is not available through Particiapi.'
-        )
-
-    def add_seed(self, conversation_id: str, text: str) -> None:
-        """Add a statement via a server-side Particiapi session.
-
-        Creates a temporary anonymous session to obtain a CSRF token, then posts
-        the statement.  Note: Particiapi does not support server-side seed marking;
-        the statement appears as a regular participant statement in the vote view.
-        """
-        # Step 1: create an anonymous session to get uid + CSRF token.
-        try:
-            r = requests.post(
-                f'{self._base}/api/session',
-                params={'create': 'true'},
-                timeout=10,
-            )
-        except requests.RequestException as exc:
-            raise PolisAdminError(str(exc)) from exc
-        if not r.ok:
-            raise PolisAdminError(
-                f'Session create HTTP {r.status_code}: {r.text[:200]}'
-            )
-        session_data  = r.json()
-        csrf_token    = session_data.get('csrf_token', '')
-        session_cookie = r.cookies.get('session', '')
-        if not csrf_token or not session_cookie:
-            raise PolisAdminError('Particiapi did not return session credentials')
-
-        # Step 2: post the statement with the session cookie and CSRF token.
-        try:
-            r2 = requests.post(
-                f'{self._base}/api/conversations/{conversation_id}/statements/',
-                json={'text': text},
-                headers={'X-CSRF-Token': csrf_token},
-                cookies={'session': session_cookie},
-                timeout=10,
-            )
-        except requests.RequestException as exc:
-            raise PolisAdminError(str(exc)) from exc
-        if not r2.ok:
-            raise PolisAdminError(
-                f'Statement POST HTTP {r2.status_code}: {r2.text[:200]}'
-            )
-
-    # ── Conversation settings ─────────────────────────────────────────────────
-
     def get_settings(self, conversation_id: str) -> dict:
         try:
             return self._req('GET', f'api/conversations/{conversation_id}')
-        except PolisAdminError:
+        except PolisParticipantError:
             return {}
 
-    def set_strict_moderation(self, conversation_id: str, enabled: bool) -> None:
-        """Not available — Particiapi has no strict-moderation setting."""
-        raise PolisAdminError(
-            'Strict moderation is not available through Particiapi.'
-        )
-
     def get_results(self, conversation_id: str) -> dict | None:
-        """Return results dict, or None if not yet available."""
         try:
             return self._req('GET', f'api/conversations/{conversation_id}/results/')
-        except PolisAdminError:
+        except PolisParticipantError:
             return None
 
 
-# ── Polis server direct client ────────────────────────────────────────────────
+# ── Polis server admin client ─────────────────────────────────────────────────
 
 class PolisServerError(Exception):
     pass
@@ -265,15 +134,17 @@ class PolisServerError(Exception):
 class PolisServerClient:
     """Direct Polis server API client (port 8001 on VPS).
 
-    Used for admin operations not available via Particiapi — currently
-    conversation creation only.  Requires a Polis system account created
-    once on the VPS (see deployment.md).
+    Handles all privileged operations: conversation creation, statement moderation,
+    strict-moderation toggle, seed statements, and conversation settings.
+    Also queries Polis Postgres directly (db_url) for stats and featured candidates.
     """
 
-    def __init__(self, polis_server_url: str, email: str, password: str):
+    def __init__(self, polis_server_url: str, email: str, password: str,
+                 db_url: str = ''):
         self._base     = polis_server_url.rstrip('/')
         self._email    = email
         self._password = password
+        self._db_url   = db_url
 
     # Polis rejects plain HTTP form submissions unless the request appears to
     # come via HTTPS (checked via X-Forwarded-Proto). Since we call it over the
@@ -307,11 +178,10 @@ class PolisServerClient:
         extra = {'x-polis': token} if token else {}
         return sess, extra
 
-    def create_conversation(self, title: str) -> str:
-        """Create a Polis conversation and return its zinvite.
+    # ── Conversations ─────────────────────────────────────────────────────────
 
-        Lets Polis generate the zinvite; parses it from the response URL.
-        """
+    def create_conversation(self, title: str) -> str:
+        """Create a Polis conversation and return its zinvite."""
         sess, auth_headers = self._login()
         headers = {**self._HEADERS, **auth_headers}
         try:
@@ -345,3 +215,145 @@ class PolisServerClient:
             if re.match(r'^[A-Za-z0-9]{6,20}$', slug):
                 return slug
         raise PolisServerError('Polis returned no usable zinvite in response.')
+
+    def update_conversation_settings(self, conversation_id: str, **kwargs) -> None:
+        """Update Polis-side conversation settings.
+
+        Accepted kwargs: strict_moderation, vis_type, auth_needed_to_vote,
+        auth_needed_to_write, is_active, topic, description, and other Polis
+        PUT /api/v3/conversations fields.
+        """
+        sess, auth_headers = self._login()
+        headers = {**self._HEADERS, **auth_headers}
+        try:
+            resp = sess.put(
+                f'{self._base}/api/v3/conversations',
+                json={'conversation_id': conversation_id, **kwargs},
+                headers=headers,
+                timeout=10,
+            )
+        except requests.RequestException as exc:
+            raise PolisServerError(str(exc)) from exc
+        if not resp.ok:
+            raise PolisServerError(
+                f'Polis conversation settings update failed (HTTP {resp.status_code}): '
+                f'{resp.text[:300]}'
+            )
+
+    def set_strict_moderation(self, conversation_id: str, enabled: bool) -> None:
+        self.update_conversation_settings(conversation_id, strict_moderation=enabled)
+
+    # ── Statements ────────────────────────────────────────────────────────────
+
+    def moderate(self, conversation_id: str, tid: int, mod: int) -> None:
+        """Set mod value on a statement (1=approved, 0=pending, -1=hidden)."""
+        sess, auth_headers = self._login()
+        headers = {**self._HEADERS, **auth_headers}
+        try:
+            resp = sess.put(
+                f'{self._base}/api/v3/comments',
+                json={
+                    'conversation_id': conversation_id,
+                    'tid':             tid,
+                    'mod':             mod,
+                    'active':          True,
+                    'is_meta':         False,
+                    'velocity':        0.5,
+                },
+                headers=headers,
+                timeout=10,
+            )
+        except requests.RequestException as exc:
+            raise PolisServerError(str(exc)) from exc
+        if not resp.ok:
+            raise PolisServerError(
+                f'Polis moderation failed (HTTP {resp.status_code}): {resp.text[:300]}'
+            )
+
+    def add_seed(self, conversation_id: str, text: str) -> None:
+        """Add a seed statement via the Polis admin API, marked is_seed=True."""
+        sess, auth_headers = self._login()
+        headers = {**self._HEADERS, **auth_headers}
+        try:
+            resp = sess.post(
+                f'{self._base}/api/v3/comments',
+                json={
+                    'conversation_id': conversation_id,
+                    'txt':             text,
+                    'is_seed':         True,
+                    'vote':            0,
+                },
+                headers=headers,
+                timeout=10,
+            )
+        except requests.RequestException as exc:
+            raise PolisServerError(str(exc)) from exc
+        if not resp.ok:
+            raise PolisServerError(
+                f'Polis seed statement creation failed (HTTP {resp.status_code}): '
+                f'{resp.text[:300]}'
+            )
+
+    # ── Direct Postgres reads ─────────────────────────────────────────────────
+
+    def get_featured_candidates(self, zinvite: str,
+                                max_statements: int = 20) -> list[dict] | None:
+        """Return candidate statements for featuring, or None if unavailable.
+
+        Each item: {tid, text, is_seed, n_agree, n_disagree, n_votes}.
+        Seeds always appear first; remainder ranked by agree rate.
+        Returns None when db_url is absent or the query fails.
+        """
+        if not self._db_url or not _SAFE_ZINVITE.match(zinvite or ''):
+            return None
+        try:
+            import psycopg2
+        except ImportError:
+            return None
+        try:
+            conn = psycopg2.connect(self._db_url)
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(_FEATURED_CANDIDATES_SQL, (zinvite, max_statements))
+                    rows = cur.fetchall()
+            finally:
+                conn.close()
+        except Exception:
+            return None
+        return [
+            {'tid': r[0], 'text': r[1], 'is_seed': r[2],
+             'n_agree': r[3], 'n_disagree': r[4], 'n_votes': r[5]}
+            for r in rows
+        ]
+
+    def get_polis_stats(self, zinvite: str) -> dict | None:
+        """Return conversation stats from Polis Postgres, or None if unavailable."""
+        if not self._db_url or not _SAFE_ZINVITE.match(zinvite or ''):
+            return None
+        try:
+            import psycopg2
+        except ImportError:
+            return None
+        try:
+            conn = psycopg2.connect(self._db_url)
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(_POLIS_STATS_SQL, (zinvite,))
+                    row = cur.fetchone()
+            finally:
+                conn.close()
+        except Exception:
+            return None
+        if not row or len(row) < 6:
+            return None
+        try:
+            return {
+                'n_participants': int(row[0]),
+                'n_votes':        int(row[1]),
+                'avg_votes':      float(row[2]),
+                'median_votes':   float(row[3]),
+                'n_statements':   int(row[4]),
+                'n_seed':         int(row[5]),
+            }
+        except (ValueError, IndexError):
+            return None

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -970,6 +970,54 @@ h3.section-heading {
 
 .error { color: var(--red); font-size: 13px; margin-top: 0.5rem; }
 
+/* ── Toast notifications ─────────────────────────────────────────────────── */
+#toast-container {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+  pointer-events: none;
+}
+.toast {
+  pointer-events: all;
+  display: flex;
+  align-items: flex-start;
+  gap: .75rem;
+  padding: .75rem 1rem;
+  border-radius: 8px;
+  font-size: 13px;
+  line-height: 1.5;
+  max-width: 340px;
+  box-shadow: 0 2px 12px rgba(0,0,0,.12);
+  animation: toast-in .2s ease;
+  transition: opacity .3s ease, transform .3s ease;
+}
+.toast--error   { background: #fff0f0; border: 1px solid #fca5a5; color: #7f1d1d; }
+.toast--warning { background: #fffbeb; border: 1px solid #fcd34d; color: #78350f; }
+.toast--success { background: #f0fdf4; border: 1px solid #86efac; color: #14532d; }
+.toast--info    { background: #f0f4ff; border: 1px solid #c7d3f5; color: #1e3a8a; }
+.toast__msg  { flex: 1; }
+.toast__close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: inherit;
+  opacity: .5;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0;
+  flex-shrink: 0;
+}
+.toast__close:hover { opacity: 1; }
+.toast--out { opacity: 0; transform: translateY(.5rem); }
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(.5rem); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 code { font-family: var(--mono); font-size: 12px; color: var(--muted); }
 
 a { color: var(--pass); }

--- a/v2/templates/admin.html
+++ b/v2/templates/admin.html
@@ -45,9 +45,6 @@
   <!-- ── New conversation ──────────────────────────── -->
   <div class="edit-form">
     <h3>New conversation</h3>
-    {% if admin_error %}
-    <p class="error" style="margin-bottom:.75rem">{{ admin_error }}</p>
-    {% endif %}
     <form method="post" action="{{ url_for('admin_conversation_new') }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="edit-row-fields">
@@ -115,9 +112,6 @@
 
   <div class="edit-form">
     <h3>Grant global admin</h3>
-    {% if admin_error %}
-    <p class="error" style="margin-bottom:.75rem">{{ admin_error }}</p>
-    {% endif %}
     <form method="post" action="{{ url_for('admin_global_admin_add') }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="edit-row-fields">

--- a/v2/templates/admin_statements.html
+++ b/v2/templates/admin_statements.html
@@ -8,11 +8,13 @@
     <a href="{{ url_for('admin') }}">← admin</a>
   </p>
 
-  <div class="info-box" style="margin-bottom:1.5rem;padding:.75rem 1rem;background:#fff8e1;border:1px solid #ffe082;border-radius:6px;font-size:13px">
-    Statement moderation and strict-moderation settings are not available through Particiapi.
-    Manage statements directly via the Polis admin interface at
-    <code>{{ polis_public_url }}/m/{{ conversation.polis_id }}</code> (requires a Polis account).
-  </div>
+  {% if polis_public_url %}
+  <p class="muted" style="font-size:13px;margin-bottom:1.5rem">
+    For advanced operations not available here, use the
+    <a href="{{ polis_public_url }}/m/{{ conversation.polis_id }}" target="_blank" rel="noopener">
+      Polis admin interface</a> (requires a Polis account).
+  </p>
+  {% endif %}
 
   <!-- ── Add seed statement ──────────────────────────── -->
   <h3 class="section-heading">Add seed statement</h3>

--- a/v2/templates/admin_statements.html
+++ b/v2/templates/admin_statements.html
@@ -14,10 +14,6 @@
     <code>{{ polis_public_url }}/m/{{ conversation.polis_id }}</code> (requires a Polis account).
   </div>
 
-  {% if error %}
-  <p class="error" style="margin-bottom:1rem">{{ error }}</p>
-  {% endif %}
-
   <!-- ── Add seed statement ──────────────────────────── -->
   <h3 class="section-heading">Add seed statement</h3>
   <div class="edit-form">

--- a/v2/templates/base.html
+++ b/v2/templates/base.html
@@ -51,5 +51,38 @@
   <main>
     {% block content %}{% endblock %}
   </main>
+
+  <div id="toast-container" aria-live="polite"></div>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+  {% if messages %}
+  <script nonce="{{ csp_nonce }}">
+  (function () {
+    var toasts = {{ messages | tojson }};
+    var container = document.getElementById('toast-container');
+    var DURATIONS = { error: 8000, warning: 6000, success: 4000, info: 5000 };
+    toasts.forEach(function (pair) {
+      var category = pair[0], message = pair[1];
+      var el = document.createElement('div');
+      el.className = 'toast toast--' + category;
+      el.setAttribute('role', 'alert');
+      el.innerHTML =
+        '<span class="toast__msg">' + message + '</span>' +
+        '<button class="toast__close" aria-label="Dismiss">&times;</button>';
+      el.querySelector('.toast__close').addEventListener('click', function () { dismiss(el); });
+      container.appendChild(el);
+      console.error('[wiki-polis] ' + category + ': ' + message);
+      var t = setTimeout(function () { dismiss(el); }, DURATIONS[category] || 6000);
+      el._timer = t;
+    });
+    function dismiss(el) {
+      clearTimeout(el._timer);
+      el.classList.add('toast--out');
+      setTimeout(function () { el.remove(); }, 320);
+    }
+  })();
+  </script>
+  {% endif %}
+  {% endwith %}
 </body>
 </html>

--- a/v2/templates/home.html
+++ b/v2/templates/home.html
@@ -112,6 +112,14 @@
 
 {% endif %}
 
+  <div style="margin-top:2.5rem;padding:0.75rem 1rem;border:1px solid var(--border);border-radius:8px;background:var(--surface);font-size:13px;color:var(--muted);line-height:1.6">
+    This is a prototype in active development — things may break or change.
+    Found a bug or have a suggestion?
+    <a href="https://github.com/lgelauff/wiki-polis/issues/new"
+       target="_blank" rel="noopener" style="color:var(--accent)">Open an issue on GitHub</a>
+    (screenshots welcome).
+  </div>
+
 </div>
 
 {% endblock %}


### PR DESCRIPTION
## Summary

- **Backend rewrite** (`polis_admin.py`): splits `PolisAdminClient` into `PolisParticipantClient` (participant reads via Particiapi port 8000) and expands `PolisServerClient` with `moderate()`, `add_seed()`, `set_strict_moderation()`, and `update_conversation_settings()` targeting the Polis server API (port 8001). `get_featured_candidates()` and `get_polis_stats()` move onto `PolisServerClient` as instance methods using a `db_url=` param for direct Postgres access. A `_polis_server_client()` helper always returns a client so DB-only paths (local dev) keep working without HTTP credentials.
- **Admin moderation** (`app.py`): the statements page now wires approve/hide/pending actions and strict-moderation toggle to `PolisServerClient`, and seed statements are posted via the Polis admin API with `is_seed=True`.
- **Toast notifications** (`base.html`, `style.css`): replaces `?error=` URL query strings with `flash()` toasts. User sees a friendly message; full traceback goes to `current_app.logger.exception()` (captured by Toolforge logging) and `console.error()`.
- **Fix #45** (`admin_statements.html`, `app.py`): removes the misleading "moderation not available" banner (it is now available), replaces it with a conditional Polis admin link shown only when `POLIS_PUBLIC_URL` is configured. Also fixes the empty-string fallback so `'https://pol.is'` is used correctly when the URL is unset.
- **Prototype notice** (`home.html`): visible to all visitors with a link to file GitHub issues.

## Test plan

- [ ] Local: home, login, admin panel, statements page, featured page all return 200
- [ ] Trigger a moderation error (no Polis admin credentials) — verify toast appears and full traceback appears in Flask log
- [ ] Add a seed statement on staging — verify it appears in the vote view and a success toast shows
- [ ] Toggle strict moderation — verify it round-trips through the Polis API
- [ ] Approve / hide / set-pending a statement — verify moderation actions work
- [ ] Statements page with `POLIS_PUBLIC_URL` unset — verify no Polis link shown and no broken URL
- [ ] Prototype notice visible when logged in and when logged out

Closes #46, #39
Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)