### PR TITLE
Replace propose affordance with V2 three-option triad

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -4,7 +4,14 @@
 
 set -euo pipefail
 
-BRANCH="${1:-}"
+BRANCH=""
+MIGRATE=0
+for arg in "$@"; do
+  case "$arg" in
+    --migrate) MIGRATE=1 ;;
+    *) BRANCH="$arg" ;;
+  esac
+done
 
 echo "==> Pulling latest changes..."
 cd ~/wiki-polis
@@ -40,6 +47,16 @@ if [ ! -f "$WC_DST" ]; then
   echo "    into v2/static/ before the conversation page will work."
 else
   echo "    Found."
+fi
+
+if [ "$MIGRATE" -eq 1 ]; then
+  echo "==> Running database migrations..."
+  DATABASE_URL=$(toolforge envvars show DATABASE_URL)
+  export DATABASE_URL
+  source ~/www/python/venv/bin/activate
+  cd ~/wiki-polis/v2
+  flask --app app db upgrade
+  echo "    Migrations done."
 fi
 
 echo "==> Restarting web service..."

--- a/v2/app.py
+++ b/v2/app.py
@@ -24,6 +24,7 @@ from flask_session import Session
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_wtf.csrf import CSRFProtect
+from sqlalchemy import text as _sa_text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 
@@ -1749,6 +1750,29 @@ def _register_routes(app: Flask) -> None:
         db.session.delete(arg)
         db.session.commit()
         return redirect(url_for('admin_conversation_featured', conv_id=conv_id))
+
+    # ── Health ────────────────────────────────────────────────────────────────
+
+    @app.get('/health')
+    @limiter.exempt
+    def health():
+        result = {'db': 'ok', 'particiapi': 'ok'}
+
+        try:
+            with db.engine.connect() as conn:
+                conn.execute(_sa_text('SELECT 1'))
+        except Exception:
+            result['db'] = 'error'
+
+        try:
+            base = current_app.config.get('PARTICIAPI_BASE', '')
+            requests.get(f'{base}/api/conversations/', timeout=2)
+        except Exception:
+            result['particiapi'] = 'unreachable'
+
+        result['status'] = 'ok' if all(v == 'ok' for v in result.values()) else 'degraded'
+        status_code = 200 if result['status'] == 'ok' else 503
+        return jsonify(result), status_code
 
 
 app = create_app()

--- a/v2/app.py
+++ b/v2/app.py
@@ -951,7 +951,8 @@ def _register_routes(app: Flask) -> None:
                                polis_public_url=current_app.config.get('POLIS_PUBLIC_URL', ''),
                                reveal_state=reveal_state,
                                reveal_opens_at=reveal_opens_at,
-                               featured_data=featured_data)
+                               featured_data=featured_data,
+                               new_stmt_unlock_at=conv.argument_vote_data.get('new_stmt_unlock_at', 10) if conv.argument_vote_data else 10)
 
     # ── Arguments ────────────────────────────────────────────────────────────
 

--- a/v2/app.py
+++ b/v2/app.py
@@ -1165,6 +1165,84 @@ def _register_routes(app: Flask) -> None:
         db.session.commit()
         return redirect(url_for('conversation', slug=slug) + '#tab-arguments')
 
+    # ── New statement submission (quota-tracked) ──────────────────────────────
+
+    @app.post('/c/<slug>/statements/new')
+    @login_required
+    @csrf.exempt
+    def conversation_statement_new(slug):
+        """Submit an entirely new statement; enforces per-participant quota and
+        records the Polis statement ID for novelty tracking."""
+        # Origin validation (same compensating control as the proxy).
+        sec_fetch = request.headers.get('Sec-Fetch-Site')
+        if sec_fetch:
+            if sec_fetch != 'same-origin':
+                abort(403)
+        else:
+            origin = request.headers.get('Origin')
+            if origin and urlparse(origin).netloc != urlparse(request.host_url).netloc:
+                abort(403)
+
+        conv = Conversation.query.filter_by(slug=slug).first_or_404()
+        if not conv.active or conv.paused or not conv.phase_submission:
+            abort(403)
+        participant = _current_participant()
+        if not participant:
+            abort(401)
+        part = Participation.query.filter_by(
+            participant_id=participant.id, conversation_id=conv.id).first_or_404()
+
+        new_stmt_max = conv.argument_vote_data.get('new_stmt_max', 3) if conv.argument_vote_data else 3
+        if len(part.new_stmt_ids or []) >= new_stmt_max:
+            return jsonify({'error': 'quota_exceeded'}), 403
+
+        body = request.get_json(silent=True) or {}
+        text = (body.get('text') or '').strip()
+        if not text or len(text) > 280:
+            abort(400)
+
+        # Get CSRF token for this Particiapi session, then submit the statement.
+        pa_cookie = request.cookies.get('pa_session')
+        forwarded = {'session': pa_cookie} if pa_cookie else {}
+        base = current_app.config['PARTICIAPI_BASE']
+
+        try:
+            sess_resp = requests.post(
+                f'{base}/api/session',
+                cookies=forwarded,
+                params={'create': 'true'},
+                timeout=5,
+            )
+            csrf_token = sess_resp.json().get('csrf_token', '')
+            new_pa_cookie = sess_resp.cookies.get('session')
+            submit_cookies = {'session': new_pa_cookie or pa_cookie} if (new_pa_cookie or pa_cookie) else {}
+
+            stmt_resp = requests.post(
+                f'{base}/api/conversations/{conv.polis_id}/statements/',
+                json={'text': text},
+                cookies=submit_cookies,
+                headers={'X-CSRF-Token': csrf_token},
+                timeout=10,
+            )
+        except requests.RequestException:
+            current_app.logger.exception('Particiapi error in conversation_statement_new')
+            abort(502)
+
+        if stmt_resp.status_code == 201:
+            stmt_id = stmt_resp.json().get('id')
+            if stmt_id is not None:
+                ids = list(part.new_stmt_ids or [])
+                ids.append(stmt_id)
+                part.new_stmt_ids = ids
+                db.session.commit()
+
+        flask_resp = make_response(stmt_resp.content, stmt_resp.status_code)
+        flask_resp.headers['Content-Type'] = stmt_resp.headers.get('Content-Type', 'application/json')
+        if new_pa_cookie:
+            flask_resp.set_cookie('pa_session', new_pa_cookie, httponly=True,
+                                  samesite='Lax', secure=not current_app.debug)
+        return flask_resp
+
     # ── Particiapi proxy ──────────────────────────────────────────────────────
 
     @app.route('/proxy/particiapi/<path:pa_path>',

--- a/v2/app.py
+++ b/v2/app.py
@@ -261,6 +261,19 @@ def _check_conversation_access(conversation, participant) -> None:
 
 # ── Particiapi proxy ──────────────────────────────────────────────────────────
 
+def _validate_same_origin():
+    """Abort 403 if the request does not appear to be same-origin.
+    Used as a compensating control on CSRF-exempt endpoints."""
+    sec_fetch = request.headers.get('Sec-Fetch-Site')
+    if sec_fetch:
+        if sec_fetch != 'same-origin':
+            abort(403)
+    else:
+        origin = request.headers.get('Origin')
+        if origin and urlparse(origin).netloc != urlparse(request.host_url).netloc:
+            abort(403)
+
+
 def _proxy_to_particiapi(pa_path: str):
     """
     Proxy a browser request to Particiapi and return the response.
@@ -277,14 +290,7 @@ def _proxy_to_particiapi(pa_path: str):
     """
     # Origin validation as compensating control for CSRF exemption.
     if request.method not in ('GET', 'HEAD'):
-        sec_fetch = request.headers.get('Sec-Fetch-Site')
-        if sec_fetch:
-            if sec_fetch != 'same-origin':
-                abort(403)
-        else:
-            origin = request.headers.get('Origin')
-            if origin and urlparse(origin).netloc != urlparse(request.host_url).netloc:
-                abort(403)
+        _validate_same_origin()
 
     # CRIT-1: Reject path traversal and non-API paths.
     if '..' in pa_path.split('/') or not pa_path.startswith('api/'):
@@ -1174,14 +1180,7 @@ def _register_routes(app: Flask) -> None:
         """Submit an entirely new statement; enforces per-participant quota and
         records the Polis statement ID for novelty tracking."""
         # Origin validation (same compensating control as the proxy).
-        sec_fetch = request.headers.get('Sec-Fetch-Site')
-        if sec_fetch:
-            if sec_fetch != 'same-origin':
-                abort(403)
-        else:
-            origin = request.headers.get('Origin')
-            if origin and urlparse(origin).netloc != urlparse(request.host_url).netloc:
-                abort(403)
+        _validate_same_origin()
 
         conv = Conversation.query.filter_by(slug=slug).first_or_404()
         if not conv.active or conv.paused or not conv.phase_submission:
@@ -1189,8 +1188,12 @@ def _register_routes(app: Flask) -> None:
         participant = _current_participant()
         if not participant:
             abort(401)
+
+        # Lock the participation row for the duration of this transaction to
+        # prevent two concurrent requests from both passing the quota check.
         part = Participation.query.filter_by(
-            participant_id=participant.id, conversation_id=conv.id).first_or_404()
+            participant_id=participant.id, conversation_id=conv.id,
+        ).with_for_update().first_or_404()
 
         new_stmt_max = conv.argument_vote_data.get('new_stmt_max', 3) if conv.argument_vote_data else 3
         if len(part.new_stmt_ids or []) >= new_stmt_max:
@@ -1213,6 +1216,9 @@ def _register_routes(app: Flask) -> None:
                 params={'create': 'true'},
                 timeout=5,
             )
+            if not sess_resp.ok:
+                current_app.logger.error('Particiapi session error: %s', sess_resp.status_code)
+                abort(502)
             csrf_token = sess_resp.json().get('csrf_token', '')
             new_pa_cookie = sess_resp.cookies.get('session')
             submit_cookies = {'session': new_pa_cookie or pa_cookie} if (new_pa_cookie or pa_cookie) else {}
@@ -1235,9 +1241,12 @@ def _register_routes(app: Flask) -> None:
                 ids.append(stmt_id)
                 part.new_stmt_ids = ids
                 db.session.commit()
+            flask_resp = make_response(stmt_resp.content, 201)
+            flask_resp.headers['Content-Type'] = 'application/json'
+        else:
+            current_app.logger.error('Particiapi statement error: %s', stmt_resp.status_code)
+            flask_resp = make_response(jsonify({'error': 'upstream_error'}), 502)
 
-        flask_resp = make_response(stmt_resp.content, stmt_resp.status_code)
-        flask_resp.headers['Content-Type'] = stmt_resp.headers.get('Content-Type', 'application/json')
         if new_pa_cookie:
             flask_resp.set_cookie('pa_session', new_pa_cookie, httponly=True,
                                   samesite='Lax', secure=not current_app.debug)

--- a/v2/app.py
+++ b/v2/app.py
@@ -952,7 +952,9 @@ def _register_routes(app: Flask) -> None:
                                reveal_state=reveal_state,
                                reveal_opens_at=reveal_opens_at,
                                featured_data=featured_data,
-                               new_stmt_unlock_at=conv.argument_vote_data.get('new_stmt_unlock_at', 10) if conv.argument_vote_data else 10)
+                               new_stmt_unlock_at=conv.argument_vote_data.get('new_stmt_unlock_at', 10) if conv.argument_vote_data else 10,
+                               new_stmt_max=conv.argument_vote_data.get('new_stmt_max', 3) if conv.argument_vote_data else 3,
+                               new_stmt_ids=participation.new_stmt_ids if participation else [])
 
     # ── Arguments ────────────────────────────────────────────────────────────
 

--- a/v2/db.py
+++ b/v2/db.py
@@ -93,6 +93,9 @@ class Participation(db.Model):
     # Nullified automatically 60 days after conversation close (data minimisation).
     public_username   = db.Column(db.String(255), nullable=True)
     revealed_at       = db.Column(db.DateTime, nullable=True)
+    # Polis statement IDs of entirely new statements submitted by this participant.
+    # Quota = len(new_stmt_ids). Slots consumed at submit time; never returned.
+    new_stmt_ids      = db.Column(db.JSON, nullable=False, default=list)
 
     participant  = db.relationship('Participant', back_populates='participations')
     conversation = db.relationship('Conversation', back_populates='participations')

