### PR TITLE
docs: correct stale v1/v2 live-vs-retired labelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Hosted on [Toolforge](https://wikitech.wikimedia.org/wiki/Portal:Toolforge) at `
 
 ---
 
-## Architecture (v2, in development)
+## Architecture
 
 ```
   Browser ──▶ Flask app (Toolforge)
@@ -27,8 +27,8 @@ Hosted on [Toolforge](https://wikitech.wikimedia.org/wiki/Portal:Toolforge) at `
 
 | Directory | Contents |
 |---|---|
-| `v1/` | Current live deployment — local dev and Toolforge deployment docs |
-| `v2/` | v2 planning: architecture, functional design, data model, roadmap |
+| `v1/` | Retired v1 code and docs (hosted pol.is embed, superseded by v2) |
+| `v2/` | Live app: Flask app, templates, migrations, tests, deployment docs |
 | `v2/reference/` | Reference notes on Particiapi API and web components |
 
 ---
@@ -37,8 +37,8 @@ Hosted on [Toolforge](https://wikitech.wikimedia.org/wiki/Portal:Toolforge) at `
 
 ```
 wiki-polis/
-  app.py          — Flask app (v1, live)
-  db.py           — SQLAlchemy models (v1)
+  app.py          — Flask app (v1, retired)
+  db.py           — SQLAlchemy models (v1, retired)
   wsgi.py         — WSGI entry point
   uwsgi.ini       — uWSGI config
   deploy.sh       — Toolforge deploy script
@@ -46,5 +46,5 @@ wiki-polis/
   templates/      — Jinja2 templates
   static/         — CSS
   v1/             — v1 docs
-  v2/             — v2 planning docs
+  v2/             — Live app (deployed via wsgi.py)
 ```

--- a/v1/README.md
+++ b/v1/README.md
@@ -1,6 +1,6 @@
 # Wiki-Polis v1
 
-The current live deployment. A lightweight Flask app that wraps a hosted pol.is conversation behind Wikimedia OAuth.
+Retired. Superseded by v2 (self-hosted Polis + Particiapi stack).
 
 ---
 

--- a/v1/README.md
+++ b/v1/README.md
@@ -61,6 +61,8 @@ Local SQLite at `instance/dev.db` — created automatically on first run.
 
 ## Deployment (Toolforge)
 
+> **⚠️ Retired — do not follow.** These instructions deploy v1 (hosted pol.is embed), which is no longer the live app. For the current deployment runbook see [`v2/deployment.md`](../v2/deployment.md).
+
 ### 1. Register the tool
 
 Register at https://toolsadmin.wikimedia.org with tool name `wiki-polis`.

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,6 +1,6 @@
 # Wiki-Polis v2
 
-Planning documents for the second version of wiki-polis. v2 replaces the hosted pol.is embed with a self-hosted Polis + Particiapi stack, giving full control over the frontend and conversation lifecycle.
+The live wiki-polis app. Replaces the v1 hosted pol.is embed with a self-hosted Polis + Particiapi stack.
 
 ## Documents
 

--- a/v2/architecture.md
+++ b/v2/architecture.md
@@ -104,7 +104,7 @@ We use stock Particiapi with `PARTICIAPI_AUTHENTICATION_DISABLED=True`. No fork 
 | Database (our data) | MariaDB via SQLAlchemy | Toolforge ToolsDB |
 | Database (Polis data) | PostgreSQL | VPS, managed by Polis Docker container |
 | Polis runtime | Stock Polis (Node.js) | VPS via Docker Compose; no fork |
-| Moderation | Polis admin UI | No in-app moderation UI |
+| Moderation | Polis admin UI + Flask admin panel | Statement moderation (approve/hide/seed) and argument moderation (hide/delete) in Flask admin; Polis admin UI for clustering/math |
 
 ---
 
@@ -118,13 +118,13 @@ We use stock Particiapi with `PARTICIAPI_AUTHENTICATION_DISABLED=True`. No fork 
 
 **ConversationInvite** — conversation + mw_username
 
-**AdminRole** — participant + role (admin / moderator) + scope (global or per-conversation)
+**AdminRole** — participant + role (moderator only; site-wide access via `Participant.is_global_admin`) + conversation_id
 
 **FeaturedStatement** — conversation + polis_statement_id + suggested_by_system (bool) + confirmed_by_admin (bool)
 
 **Argument** — featured_statement + author (Participant) + body (max 280 chars) + side (pro / con) + created_at
 
-**ArgumentVote** — argument + participant + useful (bool)
+**ArgumentVote** — argument + participant + value (nullable integer; NULL = kApproval row-presence, integer rank for future ranked voting)
 
 Removed vs. old v2: `ModAction` (not needed), `featured` flag on Conversation (removed), `arguments_enabled` on FeaturedStatement (replaced by conversation-level `phase_argument_mapping` toggle).
 

--- a/v2/next_steps.md
+++ b/v2/next_steps.md
@@ -44,7 +44,7 @@ Ordered by dependency. Each step is independently testable before the next begin
 - [x] Conversation page: `<pa-conversation>` + `<pa-statement>` + `<pa-vote-button>`; "propose alternative" prompt after each vote
 - [x] Admin panel: conversations, phase toggles (S/P/A/R), roles, invites
 - [x] Confirmed end-to-end locally: dev-login → accept → statement submission → vote → Polis recorded `{"value": -1}`
-- [x] `polis_admin.py` PolisAdminClient rewritten to use correct Particiapi paths (`api/conversations/<id>/statements/`, `/results/`); raises `PolisAdminError` for unsupported operations (moderate, seed, strict-moderation)
+- [x] `polis_admin.py` split into `PolisParticipantClient` (Particiapi HTTP reads) and `PolisServerClient` (Polis admin API + direct Postgres); raises `PolisParticipantError` / `PolisServerError`
 - [x] Test suite (74 tests) green: unit, integration, security, reveal, polis_admin
 
 **Particiapi vote API:** `PUT /api/conversations/<id>/votes/<tid>` with `{"value": <int>}` (AGREE=-1, NEUTRAL=0, DISAGREE=1). Requires `@session_required` (web component handles session creation via `POST /api/session?create=true`).
@@ -226,7 +226,6 @@ Backend logic and routes are complete (Step 5 checklist below). What remains is 
 
 **Importance voting mechanic (threshold-gated, K-approval):**
 - Voting method stored on `Conversation.argument_vote_method` (default `'kApproval'`) + `argument_vote_data` JSON (default `{'K': 2}`)
-- Unlocks per-side when that side reaches ≥ 5 arguments
 - Before a participant can cast importance votes they must complete a "contribute-or-skip" gate:
   - For each side (pro and con), they either submit an argument OR click "nothing to add"
   - Must complete both sides before voting on either


### PR DESCRIPTION
## Summary

- **README.md** — remove "v2, in development" heading; mark v1 as retired, v2 as live; fix project structure block
- **v1/README.md** — first line: "current live deployment" → retired
- **v2/README.md** — "planning documents" → live app description
- **v2/architecture.md** — three data model / technology table corrections:
  - `ArgumentVote`: `useful (bool)` → `value (nullable integer)` (matches `db.py`)
  - `AdminRole`: `role (admin / moderator)` → `moderator only` (matches `ADMIN_ROLES = ('moderator',)`)
  - Moderation row: add Flask admin panel (statement approve/hide/seed, argument hide/delete)
- **v2/next_steps.md** — two stale references:
  - `PolisAdminClient` / `PolisAdminError` → current `PolisServerClient` / `PolisParticipantClient`
  - Remove "≥5 arguments" gate-unlock threshold — never implemented; gate is purely propose-or-skip

## Test plan

- [ ] Read each changed file and confirm the new text matches the deployed code
- [ ] No functional changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)