### PR TITLE
Research synthesis: Polis statement principles, terminology, and scope

### DIFF
--- a/docs/research/01-objectives-and-statements.md
+++ b/docs/research/01-objectives-and-statements.md
@@ -1,0 +1,61 @@
+> **⚠️ Draft — not fact-checked.** This document is a synthesis of external sources compiled for internal research purposes. Claims have not been independently verified against primary sources. Do not cite or publish externally without review. Sources are listed at the bottom; URLs are only included where access was confirmed.
+
+---
+
+# Polis: objectives and the role of statements
+
+## What Polis is trying to accomplish
+
+Polis is a real-time system for gathering, analysing, and understanding what large groups of people think in their own words. Its core design goal is to surface **cross-group consensus** — positions that are broadly shared across opinion clusters, not just majority positions or the views of the most active participants.
+
+This is a deliberate departure from most online discussion formats. Traditional forums, comment sections, and polls tend to amplify the loudest voices, reward engagement over thoughtfulness, and surface conflict rather than agreement. Polis inverts that dynamic: the algorithm is explicitly designed to find statements that bridge groups rather than divide them.
+
+Audrey Tang, Taiwan's Digital Minister, described the effect: *"Polis is quite well known in that it's a kind of social media that instead of polarizing people to drive so-called engagement or addiction or attention, it automatically drives bridge-making narratives and statements. So only the ideas that speak to both sides or to multiple sides will gain prominence."* (Wikipedia article on Pol.is)
+
+Polis is not a decision-making tool. It is a step in a process — a structured listening exercise that produces a map of where a community stands, which a facilitator or institution can then act on.
+
+## How the algorithm works
+
+Participants vote Agree, Disagree, or Pass on short statements. This produces a **vote matrix**: rows are participants, columns are statements, and cells contain votes. In practice, the matrix is over 90% empty for large conversations — most participants vote on only a fraction of statements.
+
+The algorithm applies **PCA** (Principal Component Analysis) to reduce this sparse matrix to a lower-dimensional space, and then **K-means clustering** to group participants whose voting patterns are similar. The result is an opinion map showing where the major clusters of opinion lie, and — critically — which statements received high agreement across multiple clusters (cross-cluster consensus) versus which statements divided participants along cluster lines.
+
+A statement that 78% of cluster A and 80% of cluster B both agree with is a genuine point of consensus. A statement that 95% of cluster A agrees with but only 20% of cluster B does is a point of division — still useful information, but not consensus.
+
+## The role of statements
+
+Statements are the atomic units that participants vote on. They are the primary input to the algorithm, and statement quality directly determines output quality.
+
+A statement is not just a unit of content — it is a **measurement instrument**. Each vote on a statement is a data point. If the instrument is poorly designed, the data it produces is unreliable, and the opinion map built from that data will misrepresent where people actually stand.
+
+The most common failure mode is the **compound statement** — a statement that contains two separate claims. When a participant agrees with one claim but not the other, they cannot vote Agree or Disagree accurately, so they vote Pass. At scale, compound statements systematically inflate the Pass rate and remove data from the clustering algorithm. The Small et al. (2021) paper identifies this explicitly as one of the most tractable and common problems in Polis conversations.
+
+## The wikisurvey mechanic
+
+Polis operates as a "wikisurvey": participants do not just vote on statements written by the facilitator — they can submit their own. In practice, roughly 1 in 10 participants submit a new statement; the other 9 vote. This ratio matters for two reasons:
+
+1. **Facilitator seed statements have outsized influence.** They are the earliest content in the conversation, receive the most votes, and frame what the conversation is about. Poorly written seed statements propagate into the opinion map.
+2. **Participant-submitted statements extend the opinion space.** They surface perspectives the facilitator did not anticipate. Moderation policies that remove "off-topic" or "duplicate" statements risk silencing these contributions.
+
+## How Polis differs from other formats
+
+| Format | Who sets the agenda | Captures nuance | Scales to thousands | Surfaces consensus |
+|---|---|---|---|---|
+| Survey / poll | Researchers | No | Yes | Partially |
+| Forum / comment section | Anyone | Yes | Poorly | No |
+| Citizens' assembly | Facilitators + lottery | Yes | No | Yes |
+| Polis | Facilitators + participants | Partially | Yes | Yes |
+
+---
+
+## Sources
+
+| Source | Used for | URL |
+|---|---|---|
+| Small, Bjorkegren, Erkkilä, Shaw, Megill (2021). "Polis: Scaling Deliberation by Mapping High Dimensional Opinion Spaces." *RECERCA, Revista de Pensament i Anàlisi*, 26(2). | Algorithm mechanics, compound statement failure mode, facilitator practices | https://gwern.net/doc/sociology/2021-small.pdf *(confirmed accessible)* |
+| Saffron Huang, Divya Siddarth et al. (2023). "Opportunities and Risks of LLMs for Scalable Deliberation with Polis." arXiv:2306.11932. | Algorithm details (Sections 1.1, 2.3, 2.4, 3.4), participant scale statistics | https://arxiv.org/abs/2306.11932 *(confirmed accessible)* |
+| Computational Democracy Project. "Polis." compdemocracy.org. | Platform overview, design philosophy | https://compdemocracy.org/polis/ *(confirmed accessible)* |
+| Computational Democracy Project. "Lottery-Selected Assemblies." compdemocracy.org/polis/book. | Polis as a step in process; integration with citizen assemblies | https://compdemocracy.org/polis/book/lottery-selected-assemblies/ *(confirmed accessible)* |
+| EA Forum. "Polis: why and how to use it." | Wikisurvey mechanic, 1-in-10 ratio, seeding guidance | https://forum.effectivealtruism.org/posts/9jxBki5YbS7XTnyQy/polis-why-and-how-to-use-it *(confirmed accessible)* |
+| Open Rights Group & Demos. "Democratic Innovations: Polis and the Political Process." (2020–21, UK). | Validation with 997 participants; framing effects | https://www.openrightsgroup.org/publications/democratic-innovations-polis-and-the-political-process/ *(confirmed accessible)* |
+| Wikipedia contributors. "Pol.is." Wikipedia. | Audrey Tang quote; history and reception | https://en.wikipedia.org/wiki/Pol.is *(confirmed accessible)* |

