### PR TITLE
Add /health endpoint for uptime monitoring

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -24,6 +24,7 @@ from flask_session import Session
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_wtf.csrf import CSRFProtect
+from sqlalchemy import text as _sa_text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 
@@ -1749,6 +1750,29 @@ def _register_routes(app: Flask) -> None:
         db.session.delete(arg)
         db.session.commit()
         return redirect(url_for('admin_conversation_featured', conv_id=conv_id))
+
+    # ── Health ────────────────────────────────────────────────────────────────
+
+    @app.get('/health')
+    @limiter.exempt
+    def health():
+        result = {'db': 'ok', 'particiapi': 'ok'}
+
+        try:
+            with db.engine.connect() as conn:
+                conn.execute(_sa_text('SELECT 1'))
+        except Exception:
+            result['db'] = 'error'
+
+        try:
+            base = current_app.config.get('PARTICIAPI_BASE', '')
+            requests.get(f'{base}/api/conversations/', timeout=2)
+        except Exception:
+            result['particiapi'] = 'unreachable'
+
+        result['status'] = 'ok' if all(v == 'ok' for v in result.values()) else 'degraded'
+        status_code = 200 if result['status'] == 'ok' else 503
+        return jsonify(result), status_code
 
 
 app = create_app()


### PR DESCRIPTION
Closes #37.

## Summary

- `GET /health` returns JSON `{"status": "ok"|"degraded", "db": "ok"|"error", "particiapi": "ok"|"unreachable"}`
- HTTP 200 when all dependencies are healthy; HTTP 503 if any are down
- Checks the app DB with `SELECT 1` and Particiapi with a 2 s GET to `/api/conversations/`
- Exempt from rate limiting (`@limiter.exempt`) — safe to poll frequently
- No authentication required; no sensitive data exposed

## How to wire up alerting

Point any free external monitor at `https://wiki-polis.toolforge.org/health`:

- [UptimeRobot](https://uptimerobot.com) — free tier, 5-minute polling, email alerts
- [Freshping](https://www.freshping.io) — free tier, 1-minute polling

Configure: keyword `"status": "ok"` must be present, alert on absence or HTTP 503.

## What's out of scope (per issue)

- Frontend degraded-state banner — deferred as a separate issue
- `/admin/alert` endpoint for user-triggered notifications — deferred
- Polis-internal health checks

## Test plan

- [ ] `curl /health` with backend running → `{"db":"ok","particiapi":"ok","status":"ok"}` + HTTP 200
- [ ] `curl /health` with Particiapi stopped → `"particiapi":"unreachable"`, `"status":"degraded"` + HTTP 503
- [ ] `/health` is accessible without login
- [ ] Rapid polling (e.g. `ab -n 200 /health`) is not rate-limited

🤖 Generated with [Claude Code](https://claude.com/claude-code)