--- a/v2/deployment.md
+++ b/v2/deployment.md
@@ -379,11 +379,15 @@ https://wiki-polis.toolforge.org/login     → redirects to Wikimedia OAuth
 ## Ongoing deploys
 
 ```bash
-# On Toolforge as wiki-polis user:
+# On Toolforge bastion as wiki-polis user:
 cd ~/wiki-polis && git pull
-source ~/www/python/venv/bin/activate
-pip install -e ~/wiki-polis/v2
-cd v2 && flask --app app.py db upgrade
+pip install -e ~/wiki-polis/v2   # skip if no new dependencies
+```
+
+If the deploy includes database migrations, run them **before** restarting (see [Database migrations](#database-migrations) below).
+
+```bash
+cd ~   # webservice commands must run from home directory
 toolforge webservice restart
 ```
 
@@ -392,6 +396,89 @@ Or use the deploy script (which handles all steps):
 ```bash
 bash ~/wiki-polis/deploy.sh
 ```
+
+---
+
+## Database migrations
+
+Alembic migrations must run inside `toolforge webservice python3.13 shell` — **not** on the bastion shell. The reason: `toolforge envvars` (including `DATABASE_URL`) are only injected into the webservice pod environment, not exported to regular bastion sessions. Running `flask db upgrade` on the bastion will fail with `RuntimeError: DATABASE_URL is not set`.
+
+### Check whether a migration is needed
+
+After `git pull`, check if the new commits added any migration files:
+
+```bash
+ls ~/wiki-polis/v2/migrations/versions/
+```
+
+If there are new files since the last deploy, run the migration steps below before restarting.
+
+### Run migrations
+
+```bash
+# Step 1 — enter the webservice shell (envvars are available here)
+toolforge webservice python3.13 shell
+
+# Step 2 — activate the venv (flask is not on PATH by default)
+source /data/project/wiki-polis/www/python/venv/bin/activate
+
+# Step 3 — run the migration from the app directory
+cd ~/wiki-polis/v2
+flask --app app db upgrade
+
+# Step 4 — exit the webservice shell
+exit
+```
+
+Expected output:
+
+```
+INFO  [alembic.runtime.migration] Context impl MySQLImpl.
+INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
+INFO  [alembic.runtime.migration] Running upgrade <prev> -> <new>, <description>
+```
+
+No output after "Will assume non-transactional DDL." means the database is already up to date.
+
+### After migration — restart the webservice
+
+Run this from the **bastion** (not inside the webservice shell):
+
+```bash
+cd ~
+toolforge webservice restart
+```
+
+### Verify
+
+Check the live app returns 200, then inspect the log for errors:
+
+```bash
+tail -50 /data/project/wiki-polis/uwsgi.log | grep -v lseek
+```
+
+### If something goes wrong — rollback
+
+To undo the last migration:
+
+```bash
+toolforge webservice python3.13 shell
+source /data/project/wiki-polis/www/python/venv/bin/activate
+cd ~/wiki-polis/v2
+flask --app app db downgrade   # rolls back one step
+exit
+```
+
+Then revert the code change and restart.
+
+### Toolforge gotchas specific to migrations
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `RuntimeError: DATABASE_URL is not set` | Running `flask` on the bastion shell | Use `toolforge webservice python3.13 shell` — envvars only exist there |
+| `flask: command not found` | Venv not activated inside webservice shell | `source /data/project/wiki-polis/www/python/venv/bin/activate` |
+| `Error: No such command 'db'` | Wrong working directory or FLASK_APP not set | `cd ~/wiki-polis/v2` first, then `flask --app app db upgrade` |
+| `No such file or directory: .../activate` | Wrong venv path guessed | Run `find /data/project/wiki-polis -name activate -path "*/venv/*"` to find the real path |
 
 ---
 

--- a/v2/functional_design.md
+++ b/v2/functional_design.md
@@ -92,27 +92,34 @@ Wording suggestions ("Suggest different wording") do not count against this quot
 #### States
 
 - **Idle** — statement visible, Agree/Pass/Disagree buttons shown, triad dimmed below with label "After you vote, you can…"
-- **Voted** — vote submitted, statement text frozen as snapshot with badge (e.g. "YOU VOTED AGREE"), vote buttons hidden, triad activated ("What now?") with three cards
+- **Voted: below threshold** — vote submitted, statement frozen with badge, vote buttons hidden, triad active with two live cards: "Suggest different wording" and "Move on". "Propose new statement" card is present but locked, showing the unlock condition.
+- **Voted: above threshold** — same as above but "Propose new statement" card is also live (if quota > 0) or permanently disabled (if quota = 0). Quota remaining shown on the card.
 - **Composing: suggest** — triad hidden, suggest-wording textarea open, pre-filled with the statement text
 - **Composing: new** — triad hidden, blank new-statement textarea open
 - **Submitted** — confirmation shown ("Proposed — heading to moderation"), next button available
-- **All done** — no more statements to vote on; triad hidden, completion message shown
+- **All done** — no more statements to vote on; completion message shown. "Propose new statement" becomes available (threshold is met by definition — you've voted on everything). Quota rules still apply.
+
+The threshold for moving from "below" to "above" is `min(new_stmt_unlock_at, total_statements_currently_available)`, where `new_stmt_unlock_at` defaults to 10.
 
 #### Transitions
 
 | From | Trigger | To | Side effect |
 |---|---|---|---|
-| Idle | Click Agree / Pass / Disagree | Voted | Vote sent to API immediately |
-| Voted | Click "Move on" | Idle | Next statement loads |
-| Voted | Click "Suggest different wording" | Composing: suggest | — |
-| Voted | Click "Propose new statement" (unlocked, quota > 0) | Composing: new | — |
-| Voted | Click "change" in voted badge | Idle | No new API call — Polis allows revoting on next submit |
-| Composing: suggest | Click Cancel | Voted | Returns to triad for the same statement |
+| Idle | Click Agree / Pass / Disagree (threshold not yet met) | Voted: below threshold | Vote → API; vote counter +1; voted badge shown |
+| Idle | Click Agree / Pass / Disagree (threshold already met) | Voted: above threshold | Vote → API; vote counter +1; voted badge shown |
+| Voted: any | Click "Move on" | Idle | Next statement loads |
+| Voted: any | Click "Suggest different wording" | Composing: suggest | — |
+| Voted: above threshold | Click "Propose new statement" (quota > 0) | Composing: new | — |
+| Voted: any | Click "change" in voted badge | Idle | No new API call; vote counter -1 |
+| Composing: suggest | Click Cancel | Voted: (same threshold state) | Returns to triad for the same statement |
 | Composing: suggest | Click Submit (success) | Submitted | Statement sent to pool |
-| Composing: new | Click Cancel | Voted | Returns to triad for the same statement |
+| Composing: new | Click Cancel | Voted: above threshold | Returns to triad for the same statement |
 | Composing: new | Click Submit (success) | Submitted | Statement sent to pool; participant quota decremented |
 | Submitted | Click "Next statement" | Idle | Next statement loads |
 | Any | All statements voted | All done | — |
+| All done | Click "Propose new statement" (quota > 0) | Composing: new | — |
+| Composing: new (from All done) | Click Cancel | All done | Returns to completion screen |
+| Composing: new (from All done) | Click Submit (success) | All done | Statement sent to pool; participant quota decremented |
 
 #### Open questions (not yet decided)
 

--- a/v2/functional_design.md
+++ b/v2/functional_design.md
@@ -65,6 +65,61 @@ There is no discussion on the voting screen beyond this. No visible vote counts.
 
 After voting on all available statements, the participant is shown a brief completion screen. If new statements have been added since their last visit, those appear on the next session.
 
+### Current implementation — state machine (working state, not confirmed design)
+
+> The flow below describes what the code currently does. It diverges from the original spec above in one key way: feedback indicated the always-visible textarea was too aggressive, so a post-vote three-option triad was introduced instead. The triad is a lighter invitation: vote first, then choose what (if anything) to do with the statement. The triad design and its rules were agreed on 2026-05-27.
+
+#### Post-vote triad
+
+After every vote, a three-card triad appears below the statement. The three options are:
+
+1. **Suggest different wording** — open a composer pre-filled with the statement text; submit a rephrased version into the same statement pool. No quota; available after every vote.
+2. **Move on** — proceed immediately to the next statement.
+3. **Propose a new statement** — open a blank composer to submit an entirely new statement. Subject to unlock condition and per-participant quota (see below). May move to a different location in a future iteration.
+
+#### Propose new statement — unlock and quota rules
+
+"Propose a new statement" is locked until the participant has seen enough of the existing statement pool. The unlock threshold is:
+
+> **min(10, total statements currently available)**
+
+So if there are 6 statements, unlock requires 6 votes (100%). If there are 20, unlock requires 10 votes. The threshold can be configured per conversation (`new_stmt_unlock_at`, default 10).
+
+Once unlocked, each participant may submit at most **3 new statements** per conversation (default; future: configurable per conversation as `new_stmt_max`). The remaining count is shown on the card (e.g. "2 of 3 remaining"). Once the quota is exhausted, the card is permanently disabled for that participant in that conversation.
+
+Wording suggestions ("Suggest different wording") do not count against this quota.
+
+#### States
+
+- **Idle** — statement visible, Agree/Pass/Disagree buttons shown, triad dimmed below with label "After you vote, you can…"
+- **Voted** — vote submitted, statement text frozen as snapshot with badge (e.g. "YOU VOTED AGREE"), vote buttons hidden, triad activated ("What now?") with three cards
+- **Composing: suggest** — triad hidden, suggest-wording textarea open, pre-filled with the statement text
+- **Composing: new** — triad hidden, blank new-statement textarea open
+- **Submitted** — confirmation shown ("Proposed — heading to moderation"), next button available
+- **All done** — no more statements to vote on; triad hidden, completion message shown
+
+#### Transitions
+
+| From | Trigger | To | Side effect |
+|---|---|---|---|
+| Idle | Click Agree / Pass / Disagree | Voted | Vote sent to API immediately |
+| Voted | Click "Move on" | Idle | Next statement loads |
+| Voted | Click "Suggest different wording" | Composing: suggest | — |
+| Voted | Click "Propose new statement" (unlocked, quota > 0) | Composing: new | — |
+| Voted | Click "change" in voted badge | Idle | No new API call — Polis allows revoting on next submit |
+| Composing: suggest | Click Cancel | Voted | Returns to triad for the same statement |
+| Composing: suggest | Click Submit (success) | Submitted | Statement sent to pool |
+| Composing: new | Click Cancel | Voted | Returns to triad for the same statement |
+| Composing: new | Click Submit (success) | Submitted | Statement sent to pool; participant quota decremented |
+| Submitted | Click "Next statement" | Idle | Next statement loads |
+| Any | All statements voted | All done | — |
+
+#### Open questions (not yet decided)
+
+- Should "change vote" reopen voting for the same statement, or silently allow Polis revoting on next visit?
+- Should Submitted auto-advance after a delay, or always wait for an explicit click?
+- Is "Move on" as a required click the right level of friction, or should the next statement appear automatically after a short pause unless the user engages with the triad?
+
 ---
 
 ## Results

--- a/v2/functional_design.md
+++ b/v2/functional_design.md
@@ -45,25 +45,21 @@ Statements are presented to participants one at a time in a semi-random order. T
 
 ## Voting
 
+> The original design had an always-visible textarea for proposing alternatives below the vote buttons. Feedback indicated this was too aggressive. The current implementation replaces it with a post-vote triad (see state machine below). The description here reflects the current implementation.
+
 The core loop:
 
 1. A statement appears.
-2. The participant selects **Agree**, **Disagree**, or **Pass** — this highlights the chosen option but does not submit yet.
-3. A **"Have a better way to put this?"** box is shown below the selection. The participant can type a short alternative statement, or leave it blank.
-4. The participant clicks **Submit**.
-   - If the textarea is empty: the vote is cast immediately.
-   - If the textarea has content: a brief confirm appears — *"Also share your alternate phrasing with other participants?"* — with **Yes, suggest it** and **No, just my vote** options.
+2. The participant selects **Agree**, **Disagree**, or **Pass** — the vote is submitted immediately.
+3. A three-option triad appears below: **Suggest different wording**, **Move on**, **Propose a new statement**.
+4. The participant picks one, or does nothing (Move on is the default path).
 5. The UI resets for the next statement.
 
-The propose box is always visible alongside the vote buttons — it is not a separate step that appears only after voting. This keeps it a natural part of the flow rather than a secondary action.
+There is no discussion on the voting screen. No visible vote counts. No indication of how others voted. The experience is fast and private.
 
-The proposed alternative is backend-identical to any other submitted statement: it enters the same statement pool and goes through the same moderation queue before others see it.
+After voting on all available statements, the participant is shown a brief completion screen. The "Propose a new statement" option remains available there if quota permits. If new statements are added by others after the participant finishes, those appear on the next session.
 
-Whether proposed alternatives require moderation before entering the pool is admin-configurable per conversation.
-
-There is no discussion on the voting screen beyond this. No visible vote counts. No indication of how others voted. The experience is fast and private.
-
-After voting on all available statements, the participant is shown a brief completion screen. If new statements have been added since their last visit, those appear on the next session.
+Statements submitted by a participant never appear in their own voting queue. Polis rejects self-votes (403); the app pre-emptively marks submitted statement IDs as voted in the web component so they are silently skipped.
 
 ### Current implementation — state machine (working state, not confirmed design)
 
@@ -119,6 +115,7 @@ The threshold for moving from "below" to "above" is `min(new_stmt_unlock_at, tot
 | Composing: new | Click Submit (success) | Submitted | Statement sent to pool; participant quota decremented |
 | Submitted | Click "Next statement" | Idle | Next statement loads |
 | Any | All statements voted | All done | — |
+| Any | Own submitted statement appears in queue | Idle (skipped) | Statement ID added to web component votes Set; no vote submitted |
 | All done | Click "Propose new statement" (quota > 0) | Composing: new | — |
 | Composing: new (from All done) | Click Cancel | All done | Returns to completion screen |
 | Composing: new (from All done) | Click Submit (success) | All done | Statement sent to pool; participant quota decremented |

--- a/v2/functional_design.md
+++ b/v2/functional_design.md
@@ -89,6 +89,8 @@ Once unlocked, each participant may submit at most **3 new statements** per conv
 
 Wording suggestions ("Suggest different wording") do not count against this quota.
 
+Quota slots are consumed at submission time and are never returned. If a moderator hides, rejects, or removes a proposed statement, the participant does not get that slot back. Once used, it is used.
+
 #### States
 
 - **Idle** — statement visible, Agree/Pass/Disagree buttons shown, triad dimmed below with label "After you vote, you can…"

--- a/v2/migrations/versions/a3f1c8e2d905_add_new_stmt_ids_to_participations.py
+++ b/v2/migrations/versions/a3f1c8e2d905_add_new_stmt_ids_to_participations.py
@@ -1,0 +1,31 @@
+"""add new_stmt_ids to participations
+
+Revision ID: a3f1c8e2d905
+Revises: 99f8b42af697
+Create Date: 2026-05-27 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a3f1c8e2d905'
+down_revision = '99f8b42af697'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('participations', schema=None) as batch_op:
+        batch_op.add_column(sa.Column(
+            'new_stmt_ids',
+            sa.JSON(),
+            nullable=False,
+            server_default='[]',
+        ))
+
+
+def downgrade():
+    with op.batch_alter_table('participations', schema=None) as batch_op:
+        batch_op.drop_column('new_stmt_ids')

--- a/v2/reference/particiapi-api.md
+++ b/v2/reference/particiapi-api.md
@@ -80,6 +80,19 @@ X-CSRF-Token: <token>
 
 Requires `@session_required`. Field is `text`, not `txt`.
 
+Response (201):
+```json
+{
+  "id": 42,
+  "text": "Statement text here",
+  "is_meta": false,
+  "is_seed": false,
+  "last_modified": "2026-05-27T12:00:00"
+}
+```
+
+`id` is the Polis `tid` — the statement ID used in vote routes.
+
 ---
 
 ## Participant

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -835,6 +835,27 @@ pa-statement:state(no-statement) ~ .vote-choice-row { display: none; }
 .propose-submit-btn:hover { background: var(--accent); }
 
 /* State C: submitted — spot/amber (not agree green) */
+/* ── All done message ── */
+.all-done-msg {
+  padding: 28px 0 12px;
+  text-align: center;
+}
+.all-done-label {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ink);
+  margin: 0 0 4px;
+}
+.all-done-sub {
+  font-size: 13px;
+  color: var(--muted);
+  margin: 0;
+}
+
+/* In all-done state, show only the Propose New card */
+.v2-triad--alldone .v2-option-card { display: none; }
+.v2-triad--alldone #triad-newstmt  { display: flex; }
+
 .propose-submitted {
   display: flex;
   align-items: center;

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -553,6 +553,13 @@ pa-conversation:state(loading) { opacity: 0.5; }
   margin-bottom: 0;
 }
 
+/* In voted state, hide the live statement and vote buttons via parent class.
+   Using CSS (not just hidden attr) because pa-statement may re-show itself
+   when it receives the next statement from the web component. */
+.statement-card--voted pa-statement   { display: none !important; }
+.statement-card--voted .vote-choice-row { display: none !important; }
+.statement-card--voted .stmt-meta-right { visibility: hidden; }
+
 .propose-stmt-display {
   margin: 0;
   font-size: 15px;

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -686,8 +686,7 @@ pa-statement { display: block; }
 .vote-dot--pass     { background: var(--pass); }
 .vote-dot--disagree { background: var(--disagree); }
 
-pa-statement:state(no-statement) ~ .vote-choice-row,
-pa-statement:state(no-statement) ~ .propose-affordance { display: none; }
+pa-statement:state(no-statement) ~ .vote-choice-row { display: none; }
 
 /* ── Propose affordance (3 states) ── */
 
@@ -868,6 +867,208 @@ pa-statement:state(no-statement) ~ .propose-affordance { display: none; }
   cursor: pointer;
 }
 .propose-next-btn:hover { background: var(--accent); }
+
+/* ── Voted statement snapshot ── */
+
+.voted-stmt-text {
+  font-size: 28px;
+  font-weight: 500;
+  line-height: 1.28;
+  letter-spacing: -0.018em;
+  color: var(--muted);
+  margin: 0;
+  text-wrap: pretty;
+}
+
+/* ── V2 Option Triad ── */
+
+.v2-triad {
+  margin-top: 22px;
+}
+
+.v2-triad-label {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--muted);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.v2-triad-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+
+.v2-option-card {
+  text-align: left;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: 10px;
+  padding: 14px 16px;
+  cursor: default;
+  opacity: 0.72;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 120px;
+  font-family: var(--sans);
+  transition: border-color 0.12s, box-shadow 0.12s, opacity 0.12s;
+}
+
+/* Active state — set when triad has v2-triad--active */
+.v2-triad--active .v2-option-card:not([disabled]) {
+  opacity: 1;
+  cursor: pointer;
+}
+.v2-triad--active .v2-option-card:not([disabled]):hover {
+  border-color: color-mix(in srgb, var(--ink) 55%, transparent);
+}
+
+.v2-triad--active .v2-option-card--primary:not([disabled]) {
+  background: var(--surface2);
+  border-color: color-mix(in srgb, var(--ink) 25%, transparent);
+}
+.v2-triad--active .v2-option-card--primary:not([disabled]):hover {
+  border-color: color-mix(in srgb, var(--ink) 55%, transparent);
+}
+
+.v2-option-card--locked {
+  background: var(--surface2);
+  border-color: var(--hairline-soft);
+  cursor: not-allowed !important;
+  opacity: 1;
+}
+
+.v2-option-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.v2-option-glyph {
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  background: var(--surface2);
+  color: var(--ink);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.v2-option-card--locked .v2-option-glyph { color: #9ca3af; }
+
+.v2-lock-icon { flex-shrink: 0; }
+
+.v2-option-bottom {
+  margin-top: auto;
+}
+
+.v2-option-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+}
+
+.v2-option-card--locked .v2-option-title { color: var(--muted); }
+
+.v2-option-sub {
+  font-size: 12.5px;
+  color: var(--muted);
+  margin-top: 3px;
+  line-height: 1.4;
+}
+
+.v2-option-card--locked .v2-option-sub { color: #9ca3af; }
+
+.v2-option-action {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink);
+  letter-spacing: 0.05em;
+  margin-top: 8px;
+  font-weight: 600;
+}
+
+/* ── V2 Inline composer ── */
+
+.v2-composer {
+  margin-top: 14px;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: 12px;
+  padding: 20px 24px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.02);
+}
+
+.v2-composer-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.v2-composer-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--ink);
+  letter-spacing: -0.01em;
+}
+
+.v2-composer-helper {
+  font-size: 13px;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+.v2-composer-textarea {
+  width: 100%;
+  min-height: 84px;
+  padding: 12px 14px;
+  border: 1px solid var(--hairline);
+  border-radius: 8px;
+  outline: none;
+  resize: vertical;
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--ink);
+  letter-spacing: -0.008em;
+  background: var(--surface);
+  box-sizing: border-box;
+}
+
+.v2-composer-textarea:focus { border-color: var(--muted); }
+
+.v2-composer-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 14px;
+}
+
+.v2-composer-hint {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.v2-composer-btns {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+@media (max-width: 560px) {
+  .v2-triad-grid { grid-template-columns: 1fr; }
+  .v2-composer-footer { flex-direction: column; align-items: flex-start; gap: 10px; }
+  .v2-composer-btns { width: 100%; justify-content: flex-end; }
+}
 
 /* ── Hidden pa-vote-button/pa-submit-button for API submission ── */
 

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -1,5 +1,8 @@
 /* wiki-polis v2 — Cluster design */
 
+/* Enforce [hidden] over any display rules — must come before all component CSS */
+[hidden] { display: none !important; }
+
 :root {
   /* Cluster palette */
   --ink:           #0c0c0e;
@@ -8,6 +11,7 @@
   --bg:            #fafaf9;
   --surface:       #ffffff;
   --surface2:      #f4f4f3;
+  --surface3:      #eeece6;
   --hairline:      #e5e5e6;
   --hairline-soft: #efefef;
   --agree:         #1f8a5b;
@@ -917,29 +921,37 @@ pa-statement:state(no-statement) ~ .vote-choice-row { display: none; }
   transition: border-color 0.12s, box-shadow 0.12s, opacity 0.12s;
 }
 
+/* Hide action labels in pre-vote dimmed state */
+.v2-triad:not(.v2-triad--active) .v2-option-action { visibility: hidden; }
+
 /* Active state — set when triad has v2-triad--active */
-.v2-triad--active .v2-option-card:not([disabled]) {
+.v2-triad--active .v2-option-card:not([aria-disabled="true"]) {
   opacity: 1;
   cursor: pointer;
 }
-.v2-triad--active .v2-option-card:not([disabled]):hover {
+.v2-triad--active .v2-option-card:not([aria-disabled="true"]):hover {
+  border-color: #888; /* fallback for Safari < 15.4 */
   border-color: color-mix(in srgb, var(--ink) 55%, transparent);
 }
 
-.v2-triad--active .v2-option-card--primary:not([disabled]) {
-  background: var(--surface2);
+.v2-triad--active .v2-option-card--primary:not([aria-disabled="true"]) {
+  background: var(--surface3);
+  border-color: #c4c2bb; /* fallback */
   border-color: color-mix(in srgb, var(--ink) 25%, transparent);
 }
-.v2-triad--active .v2-option-card--primary:not([disabled]):hover {
+.v2-triad--active .v2-option-card--primary:not([aria-disabled="true"]):hover {
+  border-color: #888; /* fallback */
   border-color: color-mix(in srgb, var(--ink) 55%, transparent);
 }
 
-.v2-option-card--locked {
+.v2-option-card--locked,
+.v2-option-card[aria-disabled="true"] {
   background: var(--surface2);
   border-color: var(--hairline-soft);
-  cursor: not-allowed !important;
   opacity: 1;
 }
+.v2-option-card--locked { cursor: not-allowed; }
+.v2-option-card[aria-disabled="true"]:not(.v2-option-card--locked) { cursor: default; }
 
 .v2-option-top {
   display: flex;

--- a/v2/templates/accept.html
+++ b/v2/templates/accept.html
@@ -32,6 +32,10 @@
   </div>
   {% endif %}
 
+  <p style="font-size:14px;color:var(--muted);margin-top:18px;margin-bottom:0">
+    Quick setup before you start — pick a pseudonym and review how your data is handled.
+  </p>
+
   <form method="post"
         action="{{ url_for('accept_post', slug=conversation.slug) }}"
         id="accept-form"
@@ -45,7 +49,7 @@
          aria-labelledby="pseudonym-title"
          aria-describedby="pseudonym-help pseudonym-status">
       <div class="pseudonym-card-header">
-        <div class="pseudonym-card-title" id="pseudonym-title">Pick a name for yourself</div>
+        <div class="pseudonym-card-title" id="pseudonym-title">Pick a name for yourself for this consultation</div>
         <button type="button"
                 class="reroll-btn"
                 id="reroll-btn"

--- a/v2/templates/accept.html
+++ b/v2/templates/accept.html
@@ -45,7 +45,7 @@
          aria-labelledby="pseudonym-title"
          aria-describedby="pseudonym-help pseudonym-status">
       <div class="pseudonym-card-header">
-        <div class="pseudonym-card-title" id="pseudonym-title">Pick a name for this consultation</div>
+        <div class="pseudonym-card-title" id="pseudonym-title">Pick a name for yourself</div>
         <button type="button"
                 class="reroll-btn"
                 id="reroll-btn"

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -265,6 +265,12 @@
           <button type="button" id="propose-next" class="propose-next-btn">Next statement →</button>
         </div>
 
+        {# ── All done message ── #}
+        <div id="all-done-msg" class="all-done-msg" hidden>
+          <p class="all-done-label">You've voted on all available statements.</p>
+          <p class="all-done-sub">New statements may appear when others propose them.</p>
+        </div>
+
         {# ── Hidden pa-* elements for API submission ── #}
         <span class="pvb-hidden">
           <pa-vote-button id="pvb-agree"    type="agree">Agree</pa-vote-button>
@@ -806,7 +812,10 @@
 
   var LABELS = { agree: 'AGREE', neutral: 'PASS', disagree: 'DISAGREE' };
   var NEW_STMT_UNLOCK_AT = {{ new_stmt_unlock_at | default(10) }};
+  var NEW_STMT_MAX  = {{ new_stmt_max | default(3) }};
+  var NEW_STMT_USED = {{ new_stmt_ids | length }};
   var originalStmtText = '';
+  var newstmtOrigin = 'voted'; // 'voted' | 'alldone' — tracks where composer was opened from
 
   // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -814,6 +823,10 @@
 
   function getVotedCount() {
     try { return conv.client.participant.votes.size; } catch (e) { return 0; }
+  }
+
+  function getTotalStatements() {
+    try { return conv.client.statements.size; } catch (e) { return NEW_STMT_UNLOCK_AT; }
   }
 
   function isAllDone() {
@@ -829,30 +842,40 @@
   }
 
   function updateNewstmtCard() {
-    var unlocked = getVotedCount() >= NEW_STMT_UNLOCK_AT || isAllDone();
-    var remaining = Math.max(0, NEW_STMT_UNLOCK_AT - getVotedCount());
-    triadNewstmt.classList.toggle('v2-option-card--locked', !unlocked);
-    if (unlocked) {
-      triadNewstmtSub.textContent = 'A different angle entirely';
-      triadNewstmtAction.hidden   = false;
-      triadNewstmt.querySelector('.v2-lock-icon').style.display = 'none';
-    } else {
+    var effectiveUnlock = Math.min(NEW_STMT_UNLOCK_AT, getTotalStatements() || NEW_STMT_UNLOCK_AT);
+    var unlocked  = getVotedCount() >= effectiveUnlock || isAllDone();
+    var quotaLeft = Math.max(0, NEW_STMT_MAX - NEW_STMT_USED);
+    var active    = unlocked && quotaLeft > 0;
+
+    triadNewstmt.classList.toggle('v2-option-card--locked', !active);
+    triadNewstmt.querySelector('.v2-lock-icon').style.display = active ? 'none' : '';
+
+    if (!unlocked) {
+      var remaining = Math.max(0, effectiveUnlock - getVotedCount());
       triadNewstmtSub.textContent = 'Unlocks after ' + remaining + ' more vote' + (remaining === 1 ? '' : 's');
-      triadNewstmtAction.hidden   = true;
-      triadNewstmt.querySelector('.v2-lock-icon').style.display = '';
+      triadNewstmtAction.hidden = true;
+    } else if (quotaLeft === 0) {
+      triadNewstmtSub.textContent = 'Limit reached';
+      triadNewstmtAction.hidden = true;
+    } else {
+      triadNewstmtSub.textContent = quotaLeft + ' of ' + NEW_STMT_MAX + ' remaining';
+      triadNewstmtAction.hidden = false;
     }
-    // Sync aria-disabled for the newstmt card when triad is active
-    if (triad.classList.contains('v2-triad--active')) {
-      setAriaDisabled(triadNewstmt, !unlocked);
+
+    if (triad.classList.contains('v2-triad--active') || triad.classList.contains('v2-triad--alldone')) {
+      setAriaDisabled(triadNewstmt, !active);
     }
   }
 
   // ── Mode: idle ────────────────────────────────────────────────────────────────
   function enterIdle(focusTarget) {
     stmtCard.classList.remove('statement-card--voted');
+    stmtCard.hidden        = false;
     votedStmtText.hidden   = true;
     votedBadge.hidden      = true;
     originalStmtText       = '';
+    if (allDoneMsg) allDoneMsg.hidden = true;
+    triad.classList.remove('v2-triad--alldone');
 
     triad.hidden = false;
     triadLabel.textContent = 'After you vote, you can…';
@@ -968,6 +991,7 @@
 
   // ── Triad: propose new statement ─────────────────────────────────────────────
   triadGuard(triadNewstmt, function () {
+    newstmtOrigin          = triad.classList.contains('v2-triad--alldone') ? 'alldone' : 'voted';
     triad.hidden           = true;
     composerNewstmt.hidden = false;
     newstmtInput.value     = '';
@@ -1003,13 +1027,45 @@
 
   document.getElementById('newstmt-cancel').addEventListener('click', function () {
     composerNewstmt.hidden = true;
-    triad.hidden           = false;
-    triadNewstmt.focus();
+    if (newstmtOrigin === 'alldone') {
+      enterAllDone();
+    } else {
+      triad.hidden = false;
+      triadNewstmt.focus();
+    }
   });
 
   newstmtSubmit.addEventListener('click', function () {
-    if (!newstmtInput.value.trim()) return;
-    submitComposer(pvbSubmitNewstmt, newstmtSubmit, composerNewstmt);
+    var text = newstmtInput.value.trim();
+    if (!text) return;
+    newstmtSubmit.disabled = true;
+    fetch('{{ url_for("conversation_statement_new", slug=conversation.slug) }}', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'fetch' },
+      body: JSON.stringify({ text: text }),
+    }).then(function (resp) {
+      if (resp.ok) {
+        composerNewstmt.hidden  = true;
+        proposeSubmitted.hidden = false;
+        NEW_STMT_USED++;
+        updateNewstmtCard();
+        if (newstmtOrigin === 'alldone') {
+          setTimeout(function () { proposeSubmitted.hidden = true; }, 1200);
+        } else {
+          setTimeout(enterIdle, 1200);
+        }
+      } else {
+        newstmtSubmit.disabled = false;
+        convError.hidden = false;
+        convErrorMsg.textContent = resp.status === 403
+          ? 'You have reached the proposal limit for this consultation.'
+          : 'Could not submit statement. Please try again.';
+      }
+    }).catch(function () {
+      newstmtSubmit.disabled = false;
+      convError.hidden = false;
+      convErrorMsg.textContent = 'Network error. Please try again.';
+    });
   });
 
   // ── Submitted: manual next ────────────────────────────────────────────────────
@@ -1040,13 +1096,34 @@
     updateNewstmtCard();
   }
 
+  var allDoneMsg = document.getElementById('all-done-msg');
+
+  function enterAllDone() {
+    stmtCard.classList.remove('statement-card--voted');
+    stmtCard.hidden     = true;
+    allDoneMsg.hidden   = false;
+
+    composerSuggest.hidden  = true;
+    composerNewstmt.hidden  = true;
+    proposeSubmitted.hidden = true;
+
+    triad.hidden = false;
+    triad.classList.remove('v2-triad--active');
+    triad.classList.add('v2-triad--alldone');
+    triadLabel.textContent = 'Want to add something new?';
+    setAriaDisabled(triadSuggest, true);
+    setAriaDisabled(triadNext,    true);
+    updateNewstmtCard();
+  }
+
   function handleNoStatement() {
-    // All statements voted — hide the triad dimmed preview; it makes no sense
-    // to show "After you vote…" when there is nothing left to vote on.
-    if (isAllDone() && !triad.classList.contains('v2-triad--active')) {
-      triad.hidden = true;
+    if (isAllDone()) {
+      if (!triad.classList.contains('v2-triad--active')) {
+        enterAllDone();
+      }
+    } else {
+      updateNewstmtCard();
     }
-    updateNewstmtCard(); // may unlock new-statement card
   }
 
   conv.addEventListener('particiappstatementschange', function (e) { updateProgress(e.statements); });

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -113,19 +113,29 @@
           <span class="vote-progress-queued" id="vote-progress-queued"></span>
         </div>
 
-        {# ── IDLE MODE: statement card with vote buttons + dashed propose inside ── #}
-        <div class="statement-card" id="state-idle">
+        {# ── Statement card — always visible ── #}
+        <div class="statement-card" id="statement-card">
           <div class="statement-card-header">
             <span class="stmt-meta-left">
               <span class="stmt-dot"></span>
               <span class="stmt-meta-label">STATEMENT</span>
             </span>
-            <span class="stmt-meta-right">private vote</span>
+            <span class="stmt-meta-right" id="stmt-right-label">private vote</span>
+            <span id="voted-badge" class="voted-badge" data-type="agree" hidden>
+              <span class="voted-badge-check">
+                <svg width="7" height="7" viewBox="0 0 12 12" fill="none">
+                  <path d="M2 6.5L4.8 9L10 3.5" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </span>
+              YOU VOTED <span id="voted-label">AGREE</span>
+              <button type="button" id="change-vote-btn" class="change-vote-btn">change</button>
+            </span>
           </div>
 
           <pa-statement>
             <p class="muted">No statements to vote on right now. Check back later for new ones.</p>
           </pa-statement>
+          <p id="voted-stmt-text" class="voted-stmt-text" hidden></p>
 
           <div class="vote-choice-row" id="vote-choice-row">
             <button type="button" class="vote-choice" data-type="agree">
@@ -138,63 +148,117 @@
               <span class="vote-dot vote-dot--disagree"></span>Disagree
             </button>
           </div>
-
-          {# Dashed propose affordance — inside the card, always visible in idle mode #}
-          <button type="button" id="propose-idle-btn" class="propose-affordance">
-            <span class="propose-glyph">+</span>
-            <span class="propose-label">Have a better way to put this?<span class="propose-sub"> propose your own statement</span></span>
-            <span class="propose-meta">OPTIONAL</span>
-          </button>
         </div>
 
-        {# ── PROPOSE MODE: slim voted-badge card + compose form below ── #}
-        <div id="state-propose" hidden>
-          <div class="statement-card statement-card--voted">
-            <div class="statement-card-header">
-              <span class="stmt-meta-left">
-                <span class="stmt-dot"></span>
-                <span class="stmt-meta-label">STATEMENT</span>
-              </span>
-              <span id="voted-badge" class="voted-badge" data-type="agree">
-                <span class="voted-badge-check">
-                  <svg width="7" height="7" viewBox="0 0 12 12" fill="none">
-                    <path d="M2 6.5L4.8 9L10 3.5" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        {# ── V2 Option Triad — always rendered, dimmed pre-vote, active post-vote ── #}
+        <div class="v2-triad" id="v2-triad">
+          <div class="v2-triad-label" id="v2-triad-label">After you vote, you can&hellip;</div>
+          <div class="v2-triad-grid">
+
+            <button type="button" class="v2-option-card" id="triad-suggest" disabled>
+              <div class="v2-option-top">
+                <span class="v2-option-glyph">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M3 17l6-6 4 4 8-8"/>
+                    <path d="M14 7h7v7"/>
                   </svg>
                 </span>
-                YOU VOTED <span id="voted-label">AGREE</span>
-                <button type="button" id="change-vote-btn" class="change-vote-btn">change</button>
-              </span>
-            </div>
-            <p id="propose-stmt-display" class="propose-stmt-display"></p>
-          </div>
-
-          {# Compose form — below the card, starts in composing state #}
-          <div id="propose-composer" class="propose-composer propose-below">
-            <div class="propose-composer-header">
-              <span class="propose-glyph filled">+</span>
-              <span class="propose-composer-label">Your alternative phrasing · one sentence, one claim</span>
-              <span class="propose-charcount"><span id="propose-len">0</span> / 280</span>
-            </div>
-            <textarea id="propose-input" class="propose-textarea" maxlength="280"
-                      placeholder="Re-confirmation every five years would balance accountability against admin burnout…"></textarea>
-            <div class="propose-actions">
-              <span class="propose-actions-hint">Goes to moderation, then into the same pool</span>
-              <div class="propose-actions-btns">
-                <button type="button" id="propose-skip" class="btn-small btn-muted">The current wording is good as it is</button>
-                <button type="button" id="propose-submit-btn" class="propose-submit-btn" disabled>Submit my version as alternative</button>
               </div>
+              <div class="v2-option-bottom">
+                <div class="v2-option-title">Suggest different wording</div>
+                <div class="v2-option-sub">Same idea, clearer phrasing</div>
+                <div class="v2-option-action">Write yours →</div>
+              </div>
+            </button>
+
+            <button type="button" class="v2-option-card" id="triad-next" disabled>
+              <div class="v2-option-top">
+                <span class="v2-option-glyph">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M5 12h14"/>
+                    <path d="M13 5l7 7-7 7"/>
+                  </svg>
+                </span>
+              </div>
+              <div class="v2-option-bottom">
+                <div class="v2-option-title">Move on</div>
+                <div class="v2-option-sub">Next statement, nothing to add</div>
+                <div class="v2-option-action">Next →</div>
+              </div>
+            </button>
+
+            <button type="button" class="v2-option-card v2-option-card--locked" id="triad-newstmt" disabled>
+              <div class="v2-option-top">
+                <span class="v2-option-glyph">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M12 5v14"/>
+                    <path d="M5 12h14"/>
+                  </svg>
+                </span>
+                <svg class="v2-lock-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#9ca3af" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <rect x="3" y="11" width="18" height="11" rx="2"/>
+                  <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+                </svg>
+              </div>
+              <div class="v2-option-bottom">
+                <div class="v2-option-title">Propose a new statement</div>
+                <div class="v2-option-sub" id="triad-newstmt-sub">Unlocks after {{ new_stmt_unlock_at | default(10) }} votes</div>
+                <div class="v2-option-action" id="triad-newstmt-action" hidden>Compose →</div>
+              </div>
+            </button>
+
+          </div>
+        </div>
+
+        {# ── Inline composer: suggest different wording ── #}
+        <div id="composer-suggest" class="v2-composer" hidden>
+          <div class="v2-composer-header">
+            <div>
+              <div class="v2-composer-title">Suggest different wording</div>
+              <div class="v2-composer-helper">Stays close to the same idea — just a clearer or fairer phrasing.</div>
+            </div>
+            <span class="propose-charcount"><span id="suggest-len">0</span> / 280</span>
+          </div>
+          <textarea id="suggest-input" class="v2-composer-textarea" maxlength="280"
+                    placeholder="Re-confirmation every five years would balance accountability against admin burnout…"></textarea>
+          <div class="v2-composer-footer">
+            <span class="v2-composer-hint">Goes into the pool with the original</span>
+            <div class="v2-composer-btns">
+              <button type="button" id="suggest-cancel" class="btn-small btn-muted">Cancel</button>
+              <button type="button" id="suggest-submit" class="propose-submit-btn" disabled>Submit &amp; next</button>
             </div>
           </div>
+        </div>
 
-          <div id="propose-submitted" class="propose-submitted" hidden>
-            <span class="check-pill">
-              <svg width="9" height="9" viewBox="0 0 12 12" fill="none">
-                <path d="M2 6.5L4.8 9L10 3.5" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-              </svg>
-            </span>
-            <span class="propose-submitted-label">PROPOSED — heading to moderation</span>
-            <button type="button" id="propose-next" class="propose-next-btn">Next statement →</button>
+        {# ── Inline composer: propose a new statement ── #}
+        <div id="composer-newstmt" class="v2-composer" hidden>
+          <div class="v2-composer-header">
+            <div>
+              <div class="v2-composer-title">Propose a new statement</div>
+              <div class="v2-composer-helper">A different angle entirely. One claim, one sentence. Goes to moderation, then into the same pool.</div>
+            </div>
+            <span class="propose-charcount"><span id="newstmt-len">0</span> / 280</span>
           </div>
+          <textarea id="newstmt-input" class="v2-composer-textarea" maxlength="280"
+                    placeholder="A new angle on the topic…"></textarea>
+          <div class="v2-composer-footer">
+            <span class="v2-composer-hint">A separate statement — others will vote on it too</span>
+            <div class="v2-composer-btns">
+              <button type="button" id="newstmt-cancel" class="btn-small btn-muted">Cancel</button>
+              <button type="button" id="newstmt-submit" class="propose-submit-btn" disabled>Submit &amp; next</button>
+            </div>
+          </div>
+        </div>
+
+        {# ── Submitted confirmation ── #}
+        <div id="propose-submitted" class="propose-submitted" hidden>
+          <span class="check-pill">
+            <svg width="9" height="9" viewBox="0 0 12 12" fill="none">
+              <path d="M2 6.5L4.8 9L10 3.5" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </span>
+          <span class="propose-submitted-label">PROPOSED — heading to moderation</span>
+          <button type="button" id="propose-next" class="propose-next-btn">Next statement →</button>
         </div>
 
         {# ── Hidden pa-* elements for API submission ── #}
@@ -202,7 +266,8 @@
           <pa-vote-button id="pvb-agree"    type="agree">Agree</pa-vote-button>
           <pa-vote-button id="pvb-neutral"  type="neutral">Pass</pa-vote-button>
           <pa-vote-button id="pvb-disagree" type="disagree">Disagree</pa-vote-button>
-          <pa-submit-button id="pvb-submit-stmt" submitfor="propose-input">suggest</pa-submit-button>
+          <pa-submit-button id="pvb-submit-suggest" submitfor="suggest-input">suggest</pa-submit-button>
+          <pa-submit-button id="pvb-submit-newstmt" submitfor="newstmt-input">suggest</pa-submit-button>
         </span>
 
         <div id="conv-error" hidden>
@@ -698,174 +763,278 @@
 {% if conversation.phase_submission and conversation.active and not conversation.paused %}
 <script nonce="{{ csp_nonce }}">
 (function () {
-  var conv             = document.querySelector('pa-conversation');
-  var stateIdle        = document.getElementById('state-idle');
-  var statePropose     = document.getElementById('state-propose');
-  var choiceRow        = document.getElementById('vote-choice-row');
-  var votedBadge       = document.getElementById('voted-badge');
-  var votedLabel       = document.getElementById('voted-label');
-  var proposeComposer  = document.getElementById('propose-composer');
+  var conv            = document.querySelector('pa-conversation');
+  var paStmt          = conv.querySelector('pa-statement');
+  var choiceRow       = document.getElementById('vote-choice-row');
+  var stmtRightLabel  = document.getElementById('stmt-right-label');
+  var votedBadge      = document.getElementById('voted-badge');
+  var votedLabel      = document.getElementById('voted-label');
+  var votedStmtText   = document.getElementById('voted-stmt-text');
+  var triad           = document.getElementById('v2-triad');
+  var triadLabel      = document.getElementById('v2-triad-label');
+  var triadSuggest    = document.getElementById('triad-suggest');
+  var triadNext       = document.getElementById('triad-next');
+  var triadNewstmt    = document.getElementById('triad-newstmt');
+  var triadNewstmtSub = document.getElementById('triad-newstmt-sub');
+  var triadNewstmtAction = document.getElementById('triad-newstmt-action');
+  var composerSuggest = document.getElementById('composer-suggest');
+  var composerNewstmt = document.getElementById('composer-newstmt');
+  var suggestInput    = document.getElementById('suggest-input');
+  var suggestLen      = document.getElementById('suggest-len');
+  var suggestSubmit   = document.getElementById('suggest-submit');
+  var newstmtInput    = document.getElementById('newstmt-input');
+  var newstmtLen      = document.getElementById('newstmt-len');
+  var newstmtSubmit   = document.getElementById('newstmt-submit');
   var proposeSubmitted = document.getElementById('propose-submitted');
-  var proposeInput     = document.getElementById('propose-input');
-  var proposeLen       = document.getElementById('propose-len');
-  var proposeSubmitBtn = document.getElementById('propose-submit-btn');
   var pvb = {
     agree:    document.getElementById('pvb-agree'),
     neutral:  document.getElementById('pvb-neutral'),
     disagree: document.getElementById('pvb-disagree'),
   };
-  var pvbSubmitStmt = document.getElementById('pvb-submit-stmt');
-  var convError     = document.getElementById('conv-error');
-  var convErrorMsg  = document.getElementById('conv-error-msg');
-  var progressRow   = document.getElementById('vote-progress-row');
-  var votesDone     = document.getElementById('votes-done');
-  var votesTotal    = document.getElementById('votes-total');
-  var progressBar   = document.getElementById('vote-progress-bar');
-  var stmtMetaLabels = document.querySelectorAll('.stmt-meta-label');
+  var pvbSubmitSuggest = document.getElementById('pvb-submit-suggest');
+  var pvbSubmitNewstmt = document.getElementById('pvb-submit-newstmt');
+  var convError        = document.getElementById('conv-error');
+  var convErrorMsg     = document.getElementById('conv-error-msg');
+  var progressRow      = document.getElementById('vote-progress-row');
+  var votesDone        = document.getElementById('votes-done');
+  var votesTotal       = document.getElementById('votes-total');
+  var progressBar      = document.getElementById('vote-progress-bar');
 
   var LABELS = { agree: 'AGREE', neutral: 'PASS', disagree: 'DISAGREE' };
+  var NEW_STMT_UNLOCK_AT = {{ new_stmt_unlock_at | default(10) }};
   var originalStmtText = '';
-  var proposeStmtDisplay = document.getElementById('propose-stmt-display');
 
-  // ── Mode: idle ───────────────────────────────────────────────────────────────
-  function enterIdle() {
-    stateIdle.hidden    = false;
-    statePropose.hidden = true;
-    proposeInput.value  = '';
-    proposeLen.textContent = '0';
-    proposeSubmitBtn.disabled = true;
-    proposeComposer.hidden   = false;
-    proposeSubmitted.hidden  = true;
-    originalStmtText = '';
+  // ── Helpers ───────────────────────────────────────────────────────────────────
+
+  function getVotedCount() {
+    try { return conv.client.participant.votes.size; } catch (e) { return 0; }
   }
 
-  // ── Mode: propose (after vote or idle-propose click) ─────────────────────────
-  // stmtText must be captured BEFORE triggering the vote, because pvb.click()
-  // causes the web component to advance pa-statement.text synchronously.
-  function enterPropose(voteType, stmtText) {
-    stateIdle.hidden    = true;
-    statePropose.hidden = false;
-    if (voteType) {
-      votedLabel.textContent   = LABELS[voteType];
-      votedBadge.dataset.type  = voteType;
-      votedBadge.hidden        = false;
+  function updateNewstmtCard() {
+    var n = getVotedCount();
+    var remaining = Math.max(0, NEW_STMT_UNLOCK_AT - n);
+    var unlocked  = n >= NEW_STMT_UNLOCK_AT;
+    triadNewstmt.classList.toggle('v2-option-card--locked', !unlocked);
+    if (unlocked) {
+      triadNewstmtSub.textContent = 'A different angle entirely';
+      triadNewstmtAction.hidden   = false;
+      triadNewstmt.querySelector('.v2-lock-icon').style.display = 'none';
     } else {
-      votedBadge.hidden = true;
+      triadNewstmtSub.textContent = 'Unlocks after ' + remaining + ' more vote' + (remaining === 1 ? '' : 's');
+      triadNewstmtAction.hidden   = true;
+      triadNewstmt.querySelector('.v2-lock-icon').style.display = '';
     }
-    proposeComposer.hidden  = false;
-    proposeSubmitted.hidden = true;
-    originalStmtText = (stmtText || '').trim();
-    proposeStmtDisplay.textContent = originalStmtText;
-    proposeInput.value = originalStmtText;
-    proposeLen.textContent = proposeInput.value.length;
-    proposeSubmitBtn.disabled = true;
-    proposeInput.focus();
-    proposeInput.select();
   }
 
-  // ── Vote buttons — single click = immediate vote ─────────────────────────────
+  // ── Mode: idle ────────────────────────────────────────────────────────────────
+  function enterIdle() {
+    // Restore statement card to pre-vote state
+    paStmt.hidden           = false;
+    votedStmtText.hidden    = true;
+    choiceRow.hidden        = false;
+    stmtRightLabel.hidden   = false;
+    votedBadge.hidden       = true;
+    originalStmtText        = '';
+
+    // Triad — dimmed preview
+    triad.hidden    = false;
+    triadLabel.textContent = 'After you vote, you can…';
+    triad.classList.remove('v2-triad--active');
+    triadSuggest.disabled = true;
+    triadNext.disabled    = true;
+    triadNext.classList.remove('v2-option-card--primary');
+    triadNewstmt.disabled = true;
+
+    // Composers + submitted
+    composerSuggest.hidden  = true;
+    composerNewstmt.hidden  = true;
+    proposeSubmitted.hidden = true;
+    suggestInput.value      = '';
+    suggestLen.textContent  = '0';
+    suggestSubmit.disabled  = true;
+    newstmtInput.value      = '';
+    newstmtLen.textContent  = '0';
+    newstmtSubmit.disabled  = true;
+  }
+
+  // ── Mode: voted ───────────────────────────────────────────────────────────────
+  // stmtText must be captured BEFORE pvb.click() — the web component advances
+  // pa-statement.text synchronously on vote submission.
+  function enterVoted(voteType, stmtText) {
+    originalStmtText = (stmtText || '').trim();
+
+    // Show voted snapshot of statement
+    paStmt.hidden           = true;
+    votedStmtText.textContent = originalStmtText;
+    votedStmtText.hidden    = false;
+    choiceRow.hidden        = true;
+    stmtRightLabel.hidden   = true;
+    votedBadge.hidden       = false;
+    votedLabel.textContent  = LABELS[voteType];
+    votedBadge.dataset.type = voteType;
+
+    // Triad — active
+    triad.hidden    = false;
+    triadLabel.textContent = 'What now?';
+    triad.classList.add('v2-triad--active');
+    triadSuggest.disabled = false;
+    triadNext.disabled    = false;
+    triadNext.classList.add('v2-option-card--primary');
+    updateNewstmtCard();
+    triadNewstmt.disabled = getVotedCount() < NEW_STMT_UNLOCK_AT;
+
+    // Pre-fill suggest textarea
+    suggestInput.value     = originalStmtText;
+    suggestLen.textContent = suggestInput.value.length;
+    suggestSubmit.disabled = true;
+
+    // Composers hidden
+    composerSuggest.hidden  = true;
+    composerNewstmt.hidden  = true;
+    proposeSubmitted.hidden = true;
+  }
+
+  // ── Vote buttons ──────────────────────────────────────────────────────────────
   choiceRow.addEventListener('click', function (e) {
     var btn = e.target.closest('.vote-choice');
     if (!btn) return;
-    var type = btn.dataset.type;
-    // Capture text before clicking — pvb.click() advances pa-statement synchronously
-    var paStmt = conv.querySelector('pa-statement');
-    var stmtText = paStmt ? (paStmt.text || '').trim() : '';
+    var type    = btn.dataset.type;
+    var stmtTxt = paStmt ? (paStmt.text || '').trim() : '';
     pvb[type].click();
-    enterPropose(type, stmtText);
+    enterVoted(type, stmtTxt);
   });
 
-  // ── Idle propose affordance click → compose mode (no vote yet) ───────────────
-  document.getElementById('propose-idle-btn').addEventListener('click', function () {
-    var paStmt = conv.querySelector('pa-statement');
-    var stmtText = paStmt ? (paStmt.text || '').trim() : '';
-    enterPropose(null, stmtText);
-  });
-
-  // ── Change vote → back to idle ───────────────────────────────────────────────
+  // ── Change vote ───────────────────────────────────────────────────────────────
   document.getElementById('change-vote-btn').addEventListener('click', enterIdle);
 
-  // ── Propose: char count + enable submit ──────────────────────────────────────
-  proposeInput.addEventListener('input', function () {
-    proposeLen.textContent = proposeInput.value.length;
-    var val = proposeInput.value.trim();
-    proposeSubmitBtn.disabled = val.length === 0 || val === originalStmtText.trim();
+  // ── Triad: suggest different wording ─────────────────────────────────────────
+  triadSuggest.addEventListener('click', function () {
+    if (this.disabled) return;
+    triad.hidden           = true;
+    composerSuggest.hidden = false;
+    suggestInput.focus();
+    suggestInput.select();
   });
 
-  // ── Propose: nothing to propose → idle ───────────────────────────────────────
-  document.getElementById('propose-skip').addEventListener('click', enterIdle);
+  // ── Triad: move on ────────────────────────────────────────────────────────────
+  triadNext.addEventListener('click', function () {
+    if (this.disabled) return;
+    enterIdle();
+  });
 
-  // ── Propose: submit & next ────────────────────────────────────────────────────
-  proposeSubmitBtn.addEventListener('click', function () {
-    var val = proposeInput.value.trim();
-    if (val.length === 0 || val === originalStmtText.trim()) return;
+  // ── Triad: propose new statement ─────────────────────────────────────────────
+  triadNewstmt.addEventListener('click', function () {
+    if (this.disabled) return;
+    triad.hidden            = true;
+    composerNewstmt.hidden  = false;
+    newstmtInput.value      = '';
+    newstmtLen.textContent  = '0';
+    newstmtSubmit.disabled  = true;
+    newstmtInput.focus();
+  });
 
-    proposeSubmitBtn.disabled = true;
+  // ── Suggest composer ──────────────────────────────────────────────────────────
+  suggestInput.addEventListener('input', function () {
+    suggestLen.textContent = suggestInput.value.length;
+    var val = suggestInput.value.trim();
+    suggestSubmit.disabled = val.length === 0 || val === originalStmtText.trim();
+  });
 
+  document.getElementById('suggest-cancel').addEventListener('click', function () {
+    composerSuggest.hidden = true;
+    triad.hidden           = false;
+  });
+
+  suggestSubmit.addEventListener('click', function () {
+    var val = suggestInput.value.trim();
+    if (!val || val === originalStmtText.trim()) return;
+    suggestSubmit.disabled = true;
     function onSuccess() {
       conv.removeEventListener('particiappstatementsubmitsuccess', onSuccess);
       conv.removeEventListener('particiappstatementsubmiterror', onError);
-      proposeComposer.hidden  = true;
+      composerSuggest.hidden  = true;
       proposeSubmitted.hidden = false;
       setTimeout(enterIdle, 1200);
     }
-    function onError(e) {
+    function onError(ev) {
       conv.removeEventListener('particiappstatementsubmitsuccess', onSuccess);
       conv.removeEventListener('particiappstatementsubmiterror', onError);
-      proposeSubmitBtn.disabled = false;
+      suggestSubmit.disabled = false;
       convError.hidden = false;
       convErrorMsg.textContent = 'Could not submit statement'
-        + (e.error && e.error.message ? ': ' + e.error.message : '') + '.';
+        + (ev.error && ev.error.message ? ': ' + ev.error.message : '') + '.';
     }
     conv.addEventListener('particiappstatementsubmitsuccess', onSuccess);
     conv.addEventListener('particiappstatementsubmiterror', onError);
-
-    pvbSubmitStmt.click();
+    pvbSubmitSuggest.click();
   });
 
-  // ── Propose: next statement (manual fallback in submitted state) ──────────────
+  // ── New statement composer ────────────────────────────────────────────────────
+  newstmtInput.addEventListener('input', function () {
+    newstmtLen.textContent = newstmtInput.value.length;
+    newstmtSubmit.disabled = newstmtInput.value.trim().length === 0;
+  });
+
+  document.getElementById('newstmt-cancel').addEventListener('click', function () {
+    composerNewstmt.hidden = true;
+    triad.hidden           = false;
+  });
+
+  newstmtSubmit.addEventListener('click', function () {
+    var val = newstmtInput.value.trim();
+    if (!val) return;
+    newstmtSubmit.disabled = true;
+    function onSuccess() {
+      conv.removeEventListener('particiappstatementsubmitsuccess', onSuccess);
+      conv.removeEventListener('particiappstatementsubmiterror', onError);
+      composerNewstmt.hidden  = true;
+      proposeSubmitted.hidden = false;
+      setTimeout(enterIdle, 1200);
+    }
+    function onError(ev) {
+      conv.removeEventListener('particiappstatementsubmitsuccess', onSuccess);
+      conv.removeEventListener('particiappstatementsubmiterror', onError);
+      newstmtSubmit.disabled = false;
+      convError.hidden = false;
+      convErrorMsg.textContent = 'Could not submit statement'
+        + (ev.error && ev.error.message ? ': ' + ev.error.message : '') + '.';
+    }
+    conv.addEventListener('particiappstatementsubmitsuccess', onSuccess);
+    conv.addEventListener('particiappstatementsubmiterror', onError);
+    pvbSubmitNewstmt.click();
+  });
+
+  // ── Submitted: manual next ────────────────────────────────────────────────────
   document.getElementById('propose-next').addEventListener('click', enterIdle);
 
-  // ── Progress row + statement sequence number (issues #2 and #3) ──────────────
+  // ── Progress ──────────────────────────────────────────────────────────────────
   function updateProgress(statements) {
     var total = statements.size;
     if (total === 0) return;
-
-    // Count votes from the server-persisted participant record so progress
-    // is accurate across sessions. Own submitted statements are auto-voted
-    // server-side and already included in participant.votes.
     var votedIds = conv.client.participant.votes;
     var done = 0;
-    statements.forEach(function (stmt, id) {
-      if (votedIds.has(id)) done++;
-    });
-
-    // Show progress row and populate counts
+    statements.forEach(function (stmt, id) { if (votedIds.has(id)) done++; });
     progressRow.style.display = '';
-    votesDone.textContent = done;
+    votesDone.textContent  = done;
     votesTotal.textContent = total;
-
-    // Rebuild segmented bar: done segments first, then current (if any), then queued.
-    var current = conv.statement; // null if all done
+    var current = conv.statement;
     progressBar.innerHTML = '';
     for (var i = 0; i < total; i++) {
       var seg = document.createElement('div');
-      seg.className = 'vote-seg ' + (i < done ? 'vote-seg--done' : (current !== null && i === done) ? 'vote-seg--current' : 'vote-seg--queued');
+      seg.className = 'vote-seg '
+        + (i < done ? 'vote-seg--done' : (current !== null && i === done) ? 'vote-seg--current' : 'vote-seg--queued');
       progressBar.appendChild(seg);
+    }
+    updateNewstmtCard();
+    if (triad.classList.contains('v2-triad--active')) {
+      triadNewstmt.disabled = getVotedCount() < NEW_STMT_UNLOCK_AT;
     }
   }
 
-  // particiappstatementschange only fires on poll cycles, not on initial load.
-  // We also call updateProgress from the 'loaded' state handler using conv.client.statements.
-  conv.addEventListener('particiappstatementschange', function (e) {
-    updateProgress(e.statements);
-  });
+  conv.addEventListener('particiappstatementschange', function (e) { updateProgress(e.statements); });
+  conv.addEventListener('particiappvotesubmitsuccess', function ()  { updateProgress(conv.client.statements); });
 
-  conv.addEventListener('particiappvotesubmitsuccess', function () {
-    updateProgress(conv.client.statements);
-  });
-
-  // ── Error ─────────────────────────────────────────────────────────────────────
+  // ── Error / loaded ────────────────────────────────────────────────────────────
   conv.addEventListener('particiappstatechange', function (e) {
     if (e.state === 'error') {
       convError.hidden = false;

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -152,10 +152,11 @@
 
         {# ── V2 Option Triad — always rendered, dimmed pre-vote, active post-vote ── #}
         <div class="v2-triad" id="v2-triad">
-          <div class="v2-triad-label" id="v2-triad-label">After you vote, you can&hellip;</div>
-          <div class="v2-triad-grid">
+          <div class="v2-triad-label" id="v2-triad-label" aria-live="polite">After you vote, you can&hellip;</div>
+          <div class="v2-triad-grid" role="group" aria-labelledby="v2-triad-label">
 
-            <button type="button" class="v2-option-card" id="triad-suggest" disabled>
+            <button type="button" class="v2-option-card" id="triad-suggest"
+                    aria-disabled="true" tabindex="0">
               <div class="v2-option-top">
                 <span class="v2-option-glyph">
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -167,11 +168,12 @@
               <div class="v2-option-bottom">
                 <div class="v2-option-title">Suggest different wording</div>
                 <div class="v2-option-sub">Same idea, clearer phrasing</div>
-                <div class="v2-option-action">Write yours →</div>
+                <div class="v2-option-action">Write yours &rarr;</div>
               </div>
             </button>
 
-            <button type="button" class="v2-option-card" id="triad-next" disabled>
+            <button type="button" class="v2-option-card" id="triad-next"
+                    aria-disabled="true" tabindex="0">
               <div class="v2-option-top">
                 <span class="v2-option-glyph">
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -183,11 +185,13 @@
               <div class="v2-option-bottom">
                 <div class="v2-option-title">Move on</div>
                 <div class="v2-option-sub">Next statement, nothing to add</div>
-                <div class="v2-option-action">Next →</div>
+                <div class="v2-option-action">Next &rarr;</div>
               </div>
             </button>
 
-            <button type="button" class="v2-option-card v2-option-card--locked" id="triad-newstmt" disabled>
+            <button type="button" class="v2-option-card v2-option-card--locked" id="triad-newstmt"
+                    aria-disabled="true" tabindex="0"
+                    aria-describedby="triad-newstmt-sub">
               <div class="v2-option-top">
                 <span class="v2-option-glyph">
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -203,7 +207,7 @@
               <div class="v2-option-bottom">
                 <div class="v2-option-title">Propose a new statement</div>
                 <div class="v2-option-sub" id="triad-newstmt-sub">Unlocks after {{ new_stmt_unlock_at | default(10) }} votes</div>
-                <div class="v2-option-action" id="triad-newstmt-action" hidden>Compose →</div>
+                <div class="v2-option-action" id="triad-newstmt-action" hidden>Compose &rarr;</div>
               </div>
             </button>
 
@@ -266,8 +270,8 @@
           <pa-vote-button id="pvb-agree"    type="agree">Agree</pa-vote-button>
           <pa-vote-button id="pvb-neutral"  type="neutral">Pass</pa-vote-button>
           <pa-vote-button id="pvb-disagree" type="disagree">Disagree</pa-vote-button>
-          <pa-submit-button id="pvb-submit-suggest" submitfor="suggest-input">suggest</pa-submit-button>
-          <pa-submit-button id="pvb-submit-newstmt" submitfor="newstmt-input">suggest</pa-submit-button>
+          <pa-submit-button id="pvb-submit-suggest" submitfor="suggest-input">suggest-wording</pa-submit-button>
+          <pa-submit-button id="pvb-submit-newstmt" submitfor="newstmt-input">new-statement</pa-submit-button>
         </span>
 
         <div id="conv-error" hidden>
@@ -763,28 +767,27 @@
 {% if conversation.phase_submission and conversation.active and not conversation.paused %}
 <script nonce="{{ csp_nonce }}">
 (function () {
-  var conv            = document.querySelector('pa-conversation');
-  var paStmt          = conv.querySelector('pa-statement');
-  var choiceRow       = document.getElementById('vote-choice-row');
-  var stmtRightLabel  = document.getElementById('stmt-right-label');
-  var votedBadge      = document.getElementById('voted-badge');
-  var votedLabel      = document.getElementById('voted-label');
-  var votedStmtText   = document.getElementById('voted-stmt-text');
-  var triad           = document.getElementById('v2-triad');
-  var triadLabel      = document.getElementById('v2-triad-label');
-  var triadSuggest    = document.getElementById('triad-suggest');
-  var triadNext       = document.getElementById('triad-next');
-  var triadNewstmt    = document.getElementById('triad-newstmt');
-  var triadNewstmtSub = document.getElementById('triad-newstmt-sub');
+  var conv             = document.querySelector('pa-conversation');
+  var choiceRow        = document.getElementById('vote-choice-row');
+  var stmtRightLabel   = document.getElementById('stmt-right-label');
+  var votedBadge       = document.getElementById('voted-badge');
+  var votedLabel       = document.getElementById('voted-label');
+  var votedStmtText    = document.getElementById('voted-stmt-text');
+  var triad            = document.getElementById('v2-triad');
+  var triadLabel       = document.getElementById('v2-triad-label');
+  var triadSuggest     = document.getElementById('triad-suggest');
+  var triadNext        = document.getElementById('triad-next');
+  var triadNewstmt     = document.getElementById('triad-newstmt');
+  var triadNewstmtSub  = document.getElementById('triad-newstmt-sub');
   var triadNewstmtAction = document.getElementById('triad-newstmt-action');
-  var composerSuggest = document.getElementById('composer-suggest');
-  var composerNewstmt = document.getElementById('composer-newstmt');
-  var suggestInput    = document.getElementById('suggest-input');
-  var suggestLen      = document.getElementById('suggest-len');
-  var suggestSubmit   = document.getElementById('suggest-submit');
-  var newstmtInput    = document.getElementById('newstmt-input');
-  var newstmtLen      = document.getElementById('newstmt-len');
-  var newstmtSubmit   = document.getElementById('newstmt-submit');
+  var composerSuggest  = document.getElementById('composer-suggest');
+  var composerNewstmt  = document.getElementById('composer-newstmt');
+  var suggestInput     = document.getElementById('suggest-input');
+  var suggestLen       = document.getElementById('suggest-len');
+  var suggestSubmit    = document.getElementById('suggest-submit');
+  var newstmtInput     = document.getElementById('newstmt-input');
+  var newstmtLen       = document.getElementById('newstmt-len');
+  var newstmtSubmit    = document.getElementById('newstmt-submit');
   var proposeSubmitted = document.getElementById('propose-submitted');
   var pvb = {
     agree:    document.getElementById('pvb-agree'),
@@ -806,14 +809,27 @@
 
   // ── Helpers ───────────────────────────────────────────────────────────────────
 
+  function liveStmt() { return conv.querySelector('pa-statement'); }
+
   function getVotedCount() {
     try { return conv.client.participant.votes.size; } catch (e) { return 0; }
   }
 
+  function isAllDone() {
+    try { return conv.statement === null && conv.client.statements.size > 0; } catch (e) { return false; }
+  }
+
+  function setAriaDisabled(btn, disabled) {
+    btn.setAttribute('aria-disabled', disabled ? 'true' : 'false');
+  }
+
+  function isAriaDisabled(btn) {
+    return btn.getAttribute('aria-disabled') === 'true';
+  }
+
   function updateNewstmtCard() {
-    var n = getVotedCount();
-    var remaining = Math.max(0, NEW_STMT_UNLOCK_AT - n);
-    var unlocked  = n >= NEW_STMT_UNLOCK_AT;
+    var unlocked = getVotedCount() >= NEW_STMT_UNLOCK_AT || isAllDone();
+    var remaining = Math.max(0, NEW_STMT_UNLOCK_AT - getVotedCount());
     triadNewstmt.classList.toggle('v2-option-card--locked', !unlocked);
     if (unlocked) {
       triadNewstmtSub.textContent = 'A different angle entirely';
@@ -824,28 +840,30 @@
       triadNewstmtAction.hidden   = true;
       triadNewstmt.querySelector('.v2-lock-icon').style.display = '';
     }
+    // Sync aria-disabled for the newstmt card when triad is active
+    if (triad.classList.contains('v2-triad--active')) {
+      setAriaDisabled(triadNewstmt, !unlocked);
+    }
   }
 
   // ── Mode: idle ────────────────────────────────────────────────────────────────
-  function enterIdle() {
-    // Restore statement card to pre-vote state
-    paStmt.hidden           = false;
-    votedStmtText.hidden    = true;
-    choiceRow.hidden        = false;
-    stmtRightLabel.hidden   = false;
-    votedBadge.hidden       = true;
-    originalStmtText        = '';
+  function enterIdle(focusTarget) {
+    var stmt = liveStmt();
+    if (stmt) stmt.hidden = false;
+    votedStmtText.hidden   = true;
+    choiceRow.hidden       = false;
+    stmtRightLabel.hidden  = false;
+    votedBadge.hidden      = true;
+    originalStmtText       = '';
 
-    // Triad — dimmed preview
-    triad.hidden    = false;
+    triad.hidden = false;
     triadLabel.textContent = 'After you vote, you can…';
     triad.classList.remove('v2-triad--active');
-    triadSuggest.disabled = true;
-    triadNext.disabled    = true;
+    setAriaDisabled(triadSuggest, true);
+    setAriaDisabled(triadNext,    true);
+    setAriaDisabled(triadNewstmt, true);
     triadNext.classList.remove('v2-option-card--primary');
-    triadNewstmt.disabled = true;
 
-    // Composers + submitted
     composerSuggest.hidden  = true;
     composerNewstmt.hidden  = true;
     proposeSubmitted.hidden = true;
@@ -855,6 +873,12 @@
     newstmtInput.value      = '';
     newstmtLen.textContent  = '0';
     newstmtSubmit.disabled  = true;
+
+    updateNewstmtCard();
+
+    // Restore keyboard focus
+    var target = focusTarget || choiceRow.querySelector('.vote-choice');
+    if (target) target.focus();
   }
 
   // ── Mode: voted ───────────────────────────────────────────────────────────────
@@ -863,35 +887,51 @@
   function enterVoted(voteType, stmtText) {
     originalStmtText = (stmtText || '').trim();
 
-    // Show voted snapshot of statement
-    paStmt.hidden           = true;
+    var stmt = liveStmt();
+    if (stmt) stmt.hidden = true;
     votedStmtText.textContent = originalStmtText;
-    votedStmtText.hidden    = false;
-    choiceRow.hidden        = true;
-    stmtRightLabel.hidden   = true;
-    votedBadge.hidden       = false;
-    votedLabel.textContent  = LABELS[voteType];
+    votedStmtText.hidden   = false;
+    choiceRow.hidden       = true;
+    stmtRightLabel.hidden  = true;
+    votedBadge.hidden      = false;
+    votedLabel.textContent = LABELS[voteType];
     votedBadge.dataset.type = voteType;
 
-    // Triad — active
-    triad.hidden    = false;
+    triad.hidden = false;
     triadLabel.textContent = 'What now?';
     triad.classList.add('v2-triad--active');
-    triadSuggest.disabled = false;
-    triadNext.disabled    = false;
+    setAriaDisabled(triadSuggest, false);
+    setAriaDisabled(triadNext,    false);
     triadNext.classList.add('v2-option-card--primary');
     updateNewstmtCard();
-    triadNewstmt.disabled = getVotedCount() < NEW_STMT_UNLOCK_AT;
 
-    // Pre-fill suggest textarea
     suggestInput.value     = originalStmtText;
     suggestLen.textContent = suggestInput.value.length;
     suggestSubmit.disabled = true;
 
-    // Composers hidden
     composerSuggest.hidden  = true;
     composerNewstmt.hidden  = true;
     proposeSubmitted.hidden = true;
+
+    // Move focus to first active triad card
+    triadSuggest.focus();
+  }
+
+  // ── Shared submit handler ─────────────────────────────────────────────────────
+  function submitComposer(pvbEl, submitBtn, composerEl) {
+    submitBtn.disabled = true;
+    conv.addEventListener('particiappstatementsubmitsuccess', function () {
+      composerEl.hidden       = true;
+      proposeSubmitted.hidden = false;
+      setTimeout(enterIdle, 1200);
+    }, { once: true });
+    conv.addEventListener('particiappstatementsubmiterror', function (ev) {
+      submitBtn.disabled = false;
+      convError.hidden   = false;
+      convErrorMsg.textContent = 'Could not submit statement'
+        + (ev.error && ev.error.message ? ': ' + ev.error.message : '') + '.';
+    }, { once: true });
+    pvbEl.click();
   }
 
   // ── Vote buttons ──────────────────────────────────────────────────────────────
@@ -899,17 +939,27 @@
     var btn = e.target.closest('.vote-choice');
     if (!btn) return;
     var type    = btn.dataset.type;
-    var stmtTxt = paStmt ? (paStmt.text || '').trim() : '';
+    var stmt    = liveStmt();
+    var stmtTxt = stmt ? (stmt.text || '').trim() : '';
     pvb[type].click();
     enterVoted(type, stmtTxt);
   });
 
   // ── Change vote ───────────────────────────────────────────────────────────────
-  document.getElementById('change-vote-btn').addEventListener('click', enterIdle);
+  document.getElementById('change-vote-btn').addEventListener('click', function () {
+    enterIdle(choiceRow.querySelector('.vote-choice'));
+  });
+
+  // ── Triad click guard (aria-disabled) ────────────────────────────────────────
+  function triadGuard(btn, fn) {
+    btn.addEventListener('click', function () { if (!isAriaDisabled(btn)) fn(); });
+    btn.addEventListener('keydown', function (e) {
+      if ((e.key === 'Enter' || e.key === ' ') && !isAriaDisabled(btn)) { e.preventDefault(); fn(); }
+    });
+  }
 
   // ── Triad: suggest different wording ─────────────────────────────────────────
-  triadSuggest.addEventListener('click', function () {
-    if (this.disabled) return;
+  triadGuard(triadSuggest, function () {
     triad.hidden           = true;
     composerSuggest.hidden = false;
     suggestInput.focus();
@@ -917,19 +967,17 @@
   });
 
   // ── Triad: move on ────────────────────────────────────────────────────────────
-  triadNext.addEventListener('click', function () {
-    if (this.disabled) return;
-    enterIdle();
+  triadGuard(triadNext, function () {
+    enterIdle(choiceRow.querySelector('.vote-choice'));
   });
 
   // ── Triad: propose new statement ─────────────────────────────────────────────
-  triadNewstmt.addEventListener('click', function () {
-    if (this.disabled) return;
-    triad.hidden            = true;
-    composerNewstmt.hidden  = false;
-    newstmtInput.value      = '';
-    newstmtLen.textContent  = '0';
-    newstmtSubmit.disabled  = true;
+  triadGuard(triadNewstmt, function () {
+    triad.hidden           = true;
+    composerNewstmt.hidden = false;
+    newstmtInput.value     = '';
+    newstmtLen.textContent = '0';
+    newstmtSubmit.disabled = true;
     newstmtInput.focus();
   });
 
@@ -943,30 +991,13 @@
   document.getElementById('suggest-cancel').addEventListener('click', function () {
     composerSuggest.hidden = true;
     triad.hidden           = false;
+    triadSuggest.focus();
   });
 
   suggestSubmit.addEventListener('click', function () {
     var val = suggestInput.value.trim();
     if (!val || val === originalStmtText.trim()) return;
-    suggestSubmit.disabled = true;
-    function onSuccess() {
-      conv.removeEventListener('particiappstatementsubmitsuccess', onSuccess);
-      conv.removeEventListener('particiappstatementsubmiterror', onError);
-      composerSuggest.hidden  = true;
-      proposeSubmitted.hidden = false;
-      setTimeout(enterIdle, 1200);
-    }
-    function onError(ev) {
-      conv.removeEventListener('particiappstatementsubmitsuccess', onSuccess);
-      conv.removeEventListener('particiappstatementsubmiterror', onError);
-      suggestSubmit.disabled = false;
-      convError.hidden = false;
-      convErrorMsg.textContent = 'Could not submit statement'
-        + (ev.error && ev.error.message ? ': ' + ev.error.message : '') + '.';
-    }
-    conv.addEventListener('particiappstatementsubmitsuccess', onSuccess);
-    conv.addEventListener('particiappstatementsubmiterror', onError);
-    pvbSubmitSuggest.click();
+    submitComposer(pvbSubmitSuggest, suggestSubmit, composerSuggest);
   });
 
   // ── New statement composer ────────────────────────────────────────────────────
@@ -978,36 +1009,20 @@
   document.getElementById('newstmt-cancel').addEventListener('click', function () {
     composerNewstmt.hidden = true;
     triad.hidden           = false;
+    triadNewstmt.focus();
   });
 
   newstmtSubmit.addEventListener('click', function () {
-    var val = newstmtInput.value.trim();
-    if (!val) return;
-    newstmtSubmit.disabled = true;
-    function onSuccess() {
-      conv.removeEventListener('particiappstatementsubmitsuccess', onSuccess);
-      conv.removeEventListener('particiappstatementsubmiterror', onError);
-      composerNewstmt.hidden  = true;
-      proposeSubmitted.hidden = false;
-      setTimeout(enterIdle, 1200);
-    }
-    function onError(ev) {
-      conv.removeEventListener('particiappstatementsubmitsuccess', onSuccess);
-      conv.removeEventListener('particiappstatementsubmiterror', onError);
-      newstmtSubmit.disabled = false;
-      convError.hidden = false;
-      convErrorMsg.textContent = 'Could not submit statement'
-        + (ev.error && ev.error.message ? ': ' + ev.error.message : '') + '.';
-    }
-    conv.addEventListener('particiappstatementsubmitsuccess', onSuccess);
-    conv.addEventListener('particiappstatementsubmiterror', onError);
-    pvbSubmitNewstmt.click();
+    if (!newstmtInput.value.trim()) return;
+    submitComposer(pvbSubmitNewstmt, newstmtSubmit, composerNewstmt);
   });
 
   // ── Submitted: manual next ────────────────────────────────────────────────────
-  document.getElementById('propose-next').addEventListener('click', enterIdle);
+  document.getElementById('propose-next').addEventListener('click', function () {
+    enterIdle(choiceRow.querySelector('.vote-choice'));
+  });
 
-  // ── Progress ──────────────────────────────────────────────────────────────────
+  // ── Progress + no-statement handling ─────────────────────────────────────────
   function updateProgress(statements) {
     var total = statements.size;
     if (total === 0) return;
@@ -1022,13 +1037,21 @@
     for (var i = 0; i < total; i++) {
       var seg = document.createElement('div');
       seg.className = 'vote-seg '
-        + (i < done ? 'vote-seg--done' : (current !== null && i === done) ? 'vote-seg--current' : 'vote-seg--queued');
+        + (i < done ? 'vote-seg--done'
+           : (current !== null && i === done) ? 'vote-seg--current'
+           : 'vote-seg--queued');
       progressBar.appendChild(seg);
     }
     updateNewstmtCard();
-    if (triad.classList.contains('v2-triad--active')) {
-      triadNewstmt.disabled = getVotedCount() < NEW_STMT_UNLOCK_AT;
+  }
+
+  function handleNoStatement() {
+    // All statements voted — hide the triad dimmed preview; it makes no sense
+    // to show "After you vote…" when there is nothing left to vote on.
+    if (isAllDone() && !triad.classList.contains('v2-triad--active')) {
+      triad.hidden = true;
     }
+    updateNewstmtCard(); // may unlock new-statement card
   }
 
   conv.addEventListener('particiappstatementschange', function (e) { updateProgress(e.statements); });
@@ -1047,6 +1070,7 @@
     }
     if (e.state === 'loaded' && conv.client) {
       updateProgress(conv.client.statements);
+      handleNoStatement();
     }
   });
 }());

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -816,6 +816,7 @@
   var NEW_STMT_USED = {{ new_stmt_ids | length }};
   var originalStmtText = '';
   var newstmtOrigin = 'voted'; // 'voted' | 'alldone' — tracks where composer was opened from
+  var mySubmittedStmtIds = new Set(); // tids of statements this participant submitted; Polis 403s on own-vote
 
   // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -1045,6 +1046,14 @@
       body: JSON.stringify({ text: text }),
     }).then(function (resp) {
       if (resp.ok) {
+        resp.json().then(function (data) {
+          if (data && data.id != null) {
+            var tid = Number(data.id);
+            mySubmittedStmtIds.add(tid);
+            // Mark as voted in the web component so it never appears in the queue
+            try { conv.client.participant.votes.add(tid); } catch (e) {}
+          }
+        });
         composerNewstmt.hidden  = true;
         proposeSubmitted.hidden = false;
         NEW_STMT_USED++;
@@ -1128,6 +1137,21 @@
 
   conv.addEventListener('particiappstatementschange', function (e) { updateProgress(e.statements); });
   conv.addEventListener('particiappvotesubmitsuccess', function ()  { updateProgress(conv.client.statements); });
+
+  // Track the last statement ID being voted on (statementID comes from pa-vote-button event).
+  var lastVoteStmtId = null;
+  conv.addEventListener('particiappvotesubmit', function (e) {
+    lastVoteStmtId = e.statementID != null ? Number(e.statementID) : null;
+  });
+
+  // On vote failure: mark the statement as voted in the web component so it advances,
+  // then reset UI. Covers both own-statement 403s and any other transient failures.
+  conv.addEventListener('particiappvotesubmiterror', function () {
+    if (lastVoteStmtId != null) {
+      try { conv.client.participant.votes.add(lastVoteStmtId); } catch (e) {}
+    }
+    enterIdle(choiceRow.querySelector('.vote-choice'));
+  });
 
   // ── Error / loaded ────────────────────────────────────────────────────────────
   conv.addEventListener('particiappstatechange', function (e) {

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -768,6 +768,7 @@
 <script nonce="{{ csp_nonce }}">
 (function () {
   var conv             = document.querySelector('pa-conversation');
+  var stmtCard         = document.getElementById('statement-card');
   var choiceRow        = document.getElementById('vote-choice-row');
   var stmtRightLabel   = document.getElementById('stmt-right-label');
   var votedBadge       = document.getElementById('voted-badge');
@@ -848,11 +849,8 @@
 
   // ── Mode: idle ────────────────────────────────────────────────────────────────
   function enterIdle(focusTarget) {
-    var stmt = liveStmt();
-    if (stmt) stmt.hidden = false;
+    stmtCard.classList.remove('statement-card--voted');
     votedStmtText.hidden   = true;
-    choiceRow.hidden       = false;
-    stmtRightLabel.hidden  = false;
     votedBadge.hidden      = true;
     originalStmtText       = '';
 
@@ -887,12 +885,9 @@
   function enterVoted(voteType, stmtText) {
     originalStmtText = (stmtText || '').trim();
 
-    var stmt = liveStmt();
-    if (stmt) stmt.hidden = true;
+    stmtCard.classList.add('statement-card--voted');
     votedStmtText.textContent = originalStmtText;
     votedStmtText.hidden   = false;
-    choiceRow.hidden       = true;
-    stmtRightLabel.hidden  = true;
     votedBadge.hidden      = false;
     votedLabel.textContent = LABELS[voteType];
     votedBadge.dataset.type = voteType;


### PR DESCRIPTION
## Summary

- Replaces the always-visible textarea propose affordance with a post-vote three-option triad: **Suggest different wording**, **Move on**, **Propose a new statement**
- "Propose a new statement" unlocks after `min(10, total_statements)` votes and is capped at 3 per participant per conversation; remaining quota shown on the card
- Adds `new_stmt_ids` JSON column to `Participation` (migration `a3f1c8e2d905`) to track submitted statement IDs for quota enforcement and novelty indication
- New Flask route `POST /c/<slug>/statements/new` handles new-statement submission server-side (required to obtain Particiapi CSRF token); quota enforced there
- All-done state: when all statements are voted, completion screen shows with only Propose New available
- Own-statement auto-skip: submitted statement IDs are pre-emptively added to the web component's `participant.votes` Set so authors never see their own statements in the vote queue (Polis 403s self-votes)
- Functional design updated to reflect current implementation

## DB migration

```
flask db upgrade
```

Must be run on staging and production before deploying.

## Test plan

- [ ] Vote on a statement → triad appears with badge showing vote label
- [ ] "Suggest different wording" opens pre-filled composer; submit enters pool
- [ ] "Move on" advances to next statement
- [ ] "Propose new statement" locked until 10 votes, shows countdown
- [ ] After 10 votes, Propose New unlocks with "3 of 3 remaining"
- [ ] Submit new statement → quota decrements; own statement skipped in queue
- [ ] At quota 0, Propose New card shows "Limit reached" and stays disabled
- [ ] Vote all statements → all-done screen with Propose New (if quota available)
- [ ] DB `new_stmt_ids` column populated after each proposal

🤖 Generated with [Claude Code](https://claude.com/claude-code)