--- a/docs/research/02-statement-writing-guide.md
+++ b/docs/research/02-statement-writing-guide.md
@@ -1,0 +1,108 @@
+> **⚠️ Draft — not fact-checked.** This document is a synthesis of external sources compiled for internal research purposes. Claims have not been independently verified against primary sources. Do not cite or publish externally without review. Sources are listed at the bottom; URLs are only included where access was confirmed.
+
+---
+
+# Writing good statements
+
+## Why statement quality matters
+
+Every statement feeds directly into the vote matrix the clustering algorithm operates on. A poorly formed statement does not just produce a bad data point — it degrades the integrity of the entire output.
+
+The most common and most damaging failure mode is the **compound statement**: a statement that contains two separate claims. When a participant agrees with one claim but not the other, they cannot vote Agree or Disagree accurately — they vote Pass. The Small et al. (2021) paper is explicit: compound statements "elicit more passes when participants agree with one point, but not others," and identifies this as one of the most tractable problems to address. At scale, high Pass rates on compound statements deprive the system of the signal it needs to form meaningful clusters.
+
+Seed statements — those written by facilitators before the conversation opens — have an outsized effect. They are the earliest content, receive the most votes, and frame what the conversation is about. Poorly written seed statements propagate through the entire opinion map.
+
+---
+
+## Principles
+
+### 1. Atomicity — one claim per statement
+
+Each statement should make exactly one claim. If a statement contains two claims joined by "and," "but," "because," or a comma, it should almost certainly be split into two statements.
+
+**Why it matters:** A participant who agrees with one part but not the other cannot vote accurately. Their Pass vote removes their data from the algorithm without conveying any information.
+
+| Bad (compound) | Good (atomic) |
+|---|---|
+| "Wikipedia should require reliable sources and editors should disclose conflicts of interest." | "Wikipedia should require articles to cite reliable sources." |
+| | "Wikipedia editors should disclose conflicts of interest when editing related articles." |
+| "Wikimedia should prioritise editor diversity because the current editor base is unrepresentative." | "Wikimedia should prioritise increasing the diversity of active editors." |
+| | "The current Wikipedia editor base does not adequately represent the global reading public." |
+
+---
+
+### 2. Neutrality — describe, don't lead
+
+The phrasing of a statement should not predispose a participant toward one answer. Loaded language, rhetorical questions, and embedded assumptions introduce noise by making it harder to separate agreement with the underlying claim from agreement with (or aversion to) the framing.
+
+**Why it matters:** The Open Rights Group / Demos study found a measurable framing effect in a real Polis conversation: the same policy framed as "reducing red tape" received 56% support; a different framing of the same policy received opposition. Framing effects are not theoretical — they show up in the data.
+
+| Bad (loaded / leading) | Good (neutral) |
+|---|---|
+| "Wikipedia's bureaucratic deletion process unjustly silences new editors." | "Wikipedia's articles-for-deletion process discourages new editors from contributing." |
+| "Shouldn't the Wikimedia Foundation be more transparent about grant decisions?" | "The Wikimedia Foundation should make its grant decision process more transparent." |
+| "Deleting unhelpful Wikipedia articles keeps the project high-quality." | "Wikipedia should maintain stricter standards for which articles are retained." |
+
+---
+
+### 3. Concreteness — avoid vague aspiration
+
+Statements should refer to something specific enough that a vote conveys information. A statement like "Wikimedia should support a healthier community" is technically a claim, but near-universal agreement tells us almost nothing about opinion structure.
+
+**Why it matters:** The algorithm finds genuine disagreements and areas of consensus. Vague statements produce uninformative agreement and waste participant attention without adding signal.
+
+| Bad (vague) | Good (concrete) |
+|---|---|
+| "Wikimedia should support a healthier community." | "The Wikimedia Foundation should fund mental health resources for active Wikipedia editors." |
+| "Wikipedia needs to do better on diversity." | "Wikipedia's paid fellowship programmes should prioritise recruiting editors from under-represented regions." |
+
+---
+
+### 4. Appropriate scope
+
+A statement that almost everyone agrees with regardless of opinion group produces no useful clustering signal. A statement relevant to only a tiny slice of participants wastes the attention of everyone else.
+
+**Why it matters:** Scope determines what kind of opinion structure the statement can reveal. Very broad statements ("Wikipedia should be accurate") and very narrow statements ("The font size on the disambiguation notice for 'Mercury' should be changed") both contribute little.
+
+| Bad (too broad) | Good (scoped) |
+|---|---|
+| "Wikipedia should be accurate and reliable." | "Wikipedia should require secondary sources for biographical claims about living people." |
+
+---
+
+### 5. Statement form — make a claim, not a question or title
+
+A statement is a declarative claim. Questions cannot be voted Agree or Disagree. Topics and titles are not claims.
+
+| Bad (question) | Bad (title) | Good (statement) |
+|---|---|---|
+| "Should Wikipedia allow AI-generated content?" | "AI-generated content on Wikipedia." | "Wikipedia should allow AI-generated content if it meets the same sourcing standards as human-written content." |
+
+---
+
+## Seeding guidance
+
+A well-seeded conversation typically starts with **10–15 statements** written by the facilitator (EA Forum practitioner guide). Too few and the conversation space is poorly defined; too many and the facilitator is over-determining the opinion landscape.
+
+Seed statements should cover:
+- The range of perspectives likely to exist — not just the facilitator's preferred framing
+- Both diagnostic claims (what is the problem?) and policy claims (what should be done?)
+- Areas where genuine disagreement is expected, not just easy consensus
+
+Seed statements receive disproportionately more votes than participant-submitted statements because they are present from the start and routed to all participants. This makes their quality especially important.
+
+**On moderation of participant-submitted statements:** The Computational Democracy Project recommends that moderators remove only abusive content, not statements they consider "off-topic," "duplicative," or low-quality. Removing non-abusive statements risks silencing perspectives that challenge the facilitator's framing — particularly those from communities whose views are less represented in the seed set.
+
+---
+
+## Sources
+
+| Source | Used for | URL |
+|---|---|---|
+| Small, Bjorkegren, Erkkilä, Shaw, Megill (2021). "Polis: Scaling Deliberation by Mapping High Dimensional Opinion Spaces." *RECERCA*, 26(2). | Compound statement failure mode (Section 3.4.6), seed statement influence (3.4.1), moderation guidance (3.3) | https://gwern.net/doc/sociology/2021-small.pdf *(confirmed accessible)* |
+| Saffron Huang, Divya Siddarth et al. (2023). "Opportunities and Risks of LLMs for Scalable Deliberation with Polis." arXiv:2306.11932. | Compound statement problem, framing requirements, seeding influence | https://arxiv.org/abs/2306.11932 *(confirmed accessible)* |
+| EA Forum. "Polis: why and how to use it." | 10–15 seed statement recommendation, 1-in-10 participant ratio, 140-character limit | https://forum.effectivealtruism.org/posts/9jxBki5YbS7XTnyQy/polis-why-and-how-to-use-it *(confirmed accessible)* |
+| Open Rights Group & Demos. "Democratic Innovations: Polis and the Political Process." (UK, 2020–21). | Framing effects (56% support example), 997-participant study | https://www.openrightsgroup.org/publications/democratic-innovations-polis-and-the-political-process/ *(confirmed accessible)* |
+| Computational Democracy Project. "Lottery-Selected Assemblies." | Moderation policy; seed coverage of breadth of opinion | https://compdemocracy.org/polis/book/lottery-selected-assemblies/ *(confirmed accessible)* |
+| UK Policy Lab. "Cutting through complexity using collective intelligence." openpolicy.blog.gov.uk. (2022). | Practitioner account: panel moderation approach for submitted statements | https://openpolicy.blog.gov.uk/2022/10/11/cutting-through-complexity-using-collective-intelligence/ *(confirmed accessible)* |
+| PolisNL. "Hoe Polis werkt." polisnl.org. | Seed statement framing guidance | https://polisnl.org/hoe-polis-werkt *(confirmed accessible; limited content)* |

