### PR TITLE
Arguments tab: one proposal at a time with ToC sidebar

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -791,13 +791,21 @@ def _register_routes(app: Flask) -> None:
             db.session.commit()
         return state
 
+    def _short_title(text, max_len=80):
+        if len(text) <= max_len:
+            return text
+        truncated = text[:max_len]
+        last_space = truncated.rfind(' ')
+        return (truncated[:last_space] if last_space > 0 else truncated) + '…'
+
     def _build_featured_data(conv, participation, can_mod=False):
         """Return list of dicts for the argument tab, one per confirmed FS.
 
-        Each dict: {fs, text, pro_args, con_args, pro_state, con_state, voted_ids,
-                    pro_gate, con_gate}
+        Each dict: {fs, text, short_title, pro_args, con_args, pro_state,
+                    con_state, voted_ids, pro_gate, con_gate}
         Creates/updates ArgumentSideState records as a side effect.
         Moderators see hidden arguments (marked); participants never see them.
+        Order is deterministically randomised per participant.
         """
         from sqlalchemy.orm import joinedload
         fss = (FeaturedStatement.query
@@ -854,11 +862,13 @@ def _register_routes(app: Flask) -> None:
             pro_voted_count = sum(1 for a in ordered_pro if a.id in voted_ids)
             con_voted_count = sum(1 for a in ordered_con if a.id in voted_ids)
 
+            text_value = (stmt_texts.get(fs.polis_statement_id)
+                          or fs.statement_text
+                          or f'Statement #{fs.polis_statement_id}')
             result.append({
-                'fs':        fs,
-                'text':      stmt_texts.get(fs.polis_statement_id)
-                             or fs.statement_text
-                             or f'Statement #{fs.polis_statement_id}',
+                'fs':          fs,
+                'text':        text_value,
+                'short_title': _short_title(text_value),
                 'pro_args':  ordered_pro,
                 'con_args':  ordered_con,
                 'pro_state': pro_state,
@@ -873,6 +883,9 @@ def _register_routes(app: Flask) -> None:
                 'con_voted_count': con_voted_count,
                 'proposer_pseudonyms': proposer_pseudonym_map,
             })
+
+        import random as _random
+        _random.Random(pid).shuffle(result)
         return result
 
     # ── Conversation ─────────────────────────────────────────────────────────

--- a/v2/app.py
+++ b/v2/app.py
@@ -7,6 +7,7 @@ import click
 import functools
 import hashlib
 import os
+import random
 import re
 import secrets
 from datetime import datetime, timedelta, timezone
@@ -80,6 +81,14 @@ csrf    = CSRFProtect()
 # No global default — limits applied per endpoint only.
 # On multi-worker deployments configure RATELIMIT_STORAGE_URI=redis://... in env.
 limiter = Limiter(key_func=get_remote_address, default_limits=[])
+
+
+def _short_title(text: str, max_len: int = 80) -> str:
+    if len(text) <= max_len:
+        return text
+    truncated = text[:max_len]
+    last_space = truncated.rfind(' ')
+    return (truncated[:last_space] if last_space > 0 else truncated) + '…'
 
 
 def _safe_redirect(target: str, fallback: str) -> str:
@@ -791,13 +800,6 @@ def _register_routes(app: Flask) -> None:
             db.session.commit()
         return state
 
-    def _short_title(text, max_len=80):
-        if len(text) <= max_len:
-            return text
-        truncated = text[:max_len]
-        last_space = truncated.rfind(' ')
-        return (truncated[:last_space] if last_space > 0 else truncated) + '…'
-
     def _build_featured_data(conv, participation, can_mod=False):
         """Return list of dicts for the argument tab, one per confirmed FS.
 
@@ -884,8 +886,7 @@ def _register_routes(app: Flask) -> None:
                 'proposer_pseudonyms': proposer_pseudonym_map,
             })
 
-        import random as _random
-        _random.Random(pid).shuffle(result)
+        random.Random(pid).shuffle(result)
         return result
 
     # ── Conversation ─────────────────────────────────────────────────────────

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -1671,7 +1671,7 @@ a { color: var(--pass); }
 
 /* ── Argument mapping ─────────────────────────────────── */
 
-.arguments-tab {
+.arguments-tab:not(.tab-panel--hidden) {
   max-width: 1100px;
   display: flex;
   gap: 24px;
@@ -1713,16 +1713,6 @@ a { color: var(--pass); }
 }
 .arg-toc-btn:hover { color: var(--ink); background: var(--surface2); }
 .arg-toc-btn--active { color: var(--ink); font-weight: 600; background: var(--surface2); }
-
-.arg-toc-index {
-  flex-shrink: 0;
-  font-family: var(--mono);
-  font-size: 10px;
-  color: var(--muted);
-  margin-top: 2px;
-  min-width: 14px;
-}
-.arg-toc-btn--active .arg-toc-index { color: var(--accent); }
 
 .arg-toc-label { word-break: break-word; overflow-wrap: anywhere; }
 

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -1671,9 +1671,72 @@ a { color: var(--pass); }
 
 /* ── Argument mapping ─────────────────────────────────── */
 
-.arguments-tab { max-width: 940px; }
+.arguments-tab {
+  max-width: 1100px;
+  display: flex;
+  gap: 24px;
+  align-items: flex-start;
+}
 
-.arg-block { margin-bottom: 2.5rem; }
+.arg-toc {
+  flex-shrink: 0;
+  width: 200px;
+  position: sticky;
+  top: 1.5rem;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: 10px;
+  padding: 8px 0;
+}
+
+.arg-toc-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.arg-toc-btn {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font-family: var(--sans);
+  font-size: 12.5px;
+  line-height: 1.4;
+  color: var(--muted);
+  transition: color .12s, background .12s;
+}
+.arg-toc-btn:hover { color: var(--ink); background: var(--surface2); }
+.arg-toc-btn--active { color: var(--ink); font-weight: 600; background: var(--surface2); }
+
+.arg-toc-index {
+  flex-shrink: 0;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--muted);
+  margin-top: 2px;
+  min-width: 14px;
+}
+.arg-toc-btn--active .arg-toc-index { color: var(--accent); }
+
+.arg-toc-label { word-break: break-word; overflow-wrap: anywhere; }
+
+.arg-panels { flex: 1; min-width: 0; max-width: 940px; }
+
+.arg-block { margin-bottom: 0; }
+.arg-block--hidden { display: none; }
+
+@media (max-width: 720px) {
+  .arguments-tab { flex-direction: column; max-width: 940px; }
+  .arg-toc { width: 100%; position: static; }
+  .arg-toc-list { display: flex; flex-wrap: wrap; gap: 4px; padding: 8px; }
+  .arg-toc-btn { width: auto; border-radius: 6px; padding: 5px 10px; border: 1px solid var(--hairline); }
+}
 
 /* Featured statement card */
 .arg-statement {

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -321,7 +321,6 @@
                   data-target="fs-{{ item.fs.id }}"
                   {% if loop.first %}aria-current="true"{% endif %}
                   type="button">
-            <span class="arg-toc-index">{{ loop.index }}</span>
             <span class="arg-toc-label">{{ item.short_title }}</span>
           </button>
         </li>

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -312,11 +312,29 @@
     </div>
     {% endif %}
 
+    {% if featured_data | length > 1 %}
+    <nav class="arg-toc" aria-label="Proposals navigation">
+      <ul class="arg-toc-list">
+        {% for item in featured_data %}
+        <li>
+          <button class="arg-toc-btn{% if loop.first %} arg-toc-btn--active{% endif %}"
+                  data-target="fs-{{ item.fs.id }}"
+                  type="button">
+            <span class="arg-toc-index">{{ loop.index }}</span>
+            <span class="arg-toc-label">{{ item.short_title }}</span>
+          </button>
+        </li>
+        {% endfor %}
+      </ul>
+    </nav>
+    {% endif %}
+
+    <div class="arg-panels">
     {% for item in featured_data %}
     {% set fs = item.fs %}
     {% set both_gate = item.pro_gate and item.con_gate %}
 
-    <div class="arg-block" id="fs-{{ fs.id }}">
+    <div class="arg-block{% if not loop.first %} arg-block--hidden{% endif %}" id="fs-{{ fs.id }}">
 
       {# ── Featured statement card ── #}
       <div class="arg-statement">
@@ -619,6 +637,7 @@
       </div>{# end arg-columns #}
     </div>{# end arg-block #}
     {% endfor %}
+    </div>{# end arg-panels #}
 
   </div>
   {% endif %}
@@ -878,6 +897,25 @@
 (function () {
   var tab = document.getElementById('tab-arguments');
   if (!tab) return;
+
+  // ── ToC / single-panel navigation ────────────────────────────────────────────
+  var toc = tab.querySelector('.arg-toc');
+  if (toc) {
+    toc.addEventListener('click', function (e) {
+      var btn = e.target.closest('.arg-toc-btn');
+      if (!btn) return;
+      var targetId = btn.dataset.target;
+      tab.querySelectorAll('.arg-panels .arg-block').forEach(function (block) {
+        block.classList.add('arg-block--hidden');
+      });
+      var panel = document.getElementById(targetId);
+      if (panel) panel.classList.remove('arg-block--hidden');
+      toc.querySelectorAll('.arg-toc-btn').forEach(function (b) {
+        b.classList.remove('arg-toc-btn--active');
+      });
+      btn.classList.add('arg-toc-btn--active');
+    });
+  }
 
   // ── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -334,7 +334,7 @@
     {% set fs = item.fs %}
     {% set both_gate = item.pro_gate and item.con_gate %}
 
-    <div class="arg-block" id="fs-{{ fs.id }}">
+    <div class="arg-block" id="fs-{{ fs.id }}" tabindex="-1">
 
       {# ── Featured statement card ── #}
       <div class="arg-statement">
@@ -911,7 +911,7 @@
       }
     });
 
-    function activatePanel(targetId) {
+    function activatePanel(targetId, moveFocus) {
       allPanels.forEach(function (block) {
         var hide = block.id !== targetId;
         block.classList.toggle('arg-block--hidden', hide);
@@ -923,11 +923,35 @@
         if (active) { b.setAttribute('aria-current', 'true'); }
         else         { b.removeAttribute('aria-current'); }
       });
+      if (moveFocus) {
+        var panel = document.getElementById(targetId);
+        if (panel) panel.focus();
+      }
     }
 
     toc.addEventListener('click', function (e) {
       var btn = e.target.closest('.arg-toc-btn');
       if (btn) activatePanel(btn.dataset.target);
+    });
+
+    toc.addEventListener('keydown', function (e) {
+      var btns = Array.prototype.slice.call(toc.querySelectorAll('.arg-toc-btn'));
+      var idx  = btns.indexOf(document.activeElement);
+      if (idx === -1) return;
+      if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+        e.preventDefault();
+        var next = btns[(idx + 1) % btns.length];
+        activatePanel(next.dataset.target);
+        next.focus();
+      } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+        e.preventDefault();
+        var prev = btns[(idx - 1 + btns.length) % btns.length];
+        activatePanel(prev.dataset.target);
+        prev.focus();
+      } else if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        activatePanel(btns[idx].dataset.target, true);
+      }
     });
 
     // Activate the panel whose id matches the URL hash (e.g. after a

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -319,6 +319,7 @@
         <li>
           <button class="arg-toc-btn{% if loop.first %} arg-toc-btn--active{% endif %}"
                   data-target="fs-{{ item.fs.id }}"
+                  {% if loop.first %}aria-current="true"{% endif %}
                   type="button">
             <span class="arg-toc-index">{{ loop.index }}</span>
             <span class="arg-toc-label">{{ item.short_title }}</span>
@@ -334,7 +335,7 @@
     {% set fs = item.fs %}
     {% set both_gate = item.pro_gate and item.con_gate %}
 
-    <div class="arg-block{% if not loop.first %} arg-block--hidden{% endif %}" id="fs-{{ fs.id }}">
+    <div class="arg-block" id="fs-{{ fs.id }}">
 
       {# ── Featured statement card ── #}
       <div class="arg-statement">
@@ -901,20 +902,42 @@
   // ── ToC / single-panel navigation ────────────────────────────────────────────
   var toc = tab.querySelector('.arg-toc');
   if (toc) {
+    var allPanels = Array.prototype.slice.call(tab.querySelectorAll('.arg-panels .arg-block'));
+
+    // Apply initial hidden state via JS so no-JS users see all panels stacked.
+    allPanels.forEach(function (block, i) {
+      if (i > 0) {
+        block.classList.add('arg-block--hidden');
+        block.setAttribute('aria-hidden', 'true');
+      }
+    });
+
+    function activatePanel(targetId) {
+      allPanels.forEach(function (block) {
+        var hide = block.id !== targetId;
+        block.classList.toggle('arg-block--hidden', hide);
+        block.setAttribute('aria-hidden', hide ? 'true' : 'false');
+      });
+      toc.querySelectorAll('.arg-toc-btn').forEach(function (b) {
+        var active = b.dataset.target === targetId;
+        b.classList.toggle('arg-toc-btn--active', active);
+        if (active) { b.setAttribute('aria-current', 'true'); }
+        else         { b.removeAttribute('aria-current'); }
+      });
+    }
+
     toc.addEventListener('click', function (e) {
       var btn = e.target.closest('.arg-toc-btn');
-      if (!btn) return;
-      var targetId = btn.dataset.target;
-      tab.querySelectorAll('.arg-panels .arg-block').forEach(function (block) {
-        block.classList.add('arg-block--hidden');
-      });
-      var panel = document.getElementById(targetId);
-      if (panel) panel.classList.remove('arg-block--hidden');
-      toc.querySelectorAll('.arg-toc-btn').forEach(function (b) {
-        b.classList.remove('arg-toc-btn--active');
-      });
-      btn.classList.add('arg-toc-btn--active');
+      if (btn) activatePanel(btn.dataset.target);
     });
+
+    // Activate the panel whose id matches the URL hash (e.g. after a
+    // contribute/skip form posts and redirects back to #fs-N).
+    var hash = window.location.hash;
+    if (hash && hash.indexOf('#fs-') === 0) {
+      var hashId = hash.slice(1);
+      if (document.getElementById(hashId)) activatePanel(hashId);
+    }
   }
 
   // ── Helpers ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #10.

## What changed

Replaces the vertically-stacked featured-statements layout with a **single-panel display** and a **sticky sidebar table of contents**.

### Layout
- Sidebar (200px, sticky) lists all proposals by short title (first ≤80 chars, truncated at word boundary)
- Content area shows one proposal panel at a time — existing argument voting UI unchanged
- Clicking a ToC entry swaps the visible panel with no page reload
- Single-proposal conversations: ToC is suppressed, panel renders full-width at original width
- Mobile (≤720px): ToC collapses into a horizontal chip row stacked above the content

### Ordering
Proposals are shuffled deterministically per participant: `random.Random(participant_id).shuffle(result)`. Same order on every reload for the same user; different order across participants. No DB migration — pure Python.

### Short title
Derived at render time from the statement text (first 80 chars, truncated at the last word boundary with `…`). No new DB field.

## Files changed

| File | Change |
|------|--------|
| `app.py` | `_short_title()` helper; `short_title` key in `_build_featured_data()`; participant-seeded shuffle before return |
| `templates/conversation.html` | ToC `<nav>` + `<div class="arg-panels">` wrapper; `arg-block--hidden` on non-first panels; ToC click handler JS |
| `static/style.css` | `.arguments-tab` → flex row; `.arg-toc`, `.arg-toc-btn`, `.arg-panels`, `.arg-block--hidden`; responsive collapse |

## Test plan

- [x] Conversation with 3+ featured statements: ToC lists all, clicking each swaps content, active button highlighted
- [x] Reload page: same proposal is shown first (for same user) — verifies stable ordering
- [ ] Log in as a different test user: confirm different ordering
- [x] Conversation with exactly 1 featured statement: no ToC rendered, panel fills full width
- [ ] Conversation with 0 featured statements: empty-state message unchanged
- [ ] Argument voting (vote/unvote), gate transitions, compose flow — all work on non-first panels
- [ ] Mobile viewport (≤720px): ToC renders as horizontal chips above content

🤖 Generated with [Claude Code](https://claude.com/claude-code)