### PR TITLE
Default strict moderation to on for new conversations

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -1476,9 +1476,7 @@ def _register_routes(app: Flask) -> None:
             'POLIS_SERVER_URL', 'POLIS_ADMIN_EMAIL', 'POLIS_ADMIN_PASSWORD'))
         if polis_configured:
             try:
-                client   = _polis_server_client()
-                polis_id = client.create_conversation(fields['title'])
-                client.set_strict_moderation(polis_id, True)
+                polis_id = _polis_server_client().create_conversation(fields['title'])
             except PolisServerError as exc:
                 current_app.logger.exception('Polis conversation creation failed')
                 flash('Could not create the Polis conversation. Check server logs for details.', 'error')

--- a/v2/app.py
+++ b/v2/app.py
@@ -1476,7 +1476,7 @@ def _register_routes(app: Flask) -> None:
             'POLIS_SERVER_URL', 'POLIS_ADMIN_EMAIL', 'POLIS_ADMIN_PASSWORD'))
         if polis_configured:
             try:
-                polis_id = _polis_server_client().create_conversation(fields['title'])
+                polis_id = _polis_server_client().create_conversation(fields['title'], strict_moderation=True)
             except PolisServerError as exc:
                 current_app.logger.exception('Polis conversation creation failed')
                 flash('Could not create the Polis conversation. Check server logs for details.', 'error')

--- a/v2/app.py
+++ b/v2/app.py
@@ -1476,7 +1476,9 @@ def _register_routes(app: Flask) -> None:
             'POLIS_SERVER_URL', 'POLIS_ADMIN_EMAIL', 'POLIS_ADMIN_PASSWORD'))
         if polis_configured:
             try:
-                polis_id = _polis_server_client().create_conversation(fields['title'])
+                client   = _polis_server_client()
+                polis_id = client.create_conversation(fields['title'])
+                client.set_strict_moderation(polis_id, True)
             except PolisServerError as exc:
                 current_app.logger.exception('Polis conversation creation failed')
                 flash('Could not create the Polis conversation. Check server logs for details.', 'error')

--- a/v2/polis_admin.py
+++ b/v2/polis_admin.py
@@ -223,7 +223,7 @@ class PolisServerClient:
                     'is_anon':           False,
                     'profanity_filter':  False,
                     'spam_filter':       False,
-                    'strict_moderation': False,
+                    'strict_moderation': True,
                 },
                 headers=headers,
                 timeout=10,

--- a/v2/polis_admin.py
+++ b/v2/polis_admin.py
@@ -208,7 +208,7 @@ class PolisServerClient:
 
     # ── Conversations ─────────────────────────────────────────────────────────
 
-    def create_conversation(self, title: str, strict_moderation: bool = True) -> str:
+    def create_conversation(self, title: str, strict_moderation: bool = False) -> str:
         """Create a Polis conversation and return its zinvite."""
         sess, auth_headers = self._login()
         headers = {**self._HEADERS, **auth_headers}

--- a/v2/polis_admin.py
+++ b/v2/polis_admin.py
@@ -208,7 +208,7 @@ class PolisServerClient:
 
     # ── Conversations ─────────────────────────────────────────────────────────
 
-    def create_conversation(self, title: str) -> str:
+    def create_conversation(self, title: str, strict_moderation: bool = True) -> str:
         """Create a Polis conversation and return its zinvite."""
         sess, auth_headers = self._login()
         headers = {**self._HEADERS, **auth_headers}
@@ -223,7 +223,7 @@ class PolisServerClient:
                     'is_anon':           False,
                     'profanity_filter':  False,
                     'spam_filter':       False,
-                    'strict_moderation': True,
+                    'strict_moderation': strict_moderation,
                 },
                 headers=headers,
                 timeout=10,

--- a/v2/tests/test_polis_admin.py
+++ b/v2/tests/test_polis_admin.py
@@ -153,12 +153,12 @@ def _setup_create(zinvite='abc123'):
     return client, sess, login_patch
 
 
