### PR TITLE
Move argument delete from participant view to admin panel

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -1652,7 +1652,10 @@ def _register_routes(app: Flask) -> None:
         conv        = _require_mod_for_conv(conv_id)
         confirmed   = (FeaturedStatement.query
                        .filter_by(conversation_id=conv_id)
+                       .options(joinedload(FeaturedStatement.arguments))
                        .order_by(FeaturedStatement.created_at).all())
+        for fs in confirmed:
+            fs.arguments.sort(key=lambda a: a.side if isinstance(a.side, str) else a.side.value)
         _backfill_statement_texts(conv, confirmed)
         confirmed_tids = {fs.polis_statement_id for fs in confirmed}
         candidates   = _polis_server_client().get_featured_candidates(conv.polis_id)

--- a/v2/app.py
+++ b/v2/app.py
@@ -1121,19 +1121,6 @@ def _register_routes(app: Flask) -> None:
             return jsonify({'ok': True})
         return redirect(url_for('conversation', slug=slug) + '#tab-arguments')
 
-    @app.post('/c/<slug>/arguments/<int:arg_id>/delete')
-    @login_required
-    def argument_delete(slug, arg_id):
-        conv = Conversation.query.filter_by(slug=slug).first_or_404()
-        if not _can_moderate(conv):
-            abort(403)
-        arg = Argument.query.filter_by(id=arg_id).first_or_404()
-        FeaturedStatement.query.filter_by(
-            id=arg.featured_statement_id, conversation_id=conv.id).first_or_404()
-        db.session.delete(arg)
-        db.session.commit()
-        return redirect(url_for('conversation', slug=slug) + '#tab-arguments')
-
     @app.post('/c/<slug>/arguments/<int:arg_id>/hide')
     @login_required
     def argument_hide(slug, arg_id):
@@ -1732,6 +1719,17 @@ def _register_routes(app: Flask) -> None:
         fs = FeaturedStatement.query.filter_by(
             id=fs_id, conversation_id=conv_id).first_or_404()
         db.session.delete(fs)
+        db.session.commit()
+        return redirect(url_for('admin_conversation_featured', conv_id=conv_id))
+
+    @app.post('/admin/conversations/<int:conv_id>/arguments/<int:arg_id>/delete')
+    @login_required
+    def admin_argument_delete(conv_id, arg_id):
+        conv = _require_mod_for_conv(conv_id)
+        arg  = Argument.query.filter_by(id=arg_id).first_or_404()
+        FeaturedStatement.query.filter_by(
+            id=arg.featured_statement_id, conversation_id=conv.id).first_or_404()
+        db.session.delete(arg)
         db.session.commit()
         return redirect(url_for('admin_conversation_featured', conv_id=conv_id))
 

--- a/v2/app.py
+++ b/v2/app.py
@@ -1655,7 +1655,7 @@ def _register_routes(app: Flask) -> None:
                        .options(joinedload(FeaturedStatement.arguments))
                        .order_by(FeaturedStatement.created_at).all())
         for fs in confirmed:
-            fs.arguments.sort(key=lambda a: a.side if isinstance(a.side, str) else a.side.value)
+            fs.arguments.sort(key=lambda a: a.side if isinstance(a.side, str) else a.side.value or '')
         _backfill_statement_texts(conv, confirmed)
         confirmed_tids = {fs.polis_statement_id for fs in confirmed}
         candidates   = _polis_server_client().get_featured_candidates(conv.polis_id)

--- a/v2/templates/admin_featured.html
+++ b/v2/templates/admin_featured.html
@@ -31,27 +31,29 @@
       <tr>
         <td style="white-space:nowrap;vertical-align:top">{{ fs.polis_statement_id }}</td>
         <td style="font-size:13px;vertical-align:top">
-          <div style="margin-bottom:{% if fs.arguments %}0.5rem{% else %}0{% endif %}">{{ fs.statement_text or '—' }}</div>
-          {% if fs.arguments %}
-          <table style="width:100%;border-collapse:collapse;font-size:12px">
-            {% for arg in fs.arguments | sort(attribute='side') %}
-            <tr style="border-top:1px solid var(--hairline)">
-              <td style="padding:4px 8px 4px 0;white-space:nowrap;color:var(--muted)">{{ arg.side }}</td>
-              <td style="padding:4px 8px;color:var(--body)">{{ arg.body }}</td>
-              <td style="padding:4px 0 4px 8px;white-space:nowrap;color:var(--muted)">{{ arg.proposer.mw_username if arg.proposer else '—' }}</td>
-              <td style="padding:4px 0 4px 8px;white-space:nowrap">
-                <form method="post"
-                      action="{{ url_for('admin_argument_delete', conv_id=conversation.id, arg_id=arg.id) }}"
-                      style="display:inline">
-                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                  <button type="submit" class="btn-small btn-danger"
-                          onclick="return confirm('Delete this argument? This cannot be undone.')">delete</button>
-                </form>
-              </td>
-            </tr>
+          <div style="margin-bottom:0.5rem">{{ fs.statement_text or '—' }}</div>
+          <div style="border-top:1px solid var(--hairline);padding-top:0.4rem;margin-top:0.1rem">
+            <span style="font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:0.06em">Arguments</span>
+            {% if fs.arguments %}
+            {% for arg in fs.arguments %}
+            <div style="display:flex;flex-wrap:wrap;align-items:baseline;gap:6px;margin-top:4px;font-size:12px">
+              <span style="color:var(--muted);min-width:2rem;flex-shrink:0">{{ arg.side }}</span>
+              <span style="flex:1;min-width:120px;color:var(--body)">{{ arg.body }}</span>
+              <span style="color:var(--muted);white-space:nowrap">{{ arg.proposer.mw_username if arg.proposer else '—' }}</span>
+              <span style="color:var(--muted);white-space:nowrap">{{ arg.created_at.strftime('%Y-%m-%d') if arg.created_at else '' }}</span>
+              <form method="post"
+                    action="{{ url_for('admin_argument_delete', conv_id=conversation.id, arg_id=arg.id) }}"
+                    style="display:inline;flex-shrink:0">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="btn-small btn-danger"
+                        onclick="return confirm('Delete this argument and all its votes? This cannot be undone.')">delete</button>
+              </form>
+            </div>
             {% endfor %}
