### PR TITLE
Redirect logout to home page instead of triggering OAuth

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -4,9 +4,24 @@
 
 set -euo pipefail
 
+BRANCH="${1:-}"
+
 echo "==> Pulling latest changes..."
 cd ~/wiki-polis
-git pull
+if [ -n "$BRANCH" ]; then
+  git fetch origin
+  git checkout "$BRANCH"
+  git pull origin "$BRANCH"
+else
+  git pull
+fi
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+LAST_HASH=$(git log -1 --format="%h")
+LAST_MSG=$(git log -1 --format="%s")
+LAST_AGO=$(git log -1 --format="%cr")
+echo "    Branch : $CURRENT_BRANCH"
+echo "    Last   : $LAST_HASH $LAST_MSG ($LAST_AGO)"
 
 echo "==> Syncing dependencies (v2)..."
 ~/www/python/venv/bin/pip install -e ~/wiki-polis/v2

--- a/v2/app.py
+++ b/v2/app.py
@@ -1281,7 +1281,7 @@ def _register_routes(app: Flask) -> None:
     @login_required
     def logout():
         session.clear()
-        return redirect(url_for('login'))
+        return redirect(url_for('index'))
 
     # ── Admin ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- After logout, redirect to `/` (public home page) instead of `/login`, preventing users from being immediately bounced back into the OAuth flow
- The home page already handles unauthenticated users (shows public conversations + login button)
- `deploy.sh` now accepts an optional branch argument (`bash deploy.sh fix/logout-redirect`); always prints the active branch and how long ago the last commit was

## Test plan

- [ ] Log in, then log out — should land on the home page with public conversations visible
- [ ] Login button on home page should work normally
- [ ] `bash ~/wiki-polis/deploy.sh` — prints branch name and last commit age, pulls main
- [ ] `bash ~/wiki-polis/deploy.sh fix/logout-redirect` — checks out and pulls that branch