-def test_create_conversation_sends_strict_moderation_true_by_default():
+def test_create_conversation_sends_strict_moderation_false_by_default():
     client, sess, login_patch = _setup_create()
     with login_patch:
         client.create_conversation('My conversation')
     payload = sess.post.call_args[1]['json']
-    assert payload['strict_moderation'] is True
+    assert payload['strict_moderation'] is False
 
 
 def test_create_conversation_strict_moderation_can_be_overridden():

--- a/v2/tests/test_polis_admin.py
+++ b/v2/tests/test_polis_admin.py
@@ -2,72 +2,15 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests as _requests
 
-from polis_admin import PolisAdminClient, PolisAdminError, get_polis_stats
-
-
-# ── get_polis_stats ───────────────────────────────────────────────────────────
-
-def test_no_db_url_returns_none():
-    assert get_polis_stats('abc123', '') is None
-    assert get_polis_stats('abc123', None) is None
+from polis_admin import (
+    PolisParticipantClient, PolisParticipantError,
+    PolisServerClient, PolisServerError,
+)
 
 
-def test_invalid_zinvite_returns_none():
-    assert get_polis_stats('bad zinvite!', 'postgresql://x/y') is None
-    assert get_polis_stats('', 'postgresql://x/y') is None
-    assert get_polis_stats(None, 'postgresql://x/y') is None
-    assert get_polis_stats('ab', 'postgresql://x/y') is None  # too short
-
-
-def test_valid_zinvite_boundary():
-    """6-char zinvite is accepted; 5-char is not."""
-    with patch('psycopg2.connect', side_effect=Exception('no server')):
-        assert get_polis_stats('abcde', 'postgresql://x/y') is None   # 5 chars
-        assert get_polis_stats('abcdef', 'postgresql://x/y') is None  # 6 chars — accepted, conn fails
-
-
-def test_connection_error_returns_none():
-    with patch('psycopg2.connect', side_effect=Exception('conn refused')):
-        assert get_polis_stats('abc123', 'postgresql://localhost/polis') is None
-
-
-def test_empty_row_returns_none():
-    mock_conn = MagicMock()
-    mock_conn.cursor.return_value.__enter__.return_value.fetchone.return_value = None
-    with patch('psycopg2.connect', return_value=mock_conn):
-        assert get_polis_stats('abc123', 'postgresql://localhost/polis') is None
-
-
-def test_returns_correct_dict():
-    mock_conn = MagicMock()
-    cur = mock_conn.cursor.return_value.__enter__.return_value
-    cur.fetchone.return_value = (10, 150, 15.0, 12.5, 8, 3)
-    with patch('psycopg2.connect', return_value=mock_conn):
-        result = get_polis_stats('abc123', 'postgresql://localhost/polis')
-
-    assert result == {
-        'n_participants': 10,
-        'n_votes': 150,
-        'avg_votes': 15.0,
-        'median_votes': 12.5,
-        'n_statements': 8,
-        'n_seed': 3,
-    }
-    mock_conn.close.assert_called_once()
-
-
-def test_closes_connection_on_error():
-    """psycopg2 connection is always closed, even on query error."""
-    mock_conn = MagicMock()
-    mock_conn.cursor.return_value.__enter__.side_effect = Exception('query boom')
-    with patch('psycopg2.connect', return_value=mock_conn):
-        result = get_polis_stats('abc123', 'postgresql://localhost/polis')
-    assert result is None
-    mock_conn.close.assert_called_once()
-
-
-# ── PolisAdminClient ──────────────────────────────────────────────────────────
+# ── helpers ───────────────────────────────────────────────────────────────────
 
 def _mock_ok(json_data):
     resp = MagicMock()
@@ -85,63 +28,157 @@ def _mock_err(status=500):
     return resp
 
 
+def _server_client():
+    return PolisServerClient('http://polis:8001', 'admin@test.com', 'pass')
+
+
+def _mock_login(client):
+    """Patch _login to return a mock session + empty auth headers."""
+    sess = MagicMock()
+    return patch.object(type(client), '_login', return_value=(sess, {})), sess
+
+
+# ── PolisParticipantClient.get_statements ─────────────────────────────────────
+
 def test_get_statements_returns_all_as_approved():