--- a/docs/research/03-terminology.md
+++ b/docs/research/03-terminology.md
@@ -1,0 +1,53 @@
+> **⚠️ Draft — not fact-checked.** This document is a synthesis of external sources compiled for internal research purposes. Claims have not been independently verified against primary sources. Do not cite or publish externally without review. Sources are listed at the bottom; URLs are only included where access was confirmed.
+
+---
+
+# Terminology: what are these things called?
+
+## The question
+
+Polis participants vote on short pieces of text. What should those pieces of text be called? The answer matters for UI copy, documentation, and consistency with both the Polis literature and Wikimedia's own established vocabulary.
+
+## What the sources use
+
+| Term | Where it appears | Notes |
+|---|---|---|
+| **statement** | Small et al. (2021), EA Forum, Open Rights Group, UK Policy Lab, PolisNL, compdemocracy.org | Most common term across practitioner and academic sources |
+| **comment** | Small et al. (2021) abstract, compdemocracy.org | Used interchangeably with "statement" in some sources; compdemocracy.org defines the platform as one where "participants submit short text statements, or comments" |
+| **seed statement** | Small et al. (2021) | Specifically refers to facilitator-authored statements loaded before the conversation opens |
+| **card** | Small et al. (2021) Figure 1 | Describes the UI component (the card a participant sees and votes on), not the content |
+| **prompt** | Polis interface | The overarching conversation question at the top of the page — distinct from statements |
+| **wikisurvey item** | EA Forum, Framer Framed | Describes the methodology (participants can submit new items, not just vote); not used as a label for individual items in the UI |
+| **idea / opinion / viewpoint** | Various informal descriptions | Appear in non-technical summaries; not used in the literature |
+
+## Why "statement" is the right term for wiki-polis
+
+**"Comment"** is the strongest alternative, but it conflicts with established Wikimedia vocabulary. On Wikipedia and related projects, "comment" already means a message on a talk page or in an edit summary. Using it for Polis voting units would create confusion for the exact audience wiki-polis serves.
+
+**"Statement"** is:
+- The most common term in practitioner guides and academic sources
+- Neutral and declarative — it accurately describes what these units are (claims to be voted on)
+- Free of conflict with existing Wikimedia vocabulary
+- Consistent with the deliberative democracy literature more broadly (cf. Fishkin's deliberative polls, which use "statement," "claim," "argument")
+
+**"Seed statement"** should be used specifically for facilitator-authored statements loaded before the conversation opens, to distinguish them from participant-submitted statements. This distinction matters for moderation and for explaining the 1-in-10 ratio to participants.
+
+## The wikisurvey framing
+
+Polis is sometimes described as a "wikisurvey" — a survey format in which participants can extend the instrument by submitting new items, not just respond to pre-set ones. This term originates with Salganik and Levy (2015) *(citation details unverified — no confirmed URL or DOI available)*. The wikisurvey framing is useful for explaining the participatory dimension to facilitators and researchers, but is too technical for participant-facing copy.
+
+---
+
+## Sources
+
+| Source | Used for | URL |
+|---|---|---|
+| Small, Bjorkegren, Erkkilä, Shaw, Megill (2021). "Polis: Scaling Deliberation by Mapping High Dimensional Opinion Spaces." *RECERCA*, 26(2). | Primary term usage ("statement," "comment," "seed statement," "card"); abstract terminology | https://gwern.net/doc/sociology/2021-small.pdf *(confirmed accessible)* |
+| Computational Democracy Project. "Polis." compdemocracy.org. | "statement, or comment" definition; UI description | https://compdemocracy.org/polis/ *(confirmed accessible)* |
+| EA Forum. "Polis: why and how to use it." | "statement" as primary term; wikisurvey framing | https://forum.effectivealtruism.org/posts/9jxBki5YbS7XTnyQy/polis-why-and-how-to-use-it *(confirmed accessible)* |
+| Open Rights Group & Demos. "Democratic Innovations: Polis and the Political Process." | "statements" used throughout ("33,714 votes cast on statements") | https://www.openrightsgroup.org/publications/democratic-innovations-polis-and-the-political-process/ *(confirmed accessible)* |
+| UK Policy Lab. "Cutting through complexity using collective intelligence." (2022). | "statement" as primary term | https://openpolicy.blog.gov.uk/2022/10/11/cutting-through-complexity-using-collective-intelligence/ *(confirmed accessible)* |
+| PolisNL. "Hoe Polis werkt." | "statement" as primary term in Dutch practitioner context | https://polisnl.org/hoe-polis-werkt *(confirmed accessible; limited content)* |
+| Framer Framed. "Pol.is: deliberatieve digitale democratie in Nederland." | "wikisurvey" framing | https://framerframed.nl/en/dossier/pol-is-deliberatieve-digitale-democratie-in-nederland/ *(confirmed accessible; limited content)* |
+| Salganik, M.J. and Levy, K.E.C. (2015). "Wiki surveys: Open and quantifiable social data collection." *PLOS ONE*. | Origin of "wikisurvey" term | *URL/DOI unverified — do not cite without checking* |
+| Fishkin, J. (1991, 2009). Works on deliberative polling. | "statement," "argument," "claim" in deliberative democracy literature | *Citation details unverified — do not cite without checking* |

--- a/docs/research/04-arguments.md
+++ b/docs/research/04-arguments.md
@@ -1,0 +1,91 @@
+> **⚠️ Draft — not fact-checked.** This document is a synthesis of external sources compiled for internal research purposes. Claims have not been independently verified against primary sources. Do not cite or publish externally without review. Sources are listed at the bottom; URLs are only included where access was confirmed.
+
+> **⚠️ Important scope note.** Arguments are **not part of standard Polis**. They are not discussed in any of the source documents as an existing feature. This document constructs principled guidance for an argument feature specific to wiki-polis, drawing on what the sources say about deliberation quality and the mechanics of the Polis system. Claims derived by inference rather than direct citation are labelled as such.
+
+---
+
+# Writing good arguments (wiki-polis feature)
+
+## What arguments are for
+
+In standard Polis, the only participant actions are voting (Agree / Disagree / Pass) and submitting new statements. Voting data produces the opinion map; the algorithm can show *what* people think but not *why*.
+
+wiki-polis introduces an **arguments feature** — participants can write a supporting or opposing argument for a specific statement. Arguments are annotations on the voting data, not inputs to the clustering algorithm. Their purpose is to capture the reasoning behind votes, providing qualitative depth that the vote matrix cannot.
+
+This distinction matters for how arguments should be written and moderated:
+- Statements are neutral claims designed to be voted on. Arguments are directional by design.
+- Statements are primary data for the algorithm. Arguments are supplementary material for human readers.
+- Statement moderation criteria focus on form (atomicity, neutrality). Argument moderation criteria focus on quality of reasoning.
+
+## Principles for writing good arguments
+
+These principles are derived from the goals of the Polis system and from general deliberative standards. They are not directly stated in the source literature, which does not discuss arguments as a feature.
+
+### 1. State your direction clearly
+
+An argument is for or against a specific statement. Make clear which. An argument that could apply to either side adds no information.
+
+| Unclear | Clear |
+|---|---|
+| "Sourcing is important for Wikipedia's credibility." | "**For:** Requiring secondary sources for biographical claims would reduce the number of unsourced assertions about living people, which is one of Wikipedia's most significant credibility risks." |
+
+---
+
+### 2. Add information — don't restate your vote
+
+An argument that only says "I agree because this is important" contains no more information than the vote itself. A good argument adds a reason, an example, an implication, or a constraint that other participants may not have considered.
+
+| Weak (restates vote) | Strong (adds information) |
+|---|---|
+| "I disagree because this would be bad for the project." | "**Against:** This would disproportionately affect new editors, who are less likely to know sourcing conventions and more likely to be discouraged by rejection. The burden should be on reviewers to guide, not just remove." |
+
+---
+
+### 3. One line of reasoning per argument *(atomicity applied to arguments)*
+
+The same atomicity principle that applies to statements applies to arguments. An argument that makes multiple separate points makes it harder to identify which point was persuasive to other readers.
+
+| Compound | Atomic |
+|---|---|
+| "This is good because it improves quality, and also because it aligns with WMF strategy, and it would help with editor retention too." | Write three separate arguments, one for each reason. |
+
+---
+
+### 4. Be specific
+
+Vague arguments ("this matters," "this is complicated," "reasonable people disagree") add friction without adding signal. Specific arguments — naming a mechanism, citing a precedent, identifying a consequence — are more useful to readers and more likely to shift thinking.
+
+---
+
+### 5. Acknowledge tradeoffs
+
+An argument that only presents the case for one side, without acknowledging what is being traded away, is less persuasive and less useful than one that engages with the tension. *(Derived from deliberative democracy literature on argument quality; not directly cited in sources.)*
+
+---
+
+### 6. Argue the claim, not the person
+
+Arguments should engage with the statement, not with who submitted it or who is likely to agree with it. This is consistent with Wikimedia's existing community norms (assume good faith, no personal attacks).
+
+---
+
+## On moderation of arguments
+
+Arguments are more sensitive to moderate than statements, because they contain explicit reasoning that may be disputed. The Open Rights Group / Demos study found that 52% of participant-submitted *statements* were non-constructive — the proportion for arguments may differ, but the moderation challenge is real.
+
+The Computational Democracy Project's guidance for statements — remove only abusive content, not content that is merely off-topic or wrong — applies with even more force to arguments. Removing arguments because a moderator disagrees with the reasoning would undermine the purpose of the feature.
+
+Recommended moderation standard for arguments:
+- **Remove:** personal attacks, harassment, content that violates the Wikimedia Universal Code of Conduct
+- **Keep:** arguments the moderator disagrees with, arguments that are poorly reasoned (but not abusive), arguments that are repetitive
+
+---
+
+## Sources
+
+| Source | Used for | URL |
+|---|---|---|
+| Saffron Huang, Divya Siddarth et al. (2023). "Opportunities and Risks of LLMs for Scalable Deliberation with Polis." arXiv:2306.11932. | Polis output limitations (Section 2.2: automated report "not suitable for consumption without dozens of hours of manual human analysis"); group-informed consensus goal (Section 2.3) | https://arxiv.org/abs/2306.11932 *(confirmed accessible)* |
+| Small, Bjorkegren, Erkkilä, Shaw, Megill (2021). "Polis: Scaling Deliberation by Mapping High Dimensional Opinion Spaces." *RECERCA*, 26(2). | Compound statement failure mode (applied by inference to compound arguments); moderation guidance | https://gwern.net/doc/sociology/2021-small.pdf *(confirmed accessible)* |
+| Open Rights Group & Demos. "Democratic Innovations: Polis and the Political Process." (UK, 2020–21). | 52% non-constructive submission rate; high curation ratio in practice | https://www.openrightsgroup.org/publications/democratic-innovations-polis-and-the-political-process/ *(confirmed accessible)* |
+| UK Policy Lab. "Cutting through complexity using collective intelligence." (2022). | Polis used to "stress-test existing policy"; role of qualitative reasoning alongside voting | https://openpolicy.blog.gov.uk/2022/10/11/cutting-through-complexity-using-collective-intelligence/ *(confirmed accessible)* |

--- a/docs/research/05-website-copy.md
+++ b/docs/research/05-website-copy.md
@@ -1,0 +1,169 @@
+> **⚠️ Draft — not fact-checked.** This document contains draft copy for the wiki-polis website, synthesised from the research documents in this folder. It has not been reviewed for accuracy, tone, or accessibility. Do not publish without review.
+>
+> This file is referenced in GitHub issue #57 (instruction pages for writing good statements and arguments) as the source for website copy.
+
+---
+
+# Website copy: participant and facilitator guidance
+
+---
+
+## For participants
+
+### What is this?
+
+This page is a conversation. It shows you short **statements** — claims about a topic — and asks you to vote Agree, Disagree, or Pass on each one.
+
+Your votes, combined with those of other participants, create a map of where this community stands. The goal is not to find the most popular opinion — it is to find the positions that people across different viewpoints can agree on.
+
+---
+
+### How to vote
+
+**Agree** — you think the statement is true or right.
+
+**Disagree** — you think the statement is false or wrong.
+
+**Pass** — you are not sure, the statement doesn't apply to you, or the statement is written in a way that makes it impossible to vote clearly (for example, it contains two separate claims and you agree with one but not the other).
+
+You don't have to vote on every statement. Passing is fine.
+
+---
+
+### How to submit a statement
+
+Anyone can submit a new statement. Yours will be reviewed before it appears to other participants.
+
+**A good statement:**
+
+- Makes **one claim** — not two or three. If you want to say two things, submit two statements.
+- Is **neutral in phrasing** — describe the situation rather than argue for a conclusion. Other participants will make up their own minds.
+- Is **specific** — vague statements ("things should be better") produce near-universal agreement that tells us nothing useful.
+- Is a **statement**, not a question or a topic title.
+
+**Bad:** "Wikipedia should require reliable sources and editors should disclose conflicts of interest."
+*(Two separate claims. Split them.)*
+
+**Bad:** "Shouldn't the Wikimedia Foundation be more transparent?"
+*(A question, not a statement. Rewrite as a claim.)*
+
+**Good:** "The Wikimedia Foundation should publish a detailed annual report on how discretionary grants are allocated."
+
+---
+
+### How to write a good argument *(wiki-polis feature)*
+
+> **Note:** Arguments are not part of standard Polis. This is a feature specific to wiki-polis.
+
+After voting on a statement, you can add an argument explaining your reasoning. Arguments are read by other participants and facilitators — they are not used by the algorithm.
+
+**A good argument:**
+
+- **States its direction** — is it for or against this statement?
+- **Adds a reason**, not just a restatement of your vote. "I agree because this is important" adds no information.
+- **Makes one point** — if you have multiple reasons, write multiple arguments.
+- **Is specific** — name a mechanism, a consequence, or a precedent.
+- **Engages with the claim**, not with other participants.
+
+**Bad:** "I disagree because this would be bad for the project."
+*(Restates the vote. Adds nothing.)*
+
+**Good:** "**Against:** This would disproportionately affect new editors, who are less likely to know sourcing conventions and more likely to be discouraged by rejection."
+
+---
+
+## For facilitators
+
+### What you are setting up
+
+A Polis conversation produces an opinion map. Participants vote on statements; an algorithm groups participants by voting pattern and identifies which statements have broad agreement across groups.
+
+The output shows *what* the community thinks. It does not make decisions. It is a structured listening exercise that you use to inform a next step — a policy proposal, a community discussion, a follow-up process.
+
+---
+
+### Seeding the conversation
+
+You write the first statements before the conversation opens. These are called **seed statements**.
+
+Seed statements have a disproportionate effect on the conversation because they are present from the start and every participant sees them. Write them carefully.
+
+**How many:** 10–15 is a reasonable starting range. Fewer and the conversation space is poorly defined. More and you are over-determining what the conversation is about.
+
+**What to cover:**
+- Multiple perspectives — not just the one you expect or prefer
+- Both diagnostic claims ("the problem is X") and policy claims ("the solution is Y")
+- Areas of likely disagreement, not just easy consensus
+
+**What to avoid:**
+- Compound statements (two claims in one)
+- Leading phrasing that pushes toward a particular answer
+- Only covering the views your team already holds
+
+*See [02-statement-writing-guide.md](02-statement-writing-guide.md) for principles and examples.*
+
+---
+
+### The 1-in-10 ratio
+
+Roughly 1 in 10 participants submit a new statement; the other 9 only vote. Participant-submitted statements arrive later and receive fewer votes, so they have less statistical weight than seed statements. This is why seed quality matters so much — it is not just the starting point, it is where most of the data comes from.
+
+This ratio also means you should expect to see relatively few participant submissions. That is normal.
+
+---
+
+### Moderating participant-submitted statements
+
+By default, submitted statements are held for review before appearing to other participants.
+
+**Remove:**
+- Abusive, harassing, or hateful content
+- Content that violates the Wikimedia Universal Code of Conduct
+
+**Do not remove:**
+- Statements you disagree with
+- Statements that are "off-topic" by your definition — what seems off-topic to you may be a perspective you did not anticipate
+- Statements that duplicate an existing one in meaning — let participants vote on both; they may not be as similar as they appear
+- Statements that are poorly written but not abusive — consider whether a note to the author is more appropriate than removal
+
+The Computational Democracy Project's research found that moderators who remove "off-topic" or "duplicate" statements risk systematically silencing perspectives from communities whose views were not represented in the seed set.
+
+---
+
+### Common mistakes
+
+| Mistake | Why it matters | Fix |
+|---|---|---|
+| Seed statements only reflect the facilitator's expected framing | Participants whose views aren't reflected in seeds are disadvantaged | Write seed statements from multiple perspectives before you open the conversation |
+| Compound seed statements | High Pass rates on those statements; corrupted cluster signal | Split every compound statement before publishing |
+| Removing non-abusive participant submissions | Silences unexpected perspectives | Remove only abusive content |
+| Framing statements as rhetorical questions | Not voteable; biases response | Rewrite as declarative claims |
+| Too few seed statements | Conversation space poorly defined | Aim for at least 8–10 before opening |
+
+---
+
+### Reading the output
+
+The output shows opinion groups (clusters) and which statements each group agreed or disagreed with. Look for:
+
+- **Cross-cluster consensus** — statements where multiple groups agree. These are the most actionable findings.
+- **Dividing statements** — statements where groups sharply disagree. These identify the genuine fault lines.
+- **High-pass statements** — statements with many Pass votes. Often indicates a compound statement or unclear phrasing.
+
+The output does not tell you what decision to make. It tells you what the community thinks. What comes next is your responsibility as a facilitator.
+
+---
+
+## Sources for this document
+
+The guidance above is drawn from the following sources. For full references and notes on which claims are directly cited vs. inferred, see the individual research documents in this folder.
+
+| Source | URL |
+|---|---|
+| Small et al. (2021). "Polis: Scaling Deliberation by Mapping High Dimensional Opinion Spaces." | https://gwern.net/doc/sociology/2021-small.pdf *(confirmed accessible)* |
+| Huang, Siddarth et al. (2023). arXiv:2306.11932. | https://arxiv.org/abs/2306.11932 *(confirmed accessible)* |
+| EA Forum. "Polis: why and how to use it." | https://forum.effectivealtruism.org/posts/9jxBki5YbS7XTnyQy/polis-why-and-how-to-use-it *(confirmed accessible)* |
+| Computational Democracy Project. compdemocracy.org. | https://compdemocracy.org/polis/ *(confirmed accessible)* |
+| Open Rights Group & Demos. "Democratic Innovations: Polis and the Political Process." | https://www.openrightsgroup.org/publications/democratic-innovations-polis-and-the-political-process/ *(confirmed accessible)* |
+| UK Policy Lab. openpolicy.blog.gov.uk. (2022). | https://openpolicy.blog.gov.uk/2022/10/11/cutting-through-complexity-using-collective-intelligence/ *(confirmed accessible)* |
+| PolisNL. "Hoe Polis werkt." | https://polisnl.org/hoe-polis-werkt *(confirmed accessible; limited content)* |

--- a/docs/research/06-scope-and-topic.md
+++ b/docs/research/06-scope-and-topic.md
@@ -1,0 +1,135 @@
+> **⚠️ Draft — not fact-checked.** This document is a synthesis of external sources compiled for internal research purposes. Claims have not been independently verified against primary sources. Do not cite or publish externally without review.
+>
+> **Strict sourcing policy:** This document only makes claims that are directly stated or quoted from the cached source files. Criteria, examples, and observations are not invented. Where the sources are silent, this document says so explicitly.
+
+---
+
+# Scope and topic: how to define what a Polis conversation is about
+
+## Why scope matters for wiki-polis
+
+If the advising module (see issue #56) is to flag statements as potentially off-topic, it needs a definition of scope to work from. This document asks: what do the sources actually say about how to define scope, how broad it should be, and what to do with statements that fall outside it?
+
+The short answer: the sources address this unevenly. They confirm that on-topic moderation happens in practice, but they also warn against it — and they offer little concrete guidance on how to draw the line. This tension is real and worth surfacing before building any automated scope-checking.
+
+---
+
+## What the sources say: on-topic moderation happens
+
+The Huang, Siddarth et al. (2023) paper describes current moderation practice directly:
+
+> "Participant submitted statements are also typically moderated to ensure they are **on-topic**, not abusive, and sufficiently distinct from existing statements."
+> *(llms2023polis, moderation section)*
+
+This is the clearest statement in any source that scope is an explicit moderation criterion. Off-topic statements are removed, not kept.
+
+The same source identifies on-topic moderation as one of several tasks that "require significant training in best practices and commitment of time as the conversation unfolds, and run the risk of silencing voices or biasing results."
+
+---
+
+## What the sources say: the tension with silencing voices
+
+The Computational Democracy Project's guidance — cited in the same paper — warns that moderators should **not** remove statements they consider off-topic:
+
+The risk cited: moderators who remove "off-topic" or "duplicate" statements may be applying their own framing to exclude perspectives that challenge the initial assumptions of the conversation. The concern is explicitly about marginalized communities whose views may not fit the facilitator's definition of the topic.
+
+This is a genuine contradiction between what the sources describe as standard practice (removing off-topic statements) and what they recommend as best practice (not removing them). The sources do not resolve this tension.
+
+**Implication for the advising module:** flagging a statement as potentially off-topic is more defensible than removing it. The module can surface a score; the moderation decision remains human.
+
+---
+
+## What the sources say: scope emerges from the prompt
+
+The **prompt** — the top-level question displayed at the top of a Polis conversation — is the primary instrument for defining scope. Participants implicitly understand the conversation to be "about" whatever the prompt asks.
+
+The Computational Democracy Project gives an example from a Kentucky county planning exercise where the prompt was:
+
+> *"What do you believe should change in Bowling Green/Warren County in order to make it a better place to live, work and spend time?"*
+
+This broad prompt explicitly invites a wide scope. A narrower prompt — "Should Wikipedia require secondary sources for biographical claims about living people?" — would imply a much tighter scope.
+
+The sources do not provide criteria for choosing prompt breadth. This is an open design question not addressed in the available literature.
+
+---
+
+## What the sources say: scope can and should evolve
+
+The Computational Democracy Project describes scope refinement as a deliberate strategy:
+
+> "Polis helps many people collectively refine how a topic is framed by revealing new perspectives, concerns, and questions. The resulting Polis opinion map enables organizers to frame the topic for an assembly in a way that highlights both shared values and key disagreements."
+> *(compdem-book-assemblies, Strategy 2: "Improve topic framing through dynamic topic refinement")*
+
+The vTaiwan Uber conversation is the cited example:
+
+> "In vTaiwan, the Uber discussion began with assumptions about regulating Uber, but **expanded to include dimensions of the existing local taxi industry**."
+> *(compdem-book-assemblies)*
+
+This is significant: what appeared off-topic (the taxi industry) turned out to be essential to a full understanding of the issue. Strict on-topic moderation would have removed those statements and impoverished the result.
+
+The Computational Democracy Project also describes using Polis as a pre-step to define scope for a subsequent exercise:
+
+> "Use Polis to ask your population, 'what topic should be taken up by a citizen assembly?'"
+> *(compdem-book-assemblies, Strategy 1)*
+
+In other words: Polis can itself be the instrument by which scope is discovered, not just enforced.
+
+---
+
+## What the sources say: scope can be too broad
+
+The Uruguay 2021 referendum case illustrates a different problem — scope too broad for a single yes/no vote:
+
+> "16,000 people used Polis to look within a national referendum combining 150 policy positions in a single yes/no vote, going topic by topic to understand how issues could best be unbundled."
+> *(compdem-casestudies)*
+
+Here Polis was used to *decompose* an over-broad scope into meaningful sub-topics. The sources do not give criteria for when a scope is too broad to be useful in a single conversation.
+
+---
+
+## What the sources do not say
+
+The sources are silent on:
+
+- **How to determine the right scope breadth** before opening a conversation — no criteria are provided
+- **What specific types of statement count as off-topic** — only the general category is mentioned
+- **Whether participants should be told why their statement was removed** for being off-topic
+- **How to handle borderline cases** — statements that address the topic tangentially
+- **Automated scope detection** — no source discusses computational approaches to on-topic checking
+
+---
+
+## Implications for wiki-polis
+
+### For the advising module (#56)
+
+An automated on-topic score is possible in principle (compare the statement to the prompt using semantic similarity), but:
+
+- The sources provide no criteria for what threshold counts as "off-topic"
+- The vTaiwan example shows that seemingly off-topic statements can be the most valuable
+- The literature recommends human moderation for scope decisions, not automated removal
+
+**Tentative recommendation:** if the advising module includes a scope/topic score, it should flag statements for *human review* — not auto-remove or discourage submission. The score helps the moderator triage; it does not make the moderation decision.
+
+### For facilitators
+
+The prompt is the primary instrument for communicating scope. A well-written prompt reduces the volume of ambiguously in-scope statements. Facilitators should:
+
+1. Write the prompt to reflect the actual scope they want — neither so broad that everything is in-scope nor so narrow that participants feel constrained
+2. Consider running a short preliminary Polis conversation to surface what dimensions of the topic the community considers relevant before locking in scope
+
+Neither of these recommendations is from the sources — they are derived from the dynamics described above. They are flagged here as inferences, not citations.
+
+### Open design question
+
+How broad should a wiki-polis conversation be? The sources do not answer this. It likely depends on the context: a conversation about a specific Wikipedia policy is much narrower than a conversation about the future of the Wikimedia movement. A second evaluator or scoping worksheet for facilitators — helping them think through scope before opening a conversation — may be more useful than any automated check.
+
+---
+
+## Sources
+
+| Source | Relevant content | URL |
+|---|---|---|
+| Saffron Huang, Divya Siddarth et al. (2023). "Opportunities and Risks of LLMs for Scalable Deliberation with Polis." arXiv:2306.11932. | On-topic moderation described as standard practice; risk of silencing voices | https://arxiv.org/abs/2306.11932 *(confirmed accessible)* |
+| Computational Democracy Project. "Lottery-Selected Assemblies." compdemocracy.org/polis/book. | Strategy 1 (use Polis to choose topic); Strategy 2 (dynamic topic refinement); vTaiwan scope expansion example | https://compdemocracy.org/polis/book/lottery-selected-assemblies/ *(confirmed accessible)* |
+| Computational Democracy Project. Case studies index. compdemocracy.org/case-studies. | Uruguay referendum: Polis used to unbundle over-broad scope | https://compdemocracy.org/case-studies/ *(confirmed accessible)* |


### PR DESCRIPTION
## Summary

Six research documents synthesising external Polis literature to inform wiki-polis feature development. All documents carry a draft/not-fact-checked warning and list sources with confirmed URLs only.

- **01-objectives-and-statements.md** — What Polis accomplishes and how statements feed the clustering algorithm
- **02-statement-writing-guide.md** — Five principles for writing good statements (atomicity, neutrality, concreteness, scope, form) with Wikimedia-specific examples and bad/good pairs
- **03-terminology.md** — Why "statement" is the right term; "comment" conflicts with Wikimedia talk-page vocabulary
- **04-arguments.md** — Six quality principles for the wiki-polis arguments feature (not standard Polis); includes moderation guidance
- **05-website-copy.md** — Ready-to-use participant and facilitator copy; referenced in issue #57
- **06-scope-and-topic.md** — What sources say about conversation scope: on-topic moderation tension, scope evolution (vTaiwan), implications for advising module (#56)

## Related issues

- #56 — Statement advising module
- #57 — Instruction pages (05-website-copy.md is the source)
- #58 — Moderation defaults

## Status

Draft — documents are research syntheses, not final copy. Needs editorial review and fact-checking before any content is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)