### PR TITLE
Home page: Cluster card layout with pseudonym chips and action labels

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -635,6 +635,7 @@ def _register_routes(app: Flask) -> None:
                         Conversation.id.in_(mod_ids)).all()
 
         # keyed by conversation_id, scoped to current user only
+        # assumes at most one Participation per (user, conversation) — last row wins if duplicates exist
         pseudonym_map = {p.conversation_id: p for p in joined_parts}
         return render_template('home.html',
                                active_joined=active_joined,

--- a/v2/app.py
+++ b/v2/app.py
@@ -634,13 +634,14 @@ def _register_routes(app: Flask) -> None:
                     moderating = Conversation.query.filter(
                         Conversation.id.in_(mod_ids)).all()
 
-        part_map = {p.conversation_id: p for p in joined_parts}
+        # keyed by conversation_id, scoped to current user only
+        pseudonym_map = {p.conversation_id: p for p in joined_parts}
         return render_template('home.html',
                                active_joined=active_joined,
                                archived_joined=archived_joined,
                                available=available,
                                moderating=moderating,
-                               part_map=part_map)
+                               pseudonym_map=pseudonym_map)
 
     # ── Accept ───────────────────────────────────────────────────────────────
 

--- a/v2/app.py
+++ b/v2/app.py
@@ -634,11 +634,13 @@ def _register_routes(app: Flask) -> None:
                     moderating = Conversation.query.filter(
                         Conversation.id.in_(mod_ids)).all()
 