-    """Particiapi returns a dict of statements; all normalised into approved."""
-    client = PolisAdminClient('http://localhost:8000')
+    """Particiapi returns a dict; all statements normalised into approved."""
+    client = PolisParticipantClient('http://localhost:8000')
     data = {'0': {'text': 'first stmt'}, '1': {'text': 'second stmt'}}
     with patch('polis_admin.requests.request', return_value=_mock_ok(data)) as mock_req:
         pending, approved, hid = client.get_statements('abc123')
 
     assert pending == [] and hid == []
     assert len(approved) == 2
-    tids = {s['tid'] for s in approved}
-    assert tids == {0, 1}
-    assert approved[0]['txt'] == 'first stmt' or approved[1]['txt'] == 'first stmt'
-
-    call = mock_req.call_args
-    assert call[0][0] == 'GET'
-    assert 'abc123/statements/' in call[0][1]
+    assert {s['tid'] for s in approved} == {0, 1}
+    assert any(s['txt'] == 'first stmt' for s in approved)
+    assert mock_req.call_args[0][0] == 'GET'
+    assert 'abc123/statements/' in mock_req.call_args[0][1]
 
 
-def test_get_statements_non_dict_response_returns_empty():
-    """If Particiapi returns a list instead of a dict, return empty tuples."""
-    client = PolisAdminClient('http://localhost:8000')
+def test_get_statements_non_dict_returns_empty():
+    client = PolisParticipantClient('http://localhost:8000')
     with patch('polis_admin.requests.request', return_value=_mock_ok([])):
         pending, approved, hid = client.get_statements('abc123')
     assert pending == approved == hid == []
 
 
-def test_moderate_raises_not_available():
-    """Particiapi has no moderation endpoint — must raise PolisAdminError."""
-    client = PolisAdminClient('http://localhost:8000')
-    with pytest.raises(PolisAdminError, match='not available'):
-        client.moderate('abc123', tid=5, mod=1)
-
-
-def test_add_seed_raises_not_available():
-    """Particiapi seed creation requires a browser session — must raise PolisAdminError."""
-    client = PolisAdminClient('http://localhost:8000')
-    with pytest.raises(PolisAdminError, match='not available'):
-        client.add_seed('abc123', 'Seed statement text')
-
-
-def test_http_error_raises_polis_admin_error():
-    client = PolisAdminClient('http://localhost:8000')
+def test_get_statements_http_error_raises():
+    client = PolisParticipantClient('http://localhost:8000')
     with patch('polis_admin.requests.request', return_value=_mock_err(503)):
-        with pytest.raises(PolisAdminError, match='503'):
+        with pytest.raises(PolisParticipantError, match='503'):
             client.get_statements('abc123')
 
 
-def test_network_error_raises_polis_admin_error():
-    import requests as _requests
-    client = PolisAdminClient('http://localhost:8000')
+def test_get_statements_network_error_raises():
+    client = PolisParticipantClient('http://localhost:8000')
     with patch('polis_admin.requests.request',
                side_effect=_requests.RequestException('timeout')):
-        with pytest.raises(PolisAdminError, match='timeout'):
+        with pytest.raises(PolisParticipantError, match='timeout'):
             client.get_statements('abc123')
 
 
 def test_get_results_returns_none_on_error():
-    client = PolisAdminClient('http://localhost:8000')
+    client = PolisParticipantClient('http://localhost:8000')
     with patch('polis_admin.requests.request', return_value=_mock_err(404)):
         assert client.get_results('abc123') is None