-          </table>
-          {% endif %}
+            {% else %}
+            <p style="font-size:12px;color:var(--muted);margin:4px 0 0">no arguments yet</p>
+            {% endif %}
+          </div>
         </td>
         <td style="vertical-align:top">
           <form method="post"

--- a/v2/templates/admin_featured.html
+++ b/v2/templates/admin_featured.html
@@ -29,9 +29,31 @@
     <tbody>
       {% for fs in confirmed %}
       <tr>
-        <td style="white-space:nowrap">{{ fs.polis_statement_id }}</td>
-        <td style="font-size:13px">{{ fs.statement_text or '—' }}</td>
-        <td>
+        <td style="white-space:nowrap;vertical-align:top">{{ fs.polis_statement_id }}</td>
+        <td style="font-size:13px;vertical-align:top">
+          <div style="margin-bottom:{% if fs.arguments %}0.5rem{% else %}0{% endif %}">{{ fs.statement_text or '—' }}</div>
+          {% if fs.arguments %}
+          <table style="width:100%;border-collapse:collapse;font-size:12px">
+            {% for arg in fs.arguments | sort(attribute='side') %}
+            <tr style="border-top:1px solid var(--hairline)">
+              <td style="padding:4px 8px 4px 0;white-space:nowrap;color:var(--muted)">{{ arg.side }}</td>
+              <td style="padding:4px 8px;color:var(--body)">{{ arg.body }}</td>
+              <td style="padding:4px 0 4px 8px;white-space:nowrap;color:var(--muted)">{{ arg.proposer.mw_username if arg.proposer else '—' }}</td>
+              <td style="padding:4px 0 4px 8px;white-space:nowrap">
+                <form method="post"
+                      action="{{ url_for('admin_argument_delete', conv_id=conversation.id, arg_id=arg.id) }}"
+                      style="display:inline">
+                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                  <button type="submit" class="btn-small btn-danger"
+                          onclick="return confirm('Delete this argument? This cannot be undone.')">delete</button>
+                </form>
+              </td>
+            </tr>
+            {% endfor %}
+          </table>
+          {% endif %}
+        </td>
+        <td style="vertical-align:top">
           <form method="post"
                 action="{{ url_for('admin_featured_remove', conv_id=conversation.id, fs_id=fs.id) }}"
                 style="display:inline">

--- a/v2/templates/admin_featured.html
+++ b/v2/templates/admin_featured.html
@@ -51,7 +51,7 @@
             </div>
             {% endfor %}
             {% else %}
-            <p style="font-size:12px;color:var(--muted);margin:4px 0 0">no arguments yet</p>
+            <p style="font-size:12px;color:var(--body);margin:4px 0 0">no arguments yet</p>
             {% endif %}
           </div>
         </td>

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -484,10 +484,6 @@
                     <button type="submit" class="btn-small btn-warn">hide</button>
                   </form>
                   {% endif %}
-                  <form method="post" action="{{ url_for('argument_delete', slug=conversation.slug, arg_id=arg.id) }}" style="display:inline">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <button type="submit" class="btn-small btn-danger" onclick="return confirm('Delete?')">delete</button>
-                  </form>
                 </span>
                 {% endif %}
               </div>
@@ -600,10 +596,6 @@
                     <button type="submit" class="btn-small btn-warn">hide</button>
                   </form>
                   {% endif %}
-                  <form method="post" action="{{ url_for('argument_delete', slug=conversation.slug, arg_id=arg.id) }}" style="display:inline">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <button type="submit" class="btn-small btn-danger" onclick="return confirm('Delete?')">delete</button>
-                  </form>
                 </span>
                 {% endif %}
               </div>


### PR DESCRIPTION
Closes #24.

## Changes

- **`conversation.html`**: Removed inline `delete` button from argument cards. `hide`/`unhide` remain for quick in-context moderation.
- **`app.py`**: Removed old `argument_delete` route. Added `admin_argument_delete` at `/admin/conversations/<conv_id>/arguments/<arg_id>/delete` using `_require_mod_for_conv` + IDOR check.
- **`app.py`**: Eager-loads arguments with `joinedload` in `admin_conversation_featured` to prevent N+1 queries. Arguments sorted by side in Python.
- **`admin_featured.html`**: Arguments listed under each confirmed featured statement with side, body, proposer, date, and delete button. Uses flex-wrap rows (no nested table). Empty state and visual separator included.

## Test plan

- [ ] Arguments tab: delete button gone for moderator and all users; hide/unhide still work
- [ ] Admin → Featured Statements: arguments appear under each FS with side, body, proposer, date
- [ ] Empty FS shows "no arguments yet"
- [ ] Delete button → confirm dialog → argument + votes removed → lands back on Featured Statements
- [ ] Non-moderator GET/POST to `/admin/conversations/<id>/arguments/<id>/delete` returns 403
- [ ] Moderator of conversation A cannot delete argument from conversation B (404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)