### PR TITLE
refactor: fix tests, remove dead locals, deduplicate polis_admin (steps 1–4)

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -331,7 +331,7 @@ def _proxy_to_particiapi(pa_path: str):
             data=request.form if not request.is_json else None,
             timeout=10,
         )
-    except requests.RequestException as exc:
+    except requests.RequestException:
         current_app.logger.exception('Particiapi proxy error')
         abort(502)
 
@@ -776,7 +776,6 @@ def _register_routes(app: Flask) -> None:
         On subsequent views: append any new arguments at a random position.
         Commits to DB if any change is made.
         """
-        import random
         state = ArgumentSideState.query.filter_by(
             participant_id=participant_id,
             featured_statement_id=fs_id,
@@ -817,7 +816,6 @@ def _register_routes(app: Flask) -> None:
         Moderators see hidden arguments (marked); participants never see them.
         Order is deterministically randomised per participant.
         """
-        from sqlalchemy.orm import joinedload
         fss = (FeaturedStatement.query
                .filter_by(conversation_id=conv.id, confirmed_by_admin=True)
                .options(joinedload(FeaturedStatement.arguments))
@@ -983,7 +981,7 @@ def _register_routes(app: Flask) -> None:
     @login_required
     def argument_submit(slug, fs_id):
         conv, part = _require_arg_participation(slug)
-        fs   = FeaturedStatement.query.filter_by(
+        FeaturedStatement.query.filter_by(
             id=fs_id, conversation_id=conv.id).first_or_404()
         side = request.form.get('side', '').strip()
         body = nh3.clean(request.form.get('body', '').strip(), tags=frozenset())
@@ -1011,7 +1009,6 @@ def _register_routes(app: Flask) -> None:
 
         # Insert new argument at a random position in this participant's display order.
         # Create ArgumentSideState now if the participant hasn't visited the page yet.
-        import random
         state = ArgumentSideState.query.filter_by(
             participant_id=part.participant_id,
             featured_statement_id=fs_id,
@@ -1444,9 +1441,8 @@ def _register_routes(app: Flask) -> None:
     @app.get('/admin/conversations/<int:conv_id>')
     @login_required
     def admin_conversation_detail(conv_id):
-        conv        = _require_mod_for_conv(conv_id)
-        participant = _current_participant()
-        conv_roles  = (AdminRole.query
+        conv       = _require_mod_for_conv(conv_id)
+        conv_roles = (AdminRole.query
                        .filter_by(conversation_id=conv_id)
                        .all())
         participants      = Participant.query.order_by(Participant.mw_username).all()
@@ -1478,7 +1474,7 @@ def _register_routes(app: Flask) -> None:
         if polis_configured:
             try:
                 polis_id = _polis_server_client().create_conversation(fields['title'], strict_moderation=True)
-            except PolisServerError as exc:
+            except PolisServerError:
                 current_app.logger.exception('Polis conversation creation failed')
                 flash('Could not create the Polis conversation. Check server logs for details.', 'error')
                 return redirect(url_for('admin'))
@@ -1670,7 +1666,7 @@ def _register_routes(app: Flask) -> None:
                 pending, approved, hidden = PolisParticipantClient(
                     current_app.config['PARTICIAPI_BASE']
                 ).get_statements(conv.polis_id)
-            except PolisParticipantError as exc:
+            except PolisParticipantError:
                 current_app.logger.exception('get_statements failed')
                 flash('Could not load statements. Check server logs.', 'error')
         try:
@@ -1696,7 +1692,7 @@ def _register_routes(app: Flask) -> None:
             abort(400)
         try:
             _polis_server_client().moderate(conv.polis_id, tid, mod)
-        except PolisServerError as exc:
+        except PolisServerError:
             current_app.logger.exception('moderate failed')
             flash('Moderation action failed. Check server logs for details.', 'error')
             return redirect(url_for('admin_conversation_statements', conv_id=conv_id))
@@ -1713,7 +1709,7 @@ def _register_routes(app: Flask) -> None:
         try:
             _polis_server_client().add_seed(conv.polis_id, text)
             flash('Seed statement added.', 'success')
-        except PolisServerError as exc:
+        except PolisServerError:
             current_app.logger.exception('add_seed failed')
             flash('Could not add seed statement. Check server logs for details.', 'error')
         return redirect(url_for('admin_conversation_statements', conv_id=conv_id))
@@ -1725,7 +1721,7 @@ def _register_routes(app: Flask) -> None:
         enabled = request.form.get('strict_moderation') == '1'
         try:
             _polis_server_client().set_strict_moderation(conv.polis_id, enabled)
-        except PolisServerError as exc:
+        except PolisServerError:
             current_app.logger.exception('set_strict_moderation failed')
             flash('Could not update moderation settings. Check server logs for details.', 'error')
         return redirect(url_for('admin_conversation_statements', conv_id=conv_id))

--- a/v2/polis_admin.py
+++ b/v2/polis_admin.py
@@ -244,19 +244,13 @@ class PolisServerClient:
                 return slug
         raise PolisServerError('Polis returned no usable zinvite in response.')
 
-    def update_conversation_settings(self, conversation_id: str, **kwargs) -> None:
-        """Update Polis-side conversation settings.
-
-        Accepted kwargs: strict_moderation, vis_type, auth_needed_to_vote,
-        auth_needed_to_write, is_active, topic, description, and other Polis
-        PUT /api/v3/conversations fields.
-        """
+    def set_strict_moderation(self, conversation_id: str, enabled: bool) -> None:
         sess, auth_headers = self._login()
         headers = {**self._HEADERS, **auth_headers}
         try:
             resp = sess.put(
                 f'{self._base}/api/v3/conversations',
-                json={'conversation_id': conversation_id, **kwargs},
+                json={'conversation_id': conversation_id, 'strict_moderation': enabled},
                 headers=headers,
                 timeout=10,
             )
@@ -267,9 +261,6 @@ class PolisServerClient:
                 f'Polis conversation settings update failed (HTTP {resp.status_code}): '
                 f'{resp.text[:300]}'
             )
-
-    def set_strict_moderation(self, conversation_id: str, enabled: bool) -> None:
-        self.update_conversation_settings(conversation_id, strict_moderation=enabled)
 
     # ── Statements ────────────────────────────────────────────────────────────
 
@@ -324,6 +315,30 @@ class PolisServerClient:
 
     # ── Direct Postgres reads ─────────────────────────────────────────────────
 
+    def _pg_query(self, sql: str, params: tuple, label: str) -> list[tuple] | None:
+        """Run a parameterised Postgres query and return all rows, or None on failure.
+
+        Returns None when db_url is absent, psycopg2 is unavailable, or the
+        query raises. Callers are responsible for their own zinvite guard.
+        """
+        try:
+            import psycopg2
+        except ImportError:
+            logger.exception('psycopg2 not available — %s unavailable', label)
+            return None
+        try:
+            conn = psycopg2.connect(self._db_url)
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(sql, params)
+                    rows = cur.fetchall()
+            finally:
+                conn.close()
+        except Exception:
+            logger.exception('Postgres %s failed', label)
+            return None
+        return rows
+
     def get_statements(self, zinvite: str) -> tuple[list, list, list] | None:
         """Return (pending, approved, hidden) from Postgres, or None if unavailable.
 
@@ -332,21 +347,9 @@ class PolisServerClient:
         """
         if not self._db_url or not _SAFE_ZINVITE.match(zinvite or ''):
             return None
-        try:
-            import psycopg2
-        except ImportError:
-            logger.exception('psycopg2 not available — falling back to Particiapi')
-            return None
-        try:
-            conn = psycopg2.connect(self._db_url)
-            try:
-                with conn.cursor() as cur:
-                    cur.execute(_STATEMENTS_SQL, (zinvite,))
-                    rows = cur.fetchall()
-            finally:
-                conn.close()
-        except Exception:
-            logger.exception('Postgres get_statements failed — falling back to Particiapi')
+        rows = self._pg_query(_STATEMENTS_SQL, (zinvite,),
+                              'get_statements — falling back to Particiapi')
+        if rows is None:
             return None
         pending, approved, hidden = [], [], []
         for r in rows:
@@ -377,21 +380,9 @@ class PolisServerClient:
         """
         if not self._db_url or not _SAFE_ZINVITE.match(zinvite or ''):
             return None
-        try:
-            import psycopg2
-        except ImportError:
-            logger.exception('psycopg2 not available — get_featured_candidates unavailable')
-            return None
-        try:
-            conn = psycopg2.connect(self._db_url)
-            try:
-                with conn.cursor() as cur:
-                    cur.execute(_FEATURED_CANDIDATES_SQL, (zinvite, max_statements))
-                    rows = cur.fetchall()
-            finally:
-                conn.close()
-        except Exception:
-            logger.exception('Postgres get_featured_candidates failed')
+        rows = self._pg_query(_FEATURED_CANDIDATES_SQL, (zinvite, max_statements),
+                              'get_featured_candidates')
+        if rows is None:
             return None
         return [
             {'tid': r[0], 'text': r[1], 'is_seed': r[2],
@@ -403,22 +394,10 @@ class PolisServerClient:
         """Return conversation stats from Polis Postgres, or None if unavailable."""
         if not self._db_url or not _SAFE_ZINVITE.match(zinvite or ''):
             return None
-        try:
-            import psycopg2
-        except ImportError:
-            logger.exception('psycopg2 not available — get_polis_stats unavailable')
+        rows = self._pg_query(_POLIS_STATS_SQL, (zinvite,), 'get_polis_stats')
+        if rows is None:
             return None
-        try:
-            conn = psycopg2.connect(self._db_url)
-            try:
-                with conn.cursor() as cur:
-                    cur.execute(_POLIS_STATS_SQL, (zinvite,))
-                    row = cur.fetchone()
-            finally:
-                conn.close()
-        except Exception:
-            logger.exception('Postgres get_polis_stats failed')
-            return None
+        row = rows[0] if rows else None
         if not row or len(row) < 6:
             return None
         try:

--- a/v2/tests/test_admin.py
+++ b/v2/tests/test_admin.py
@@ -1,7 +1,10 @@
 """Tests for admin conversation management, roles, and phase toggles."""
+from unittest.mock import patch
+
 import pytest
 
 from db import AdminRole, Conversation, ConversationInvite, Participation, db
+from polis_admin import PolisServerError
 
 
 @pytest.fixture
@@ -30,16 +33,18 @@ def test_admin_index_accessible_to_global_admin(admin_client):
 # ── Conversation CRUD ─────────────────────────────────────────────────────────
 
 def test_create_conversation(admin_client):
-    resp = admin_client.post('/admin/conversations/new', data={
-        'slug': 'new-conv',
-        'polis_id': 'new1234567',
-        'title': 'New Conversation',
-        'access_policy': 'public',
-    })
+    with patch('app.PolisServerClient.create_conversation',
+               return_value='newpolis12'):
+        resp = admin_client.post('/admin/conversations/new', data={
+            'slug': 'new-conv',
+            'title': 'New Conversation',
+            'access_policy': 'public',
+        })
     assert resp.status_code == 302
     conv = Conversation.query.filter_by(slug='new-conv').first()
     assert conv is not None
     assert conv.title == 'New Conversation'
+    assert conv.polis_id == 'newpolis12'
     assert conv.active is True
 
 
@@ -53,14 +58,17 @@ def test_create_conversation_invalid_slug_rejected(admin_client):
     assert resp.status_code == 400
 
 
-def test_create_conversation_invalid_polis_id_rejected(admin_client):
-    resp = admin_client.post('/admin/conversations/new', data={
-        'slug': 'good-slug',
-        'polis_id': 'bad id!',
-        'title': 'Test',
-        'access_policy': 'public',
-    })
-    assert resp.status_code == 400
+def test_create_conversation_polis_failure_redirects(admin_client):
+    """Polis server error on creation → redirect to admin with flash, no conv written."""
+    with patch('app.PolisServerClient.create_conversation',
+               side_effect=PolisServerError('test error')):
+        resp = admin_client.post('/admin/conversations/new', data={
+            'slug': 'should-not-exist',
+            'title': 'Test',
+            'access_policy': 'public',
+        })
+    assert resp.status_code == 302
+    assert Conversation.query.filter_by(slug='should-not-exist').first() is None
 
 
 def test_edit_conversation(admin_client, conv):

--- a/v2/tests/test_arguments.py
+++ b/v2/tests/test_arguments.py
@@ -311,7 +311,8 @@ def test_moderator_can_delete_argument(admin_client, arg_conv, arg_part, fs,
                    body='To be deleted.', side='pro')
     db.session.add(arg)
     db.session.commit()
-    resp = admin_client.post(f'/c/arg-conv/arguments/{arg.id}/delete')
+    resp = admin_client.post(
+        f'/admin/conversations/{arg_conv.id}/arguments/{arg.id}/delete')
     assert resp.status_code == 302
     assert db.session.get(Argument, arg.id) is None
 
@@ -321,7 +322,8 @@ def test_participant_cannot_delete_argument(auth_client, arg_conv, arg_part, fs,
                    body='Should survive.', side='pro')
     db.session.add(arg)
     db.session.commit()
-    resp = auth_client.post(f'/c/arg-conv/arguments/{arg.id}/delete')
+    resp = auth_client.post(
+        f'/admin/conversations/{arg_conv.id}/arguments/{arg.id}/delete')
     assert resp.status_code == 403
     assert db.session.get(Argument, arg.id) is not None
 

--- a/v2/tests/test_auth.py
+++ b/v2/tests/test_auth.py
@@ -19,10 +19,11 @@ def test_login_with_oauth_redirects_to_wikimedia(client, app):
     assert 'code_challenge' in resp.headers['Location']
 
 
-def test_oauth_callback_state_mismatch_returns_400(client):
-    """Bad state in callback → 400, no session set."""
+def test_oauth_callback_state_mismatch_redirects_to_login(client):
+    """Bad state in callback → redirect to /login, no session set."""
     resp = client.get('/oauth-callback?code=abc&state=bad-state')
-    assert resp.status_code == 400
+    assert resp.status_code == 302
+    assert '/login' in resp.headers['Location']
     with client.session_transaction() as sess:
         assert 'username' not in sess
 

--- a/v2/tests/test_polis_admin.py
+++ b/v2/tests/test_polis_admin.py
@@ -93,7 +93,7 @@ def _make_stats_client(db_rows=None, db_error=None):
     if db_error:
         cur.execute.side_effect = db_error
     else:
-        cur.fetchone.return_value = db_rows
+        cur.fetchall.return_value = [db_rows] if db_rows is not None else []
     return client, mock_conn
 
 


### PR DESCRIPTION
Implements refactor plan steps 1–4. Each step is a clean, independently-verifiable change. No behaviour is altered.

## Step 1 — Green test suite (5 → 0 failures)

Three test files were drifted from code changes made since they were written:

- **`test_auth`** — `test_oauth_callback_state_mismatch` asserted HTTP 400; code now redirects 302 to `/login` (changed in `a46905f`). Renamed and asserts 302 + `/login` in `Location`.
- **`test_arguments`** — delete tests POSTed to `/c/<slug>/arguments/<id>/delete`; route moved to `/admin/conversations/<conv_id>/arguments/<id>/delete` (`64df218`). Updated URLs.
- **`test_admin`** — `test_create_conversation` hit the real Polis server (refused connection) because `v2/.env` is loaded at import time and sets `POLIS_SERVER_URL`. Fixed with `patch('app.PolisServerClient.create_conversation', return_value='newpolis12')`. Replaced `test_create_conversation_invalid_polis_id_rejected` (tests a fallback path that is no longer reached when Polis is configured) with `test_create_conversation_polis_failure_redirects` which tests the real failure path.

## Step 2 — Dead locals and redundant imports

- 6 `except ... as exc:` bindings where `exc` was never read (only `logger.exception()` called, which captures the active exception automatically). Dropped the binding.
- `fs =` in `argument_submit` — `first_or_404()` side effect is the point; binding unused.
- `participant =` in `admin_conversation_detail` — never read after assignment.
- `import random` inside two functions + `from sqlalchemy.orm import joinedload` inside one function — all three already imported at module top.

## Step 3 — Inline single-caller indirection

`update_conversation_settings(**kwargs)` in `polis_admin.py` had exactly one caller: `set_strict_moderation`. Inlined the PUT body directly into `set_strict_moderation` and deleted the generic wrapper.

## Step 4 — Deduplicate psycopg2 boilerplate

`get_statements`, `get_featured_candidates`, and `get_polis_stats` each contained an identical block: `import psycopg2` fallback, `connect / cursor / fetchall / finally close / except log return None`. Extracted to `_pg_query(sql, params, label)` on `PolisServerClient`. Each method now contains only its row-shaping logic.

Updated `_make_stats_client` test helper to mock `fetchall` instead of `fetchone` (consistent with the shared helper using `fetchall`).

## Test results

```
108 passed, 0 failed (was 5 failed before)
```

## Test plan
- [x] `pytest` from `v2/` — 108 passed, 0 failed
- [x] `ruff check app.py --select F401,F811,F841` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)