+
+
+# ── PolisServerClient.get_polis_stats ─────────────────────────────────────────
+
+def _make_stats_client(db_rows=None, db_error=None):
+    client = PolisServerClient('http://polis', 'a@b.com', 'pw',
+                               db_url='postgresql://localhost/polis')
+    mock_conn = MagicMock()
+    cur = mock_conn.cursor.return_value.__enter__.return_value
+    if db_error:
+        cur.execute.side_effect = db_error
+    else:
+        cur.fetchone.return_value = db_rows
+    return client, mock_conn
+
+
+def test_stats_no_db_url_returns_none():
+    client = PolisServerClient('http://polis', 'a@b.com', 'pw', db_url='')
+    assert client.get_polis_stats('abc123') is None
+
+
+def test_stats_invalid_zinvite_returns_none():
+    client = PolisServerClient('http://polis', 'a@b.com', 'pw',
+                               db_url='postgresql://localhost/polis')
+    for bad in ('bad zinvite!', '', None, 'ab'):
+        assert client.get_polis_stats(bad) is None
+
+
+def test_stats_connection_error_returns_none():
+    client = PolisServerClient('http://polis', 'a@b.com', 'pw',
+                               db_url='postgresql://localhost/polis')
+    with patch('psycopg2.connect', side_effect=Exception('conn refused')):
+        assert client.get_polis_stats('abc123') is None
+
+
+def test_stats_empty_row_returns_none():
+    client, mock_conn = _make_stats_client(db_rows=None)
+    with patch('psycopg2.connect', return_value=mock_conn):
+        assert client.get_polis_stats('abc123') is None
+
+
+def test_stats_returns_correct_dict():
+    client, mock_conn = _make_stats_client(db_rows=(10, 150, 15.0, 12.5, 8, 3))
+    with patch('psycopg2.connect', return_value=mock_conn):
+        result = client.get_polis_stats('abc123')
+    assert result == {
+        'n_participants': 10, 'n_votes': 150, 'avg_votes': 15.0,
+        'median_votes': 12.5, 'n_statements': 8, 'n_seed': 3,
+    }
+    mock_conn.close.assert_called_once()
+
+
+def test_stats_closes_connection_on_error():
+    client, mock_conn = _make_stats_client(db_error=Exception('query boom'))
+    with patch('psycopg2.connect', return_value=mock_conn):
+        assert client.get_polis_stats('abc123') is None
+    mock_conn.close.assert_called_once()
+
+
+# ── PolisServerClient.create_conversation ────────────────────────────────────
+
+def _setup_create(zinvite='abc123'):
+    client = _server_client()
+    sess = MagicMock()
+    resp = MagicMock()
+    resp.ok = True
+    resp.json.return_value = {'url': f'https://pol.is/{zinvite}', 'zid': 1}
+    sess.post.return_value = resp
+    login_patch = patch.object(PolisServerClient, '_login', return_value=(sess, {}))
+    return client, sess, login_patch
+
+
+def test_create_conversation_sends_strict_moderation_true_by_default():
+    client, sess, login_patch = _setup_create()
+    with login_patch:
+        client.create_conversation('My conversation')
+    payload = sess.post.call_args[1]['json']
+    assert payload['strict_moderation'] is True
+
+
+def test_create_conversation_strict_moderation_can_be_overridden():
+    client, sess, login_patch = _setup_create()
+    with login_patch:
+        client.create_conversation('My conversation', strict_moderation=False)
+    payload = sess.post.call_args[1]['json']
+    assert payload['strict_moderation'] is False
+
+
+def test_create_conversation_returns_zinvite():
+    client, sess, login_patch = _setup_create(zinvite='xyz789')
+    with login_patch:
+        result = client.create_conversation('My conversation')
+    assert result == 'xyz789'
+
+
+def test_create_conversation_raises_on_polis_error():
+    client, sess, login_patch = _setup_create()
+    sess.post.return_value = _mock_err(500)
+    with login_patch:
+        with pytest.raises(PolisServerError):
+            client.create_conversation('My conversation')


### PR DESCRIPTION
## Summary

- Changes the default `strict_moderation` flag in `create_conversation()` from `False` to `True`
- All participant-submitted statements on new conversations are now held for review before entering the vote matrix
- Facilitators can disable this explicitly via the Moderation settings on the statements admin page
- No effect on existing conversations

Closes #58.

## Test plan

- [ ] Create a new conversation — confirm the Strict moderation checkbox is pre-checked on the statements page
- [ ] Submit a participant statement — confirm it lands in Pending rather than Approved
- [ ] Uncheck Strict moderation and save — confirm subsequent statements appear immediately
- [ ] Confirm existing conversations are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)