+        part_map = {p.conversation_id: p for p in joined_parts}
         return render_template('home.html',
                                active_joined=active_joined,
                                archived_joined=archived_joined,
                                available=available,
-                               moderating=moderating)
+                               moderating=moderating,
+                               part_map=part_map)
 
     # ── Accept ───────────────────────────────────────────────────────────────
 

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -272,6 +272,16 @@ header {
 
 /* ── Home page — Cluster card layout ── */
 
+.home-container {
+  max-width: 820px;
+}
+
+@media (max-width: 600px) {
+  .home-container { padding: 0 1rem; }
+  .conv-card { padding: 12px 14px; }
+  .conv-card-action { display: none; }
+}
+
 .home-section {
   margin-bottom: 24px;
 }
@@ -343,10 +353,6 @@ header {
   text-decoration: none;
 }
 
-a.conv-card-title:hover {
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
 
 .conv-card-badge {
   font-family: var(--mono);

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -357,6 +357,7 @@ header {
 @media (prefers-reduced-motion: reduce) {
   .conv-card { transition: none; }
   .conv-card:active { transform: none; }
+  /* shadow change on :active is retained intentionally — not vestibular motion */
 }
 
 .conv-card-left {
@@ -449,15 +450,27 @@ header {
 }
 
 .conv-card--split:hover {
+  /* intentional: split cards don't lift — whole card is not a single click target */
+  background: var(--surface2);
   border-color: var(--hairline);
   box-shadow: none;
 }
 
+.conv-card--split:has(:focus-visible) {
+  border-color: var(--accent);
+}
+
 @media (max-width: 480px) {
+  .conv-card--split {
+    flex-wrap: wrap;
+  }
   .conv-card--split .conv-card-divider { display: none; }
   .conv-card--split .admin-action-btn {
     flex-basis: 100%;
-    margin-top: 8px;
+    margin-top: 12px;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
     justify-content: center;
   }
 }

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -39,6 +39,22 @@
   outline-offset: 2px;
 }
 
+.conv-card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-color: var(--accent);
+  box-shadow:
+    0 1px 0 0 var(--hairline-soft),
+    0 6px 16px -10px rgba(0, 0, 0, 0.12);
+}
+
+.conv-card .conv-card-title:focus-visible,
+.conv-card .admin-action-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 body {
   font-family: var(--sans);
   font-size: 15px;
@@ -318,11 +334,29 @@ header {
   margin-bottom: 8px;
   text-decoration: none;
   color: inherit;
-  transition: border-color 0.12s;
+  transition:
+    border-color 0.12s ease,
+    box-shadow 0.12s ease,
+    transform 0.08s ease;
 }
 
 .conv-card:hover {
   border-color: var(--accent);
+  box-shadow:
+    0 1px 0 0 var(--hairline-soft),
+    0 6px 16px -10px rgba(0, 0, 0, 0.12);
+}
+
+.conv-card:active {
+  transform: translateY(1px);
+  box-shadow:
+    0 0 0 0 var(--hairline-soft),
+    0 2px 6px -4px rgba(0, 0, 0, 0.10);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .conv-card { transition: none; }
+  .conv-card:active { transform: none; }
 }
 
 .conv-card-left {
@@ -384,6 +418,49 @@ header {
 }
 
 .conv-card-action--muted { color: var(--muted); }
+
+.conv-card--split { cursor: default; }
+
+.conv-card--split .conv-card-left {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex: 1;
+  min-width: 0;
+}
+
+.conv-card--split .conv-card-title {
+  color: var(--ink);
+  text-decoration: none;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+}
+
+.conv-card--split .conv-card-title:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.conv-card--split .conv-card-divider {
+  width: 1px;
+  align-self: stretch;
+  margin: 4px 12px;
+  background: var(--hairline-soft);
+}
+
+.conv-card--split:hover {
+  border-color: var(--hairline);
+  box-shadow: none;
+}
+
+@media (max-width: 480px) {
+  .conv-card--split .conv-card-divider { display: none; }
+  .conv-card--split .admin-action-btn {
+    flex-basis: 100%;
+    margin-top: 8px;
+    justify-content: center;
+  }
+}
 
 /* ── Voting column (outer container, no card styling) ── */
 

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -270,6 +270,115 @@ header {
   vertical-align: middle;
 }
 
+/* ── Home page — Cluster card layout ── */
+
+.home-section {
+  margin-bottom: 24px;
+}
+
+.home-section-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.home-section-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.home-section-count {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.conv-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 14px 18px;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: 10px;
+  margin-bottom: 8px;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.12s;
+}
+
+.conv-card:hover {
+  border-color: var(--accent);
+}
+
+.conv-card-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+  min-width: 0;
+}
+
+.conv-card-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.conv-card-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.conv-card-title {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+  text-decoration: none;
+}
+
+a.conv-card-title:hover {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.conv-card-badge {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+  background: var(--surface2);
+  border: 1px solid var(--hairline);
+  padding: 1px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.conv-card-sub {
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+.conv-card-action {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  text-decoration: none;
+  flex-shrink: 0;
+}
+
+.conv-card-action--muted { color: var(--muted); }
+
 /* ── Voting column (outer container, no card styling) ── */
 
 .voting-col {

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -39,6 +39,7 @@
   outline-offset: 2px;
 }
 
+/* .conv-card is always an <a> element — this rule relies on that assumption */
 .conv-card:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
@@ -52,7 +53,7 @@
 .conv-card .admin-action-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
-  border-radius: 4px;
+  border-radius: 4px; /* matches badge radius (--surface2 chip) */
 }
 
 body {
@@ -423,18 +424,7 @@ header {
 .conv-card--split { cursor: default; }
 
 .conv-card--split .conv-card-left {
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  flex: 1;
-  min-width: 0;
-}
-
-.conv-card--split .conv-card-title {
-  color: var(--ink);
-  text-decoration: none;
-  font-weight: 500;
-  letter-spacing: -0.01em;
+  gap: 10px; /* 2px tighter than base to match divider rhythm */
 }
 
 .conv-card--split .conv-card-title:hover {
@@ -456,7 +446,12 @@ header {
   box-shadow: none;
 }
 
-.conv-card--split:has(:focus-visible) {
+/* :focus-within fires on any descendant focus; :has() refines to keyboard-only.
+   :focus-within listed first as fallback for pre-Firefox-121 browsers. */
+.conv-card--split:focus-within {
+  border-color: var(--accent);
+}
+.conv-card--split:hover:has(:focus-visible) {
   border-color: var(--accent);
 }
 

--- a/v2/templates/home.html
+++ b/v2/templates/home.html
@@ -30,7 +30,7 @@
   </div>
 
   {% if public_conversations %}
-  <section aria-label="Open consultations, {{ public_conversations | length }}">
+  <section aria-label="Open consultations">
     <div class="home-section">
       <div class="home-section-header">
         <span class="home-section-label">Open consultations</span>
@@ -53,7 +53,7 @@
 {% else %}
 
   {% if active_joined %}
-  <section aria-label="Active consultations, {{ active_joined | length }}">
+  <section aria-label="Active consultations">
     <div class="home-section">
       <div class="home-section-header">
         <span class="home-section-label">Active</span>
@@ -62,7 +62,7 @@
       {% for c in active_joined %}
       {% set part = pseudonym_map.get(c.id) %}
       <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
-         aria-label="{{ c.title }}{% if part %} ({{ part.pseudonym }}){% endif %}, {{ 'temporarily paused' if c.paused else 'voting open' }} — continue">
+         aria-label="{{ c.title }}{% if part %} — {{ part.pseudonym }}{% endif %} — {{ 'temporarily paused' if c.paused else 'voting open' }} — continue">
         <div class="conv-card-left">
           <span class="conv-dot conv-dot--active" aria-hidden="true"></span>
           <div class="conv-card-info">
@@ -83,7 +83,7 @@
   {% endif %}
 
   {% if available %}
-  <section aria-label="Open to you, {{ available | length }}">
+  <section aria-label="Open consultations">
     <div class="home-section">
       <div class="home-section-header">
         <span class="home-section-label">Open to you</span>
@@ -106,7 +106,7 @@
   {% endif %}
 
   {% if archived_joined %}
-  <section aria-label="Closed consultations, {{ archived_joined | length }}">
+  <section aria-label="Closed consultations">
     <div class="home-section">
       <div class="home-section-header">
         <span class="home-section-label">Closed</span>
@@ -115,7 +115,7 @@
       {% for c in archived_joined %}
       {% set part = pseudonym_map.get(c.id) %}
       <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
-         aria-label="{{ c.title }}{% if part %} ({{ part.pseudonym }}){% endif %}, closed{% if c.closed_at %} {{ c.closed_at.strftime('%B %Y') }}{% endif %}">
+         aria-label="{{ c.title }}{% if part %} — {{ part.pseudonym }}{% endif %} — closed{% if c.closed_at %} {{ c.closed_at.strftime('%B %Y') }}{% endif %}">
         <div class="conv-card-left">
           <span class="conv-dot conv-dot--closed" aria-hidden="true"></span>
           <div class="conv-card-info">
@@ -136,14 +136,14 @@
   {% endif %}
 
   {% if moderating %}
-  <section aria-label="You moderate, {{ moderating | length }}">
+  <section aria-label="Consultations you moderate">
     <div class="home-section">
       <div class="home-section-header">
         <span class="home-section-label">You moderate</span>
         <span class="home-section-count" aria-hidden="true">{{ moderating | length }} consultation{{ 's' if moderating | length != 1 }}</span>
       </div>
       {% for c in moderating %}
-      <div class="conv-card conv-card--split" role="group" aria-label="{{ c.title }}">
+      <div class="conv-card conv-card--split">
         <span class="conv-card-left">
           <span class="conv-dot {{ 'conv-dot--active' if c.active else 'conv-dot--closed' }}" aria-hidden="true"></span>
           <a href="{{ url_for('conversation', slug=c.slug) }}"
@@ -151,6 +151,7 @@
           {% if not c.active %}<span class="conv-card-badge">closed</span>{% endif %}
         </span>
         <span class="conv-card-divider" aria-hidden="true"></span>
+        {# → aria-hidden on "Admin →" not needed — the aria-label overrides the text content #}
         <a href="{{ url_for('admin_conversation_detail', conv_id=c.id) }}"
            class="admin-action-btn"
            aria-label="Open admin panel for {{ c.title }}">Admin →</a>

--- a/v2/templates/home.html
+++ b/v2/templates/home.html
@@ -1,36 +1,23 @@
 {% extends "base.html" %}
 {% block content %}
 
-<div class="container">
+<div class="container" style="max-width:820px">
 
-  <div style="margin-bottom:1.25rem;padding:0.6rem 1rem;border:1px solid var(--border);border-radius:8px;background:var(--surface);font-size:13px;color:var(--muted);line-height:1.6">
-    This is a prototype in active development — things may break or change.
-    Found a bug or have a suggestion?
+  <div style="margin-bottom:1.25rem;padding:10px 14px;border:1px solid var(--hairline);border-radius:8px;background:var(--surface);font-size:13px;color:var(--muted);line-height:1.6">
+    Prototype in active development — things may change.
     <a href="https://github.com/lgelauff/wiki-polis/issues/new"
-       target="_blank" rel="noopener" style="color:var(--accent)">Open an issue on GitHub</a>
-    (screenshots welcome).
-  </div>
-
-  <div class="landing-section">
-    <h2>Where the community actually stands.</h2>
-    <p style="font-size:15px;line-height:1.6;color:var(--body);margin-top:4px;max-width:520px">
-      Vote on short statements, watch opinion clusters emerge.
-      No threads, no replies — just signal.
-    </p>
-    <p style="font-size:15px;line-height:1.6;color:var(--body);margin-top:10px;max-width:520px">
-      Vote privately on short statements — agree, disagree, or pass. No one sees how
-      you voted individually; only the patterns that emerge across all participants are
-      shared. You'll participate under a pseudonym that's unique to each consultation.
-    </p>
+       target="_blank" rel="noopener" style="color:var(--pass)">Open an issue</a> if you find a bug.
   </div>
 
 {% if not username %}
 
   <div class="landing-section">
-    <p style="font-size:14px;color:var(--muted)">
-      Log in with your Wikimedia account to join an open consultation.
+    <h2 style="font-size:26px;font-weight:600;letter-spacing:-0.02em;line-height:1.15;margin-bottom:12px">Where the community actually stands.</h2>
+    <p style="font-size:15px;line-height:1.6;color:var(--body);max-width:520px">
+      Vote on short statements, watch opinion clusters emerge.
+      No threads, no replies — just signal.
     </p>
-    <a href="{{ url_for('login') }}" class="login-btn" style="margin-top:10px">
+    <a href="{{ url_for('login') }}" class="login-btn" style="margin-top:18px">
       <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
            stroke="currentColor" stroke-width="1" stroke-linecap="round"
            stroke-dasharray="1.4 1.6" aria-hidden="true">
@@ -43,80 +30,117 @@
   </div>
 
   {% if public_conversations %}
-  <div class="landing-section">
-    <p class="section-label">Open consultations</p>
-    <ul class="conversation-list">
-      {% for c in public_conversations %}
-      <li>
+  <div class="home-section">
+    <div class="home-section-header">
+      <span class="home-section-label">Open consultations</span>
+      <span class="home-section-count">{{ public_conversations | length }} total</span>
+    </div>
+    {% for c in public_conversations %}
+    <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card">
+      <div class="conv-card-left">
         <span class="conv-dot conv-dot--available"></span>
-        <a href="{{ url_for('conversation', slug=c.slug) }}">{{ c.title }}</a>
-      </li>
-      {% endfor %}
-    </ul>
+        <span class="conv-card-title">{{ c.title }}</span>
+      </div>
+      <span class="conv-card-action">JOIN →</span>
+    </a>
+    {% endfor %}
   </div>
   {% endif %}
 
 {% else %}
 
   {% if active_joined %}
-  <div class="landing-section">
-    <p class="section-label">Your consultations</p>
-    <ul class="conversation-list">
-      {% for c in active_joined %}
-      <li>
+  <div class="home-section">
+    <div class="home-section-header">
+      <span class="home-section-label">Active</span>
+      <span class="home-section-count">{{ active_joined | length }} consultation{{ 's' if active_joined | length != 1 }}</span>
+    </div>
+    {% for c in active_joined %}
+    {% set part = part_map.get(c.id) %}
+    <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card">
+      <div class="conv-card-left">
         <span class="conv-dot conv-dot--active"></span>
-        <a href="{{ url_for('conversation', slug=c.slug) }}">{{ c.title }}</a>
-      </li>
-      {% endfor %}
-    </ul>
+        <div class="conv-card-info">
+          <div class="conv-card-title-row">
+            <span class="conv-card-title">{{ c.title }}</span>
+            {% if part %}<span class="conv-card-badge">{{ part.pseudonym }}</span>{% endif %}
+          </div>
+          <div class="conv-card-sub">
+            {%- if c.paused -%}temporarily paused{%- else -%}voting open{%- endif -%}
+          </div>
+        </div>
+      </div>
+      <span class="conv-card-action">CONTINUE →</span>
+    </a>
+    {% endfor %}
   </div>
   {% endif %}
 
   {% if available %}
-  <div class="landing-section">
-    <p class="section-label">Open to you</p>
-    <ul class="conversation-list">
-      {% for c in available %}
-      <li>
+  <div class="home-section">
+    <div class="home-section-header">
+      <span class="home-section-label">Open to you</span>
+    </div>
+    {% for c in available %}
+    <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card">
+      <div class="conv-card-left">
         <span class="conv-dot conv-dot--available"></span>
-        <a href="{{ url_for('conversation', slug=c.slug) }}">{{ c.title }}</a>
-      </li>
-      {% endfor %}
-    </ul>
+        <div class="conv-card-info">
+          <span class="conv-card-title">{{ c.title }}</span>
+        </div>
+      </div>
+      <span class="conv-card-action">JOIN →</span>
+    </a>
+    {% endfor %}
   </div>
   {% endif %}
 
   {% if archived_joined %}
-  <div class="landing-section">
-    <p class="section-label">Closed</p>
-    <ul class="conversation-list">
-      {% for c in archived_joined %}
-      <li>
+  <div class="home-section">
+    <div class="home-section-header">
+      <span class="home-section-label">Closed</span>
+    </div>
+    {% for c in archived_joined %}
+    {% set part = part_map.get(c.id) %}
+    <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card">
+      <div class="conv-card-left">
         <span class="conv-dot conv-dot--closed"></span>
-        <a href="{{ url_for('conversation', slug=c.slug) }}">{{ c.title }}</a>
-        <span class="badge-inactive">closed</span>
-      </li>
-      {% endfor %}
-    </ul>
+        <div class="conv-card-info">
+          <div class="conv-card-title-row">
+            <span class="conv-card-title">{{ c.title }}</span>
+            {% if part %}<span class="conv-card-badge">{{ part.pseudonym }}</span>{% endif %}
+          </div>
+          {% if c.closed_at %}
+          <div class="conv-card-sub">closed {{ c.closed_at.strftime('%b %Y') }}</div>
+          {% endif %}
+        </div>
+      </div>
+      <span class="conv-card-action conv-card-action--muted">DONE</span>
+    </a>
+    {% endfor %}
   </div>
   {% endif %}
 
   {% if moderating %}
-  <div class="landing-section">
-    <p class="section-label">You moderate</p>
-    <ul class="conversation-list">
-      {% for c in moderating %}
-      <li class="conv-mod-row">
-        <span style="display:flex;align-items:center;gap:10px">
-          <span class="conv-dot {{ 'conv-dot--active' if c.active else 'conv-dot--closed' }}"></span>
-          <a href="{{ url_for('conversation', slug=c.slug) }}">{{ c.title }}</a>
-          {% if not c.active %}<span class="badge-inactive">closed</span>{% endif %}
-        </span>
-        <a href="{{ url_for('admin_conversation_detail', conv_id=c.id) }}"
-           class="admin-action-btn">Admin →</a>
-      </li>
-      {% endfor %}
-    </ul>
+  <div class="home-section">
+    <div class="home-section-header">
+      <span class="home-section-label">You moderate</span>
+    </div>
+    {% for c in moderating %}
+    <div class="conv-card">
+      <div class="conv-card-left">
+        <span class="conv-dot {{ 'conv-dot--active' if c.active else 'conv-dot--closed' }}"></span>
+        <div class="conv-card-info">
+          <div class="conv-card-title-row">
+            <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card-title">{{ c.title }}</a>
+            {% if not c.active %}<span class="conv-card-badge">closed</span>{% endif %}
+          </div>
+        </div>
+      </div>
+      <a href="{{ url_for('admin_conversation_detail', conv_id=c.id) }}"
+         class="conv-card-action">ADMIN →</a>
+    </div>
+    {% endfor %}
   </div>
   {% endif %}
 
@@ -127,7 +151,6 @@
   {% endif %}
 
 {% endif %}
-
 
 </div>
 

--- a/v2/templates/home.html
+++ b/v2/templates/home.html
@@ -30,122 +30,134 @@
   </div>
 
   {% if public_conversations %}
-  <div class="home-section">
-    <div class="home-section-header">
-      <span class="home-section-label">Open consultations</span>
-      <span class="home-section-count">{{ public_conversations | length }} total</span>
-    </div>
-    {% for c in public_conversations %}
-    <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
-       aria-label="{{ c.title }} — join consultation">
-      <div class="conv-card-left">
-        <span class="conv-dot conv-dot--available" aria-hidden="true"></span>
-        <span class="conv-card-title">{{ c.title }}</span>
+  <section aria-label="Open consultations, {{ public_conversations | length }}">
+    <div class="home-section">
+      <div class="home-section-header">
+        <span class="home-section-label">Open consultations</span>
+        <span class="home-section-count" aria-hidden="true">{{ public_conversations | length }} total</span>
       </div>
-      <span class="conv-card-action" aria-hidden="true">JOIN →</span>
-    </a>
-    {% endfor %}
-  </div>
+      {% for c in public_conversations %}
+      <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
+         aria-label="{{ c.title }} — join consultation">
+        <div class="conv-card-left">
+          <span class="conv-dot conv-dot--available" aria-hidden="true"></span>
+          <span class="conv-card-title">{{ c.title }}</span>
+        </div>
+        <span class="conv-card-action" aria-hidden="true">JOIN →</span>
+      </a>
+      {% endfor %}
+    </div>
+  </section>
   {% endif %}
 
 {% else %}
 
   {% if active_joined %}
-  <div class="home-section">
-    <div class="home-section-header">
-      <span class="home-section-label">Active</span>
-      <span class="home-section-count">{{ active_joined | length }} consultation{{ 's' if active_joined | length != 1 }}</span>
-    </div>
-    {% for c in active_joined %}
-    {% set part = pseudonym_map.get(c.id) %}
-    <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
-       aria-label="{{ c.title }}{% if part %} ({{ part.pseudonym }}){% endif %}, {{ 'temporarily paused' if c.paused else 'voting open' }} — continue">
-      <div class="conv-card-left">
-        <span class="conv-dot conv-dot--active" aria-hidden="true"></span>
-        <div class="conv-card-info">
-          <div class="conv-card-title-row">
-            <span class="conv-card-title">{{ c.title }}</span>
-            {% if part %}<span class="conv-card-badge">{{ part.pseudonym }}</span>{% endif %}
-          </div>
-          <div class="conv-card-sub">
-            {%- if c.paused -%}temporarily paused{%- else -%}voting open{%- endif -%}
+  <section aria-label="Active consultations, {{ active_joined | length }}">
+    <div class="home-section">
+      <div class="home-section-header">
+        <span class="home-section-label">Active</span>
+        <span class="home-section-count" aria-hidden="true">{{ active_joined | length }} consultation{{ 's' if active_joined | length != 1 }}</span>
+      </div>
+      {% for c in active_joined %}
+      {% set part = pseudonym_map.get(c.id) %}
+      <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
+         aria-label="{{ c.title }}{% if part %} ({{ part.pseudonym }}){% endif %}, {{ 'temporarily paused' if c.paused else 'voting open' }} — continue">
+        <div class="conv-card-left">
+          <span class="conv-dot conv-dot--active" aria-hidden="true"></span>
+          <div class="conv-card-info">
+            <div class="conv-card-title-row">
+              <span class="conv-card-title">{{ c.title }}</span>
+              {% if part %}<span class="conv-card-badge">{{ part.pseudonym }}</span>{% endif %}
+            </div>
+            <div class="conv-card-sub">
+              {%- if c.paused -%}temporarily paused{%- else -%}voting open{%- endif -%}
+            </div>
           </div>
         </div>
-      </div>
-      <span class="conv-card-action" aria-hidden="true">CONTINUE →</span>
-    </a>
-    {% endfor %}
-  </div>
+        <span class="conv-card-action" aria-hidden="true">CONTINUE →</span>
+      </a>
+      {% endfor %}
+    </div>
+  </section>
   {% endif %}
 
   {% if available %}
-  <div class="home-section">
-    <div class="home-section-header">
-      <span class="home-section-label">Open to you</span>
-    </div>
-    {% for c in available %}
-    <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
-       aria-label="{{ c.title }} — join consultation">
-      <div class="conv-card-left">
-        <span class="conv-dot conv-dot--available" aria-hidden="true"></span>
-        <div class="conv-card-info">
-          <span class="conv-card-title">{{ c.title }}</span>
-        </div>
+  <section aria-label="Open to you, {{ available | length }}">
+    <div class="home-section">
+      <div class="home-section-header">
+        <span class="home-section-label">Open to you</span>
+        <span class="home-section-count" aria-hidden="true">{{ available | length }} consultation{{ 's' if available | length != 1 }}</span>
       </div>
-      <span class="conv-card-action" aria-hidden="true">JOIN →</span>
-    </a>
-    {% endfor %}
-  </div>
+      {% for c in available %}
+      <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
+         aria-label="{{ c.title }} — join consultation">
+        <div class="conv-card-left">
+          <span class="conv-dot conv-dot--available" aria-hidden="true"></span>
+          <div class="conv-card-info">
+            <span class="conv-card-title">{{ c.title }}</span>
+          </div>
+        </div>
+        <span class="conv-card-action" aria-hidden="true">JOIN →</span>
+      </a>
+      {% endfor %}
+    </div>
+  </section>
   {% endif %}
 
   {% if archived_joined %}
-  <div class="home-section">
-    <div class="home-section-header">
-      <span class="home-section-label">Closed</span>
-    </div>
-    {% for c in archived_joined %}
-    {% set part = pseudonym_map.get(c.id) %}
-    <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
-       aria-label="{{ c.title }}{% if part %} ({{ part.pseudonym }}){% endif %}, closed{% if c.closed_at %} {{ c.closed_at.strftime('%B %Y') }}{% endif %}">
-      <div class="conv-card-left">
-        <span class="conv-dot conv-dot--closed" aria-hidden="true"></span>
-        <div class="conv-card-info">
-          <div class="conv-card-title-row">
-            <span class="conv-card-title">{{ c.title }}</span>
-            {% if part %}<span class="conv-card-badge">{{ part.pseudonym }}</span>{% endif %}
-          </div>
-          {% if c.closed_at %}
-          <div class="conv-card-sub">closed {{ c.closed_at.strftime('%b %Y') }}</div>
-          {% endif %}
-        </div>
+  <section aria-label="Closed consultations, {{ archived_joined | length }}">
+    <div class="home-section">
+      <div class="home-section-header">
+        <span class="home-section-label">Closed</span>
+        <span class="home-section-count" aria-hidden="true">{{ archived_joined | length }} consultation{{ 's' if archived_joined | length != 1 }}</span>
       </div>
-      <span class="conv-card-action conv-card-action--muted" aria-hidden="true">DONE</span>
-    </a>
-    {% endfor %}
-  </div>
+      {% for c in archived_joined %}
+      {% set part = pseudonym_map.get(c.id) %}
+      <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
+         aria-label="{{ c.title }}{% if part %} ({{ part.pseudonym }}){% endif %}, closed{% if c.closed_at %} {{ c.closed_at.strftime('%B %Y') }}{% endif %}">
+        <div class="conv-card-left">
+          <span class="conv-dot conv-dot--closed" aria-hidden="true"></span>
+          <div class="conv-card-info">
+            <div class="conv-card-title-row">
+              <span class="conv-card-title">{{ c.title }}</span>
+              {% if part %}<span class="conv-card-badge">{{ part.pseudonym }}</span>{% endif %}
+            </div>
+            {% if c.closed_at %}
+            <div class="conv-card-sub">closed {{ c.closed_at.strftime('%b %Y') }}</div>
+            {% endif %}
+          </div>
+        </div>
+        <span class="conv-card-action" aria-hidden="true">VIEW →</span>
+      </a>
+      {% endfor %}
+    </div>
+  </section>
   {% endif %}
 
   {% if moderating %}
-  <div class="home-section">
-    <div class="home-section-header">
-      <span class="home-section-label">You moderate</span>
-    </div>
-    {% for c in moderating %}
-    <div class="conv-card">
-      <div class="conv-card-left">
-        <span class="conv-dot {{ 'conv-dot--active' if c.active else 'conv-dot--closed' }}" aria-hidden="true"></span>
-        <div class="conv-card-info">
-          <div class="conv-card-title-row">
-            <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card-title">{{ c.title }}</a>
-            {% if not c.active %}<span class="conv-card-badge">closed</span>{% endif %}
-          </div>
-        </div>
+  <section aria-label="You moderate, {{ moderating | length }}">
+    <div class="home-section">
+      <div class="home-section-header">
+        <span class="home-section-label">You moderate</span>
+        <span class="home-section-count" aria-hidden="true">{{ moderating | length }} consultation{{ 's' if moderating | length != 1 }}</span>
       </div>
-      <a href="{{ url_for('admin_conversation_detail', conv_id=c.id) }}"
-         class="conv-card-action">ADMIN →</a>
+      {% for c in moderating %}
+      <div class="conv-card conv-card--split">
+        <span class="conv-card-left">
+          <span class="conv-dot {{ 'conv-dot--active' if c.active else 'conv-dot--closed' }}" aria-hidden="true"></span>
+          <a href="{{ url_for('conversation', slug=c.slug) }}"
+             class="conv-card-title">{{ c.title }}</a>
+          {% if not c.active %}<span class="conv-card-badge">closed</span>{% endif %}
+        </span>
+        <span class="conv-card-divider" aria-hidden="true"></span>
+        <a href="{{ url_for('admin_conversation_detail', conv_id=c.id) }}"
+           class="admin-action-btn"
+           aria-label="Open admin panel for {{ c.title }}">Admin →</a>
+      </div>
+      {% endfor %}
     </div>
-    {% endfor %}
-  </div>
+  </section>
   {% endif %}
 
   {% if not active_joined and not available and not archived_joined and not moderating %}

--- a/v2/templates/home.html
+++ b/v2/templates/home.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 
-<div class="container" style="max-width:820px">
+<div class="container home-container">
 
   <div style="margin-bottom:1.25rem;padding:10px 14px;border:1px solid var(--hairline);border-radius:8px;background:var(--surface);font-size:13px;color:var(--muted);line-height:1.6">
     Prototype in active development — things may change.
@@ -36,12 +36,13 @@
       <span class="home-section-count">{{ public_conversations | length }} total</span>
     </div>
     {% for c in public_conversations %}
-    <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card">
+    <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
+       aria-label="{{ c.title }} — join consultation">
       <div class="conv-card-left">
-        <span class="conv-dot conv-dot--available"></span>
+        <span class="conv-dot conv-dot--available" aria-hidden="true"></span>
         <span class="conv-card-title">{{ c.title }}</span>
       </div>
-      <span class="conv-card-action">JOIN →</span>
+      <span class="conv-card-action" aria-hidden="true">JOIN →</span>
     </a>
     {% endfor %}
   </div>
@@ -56,10 +57,11 @@
       <span class="home-section-count">{{ active_joined | length }} consultation{{ 's' if active_joined | length != 1 }}</span>
     </div>
     {% for c in active_joined %}
-    {% set part = part_map.get(c.id) %}
-    <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card">
+    {% set part = pseudonym_map.get(c.id) %}
+    <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
+       aria-label="{{ c.title }}{% if part %} ({{ part.pseudonym }}){% endif %}, {{ 'temporarily paused' if c.paused else 'voting open' }} — continue">
       <div class="conv-card-left">
-        <span class="conv-dot conv-dot--active"></span>
+        <span class="conv-dot conv-dot--active" aria-hidden="true"></span>
         <div class="conv-card-info">
           <div class="conv-card-title-row">
             <span class="conv-card-title">{{ c.title }}</span>
@@ -70,7 +72,7 @@
           </div>
         </div>
       </div>
-      <span class="conv-card-action">CONTINUE →</span>
+      <span class="conv-card-action" aria-hidden="true">CONTINUE →</span>
     </a>
     {% endfor %}
   </div>
@@ -82,14 +84,15 @@
       <span class="home-section-label">Open to you</span>
     </div>
     {% for c in available %}
-    <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card">
+    <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
+       aria-label="{{ c.title }} — join consultation">
       <div class="conv-card-left">
-        <span class="conv-dot conv-dot--available"></span>
+        <span class="conv-dot conv-dot--available" aria-hidden="true"></span>
         <div class="conv-card-info">
           <span class="conv-card-title">{{ c.title }}</span>
         </div>
       </div>
-      <span class="conv-card-action">JOIN →</span>
+      <span class="conv-card-action" aria-hidden="true">JOIN →</span>
     </a>
     {% endfor %}
   </div>
@@ -101,10 +104,11 @@
       <span class="home-section-label">Closed</span>
     </div>
     {% for c in archived_joined %}
-    {% set part = part_map.get(c.id) %}
-    <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card">
+    {% set part = pseudonym_map.get(c.id) %}
+    <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
+       aria-label="{{ c.title }}{% if part %} ({{ part.pseudonym }}){% endif %}, closed{% if c.closed_at %} {{ c.closed_at.strftime('%B %Y') }}{% endif %}">
       <div class="conv-card-left">
-        <span class="conv-dot conv-dot--closed"></span>
+        <span class="conv-dot conv-dot--closed" aria-hidden="true"></span>
         <div class="conv-card-info">
           <div class="conv-card-title-row">
             <span class="conv-card-title">{{ c.title }}</span>
@@ -115,7 +119,7 @@
           {% endif %}
         </div>
       </div>
-      <span class="conv-card-action conv-card-action--muted">DONE</span>
+      <span class="conv-card-action conv-card-action--muted" aria-hidden="true">DONE</span>
     </a>
     {% endfor %}
   </div>
@@ -129,7 +133,7 @@
     {% for c in moderating %}
     <div class="conv-card">
       <div class="conv-card-left">
-        <span class="conv-dot {{ 'conv-dot--active' if c.active else 'conv-dot--closed' }}"></span>
+        <span class="conv-dot {{ 'conv-dot--active' if c.active else 'conv-dot--closed' }}" aria-hidden="true"></span>
         <div class="conv-card-info">
           <div class="conv-card-title-row">
             <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card-title">{{ c.title }}</a>

--- a/v2/templates/home.html
+++ b/v2/templates/home.html
@@ -143,7 +143,7 @@
         <span class="home-section-count" aria-hidden="true">{{ moderating | length }} consultation{{ 's' if moderating | length != 1 }}</span>
       </div>
       {% for c in moderating %}
-      <div class="conv-card conv-card--split">
+      <div class="conv-card conv-card--split" role="group" aria-label="{{ c.title }}">
         <span class="conv-card-left">
           <span class="conv-dot {{ 'conv-dot--active' if c.active else 'conv-dot--closed' }}" aria-hidden="true"></span>
           <a href="{{ url_for('conversation', slug=c.slug) }}"


### PR DESCRIPTION
## Summary

- Replaces the flat `<ul>` conversation list with individual surface cards matching the Cluster design direction
- Each card shows: coloured state dot · conversation title · participant's pseudonym chip (for joined conversations) · sub-line status · mono-uppercase action label (`CONTINUE →` / `JOIN →` / `DONE`)
- Sections are labelled with mono uppercase headers: **Active** · **Open to you** · **Closed** · **You moderate**
- Logged-out view keeps the hero copy + open consultations list, now also in card layout

**Backend**: `home` route now passes `part_map` (conversation_id → Participation) so the template can render each user's pseudonym per conversation without extra queries.

**CSS**: new `.home-section`, `.conv-card`, `.conv-card-*` utility classes implement the row-card spec from the design handoff (`cluster.jsx` — `XHomeLoggedIn` artboard).

## What this is

Part of the Cluster design handoff implementation. The voting tab, propose affordance, arguments tab, and CSS tokens were landed in earlier PRs. This PR covers the home page, which had the largest remaining visual gap from the design spec.

## Test plan
- [ ] Logged out: see hero copy + open consultations in card format with "JOIN →" label
- [ ] Logged in with joined active conversations: cards show dot, title, pseudonym badge, "voting open" sub-line, "CONTINUE →"
- [ ] Logged in with closed conversations: cards show "closed Mon YYYY" sub-line, "DONE" label
- [ ] Logged in with available-to-join conversations: "JOIN →" label, no pseudonym badge
- [ ] Moderator row shows "ADMIN →" link
- [ ] Empty state: "No consultations available" landing section shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)