### PR TITLE
Fix post-login redirect landing on raw proxy JSON

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -173,7 +173,8 @@ def login_required(f):
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
         if 'username' not in session:
-            session['next'] = request.path
+            if not request.path.startswith('/proxy/'):
+                session['next'] = request.path
             return redirect(url_for('login'))
         return f(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
## Summary

- When an unauthenticated user's browser hit `/proxy/particiapi/...` (Polis embed XHR), `login_required` saved that path as `next`
- After OAuth, `_safe_redirect` correctly allowed it (same host), sending the browser to raw JSON instead of the app
- Fix: don't store `next` for `/proxy/` paths — fall back to index after login

## Test plan

- [ ] Log out, visit a conversation page (Polis embed loads), then log in — confirm you land on the conversation page or index, not raw JSON
- [ ] Direct navigation to a protected page still redirects back correctly after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)