### PR TITLE
audit: add codebase audit, runtime audit, and refactor plan

### DIFF
--- a/v2/audit/codebase-audit.md
+++ b/v2/audit/codebase-audit.md
@@ -1,0 +1,335 @@
+# wiki-polis — Codebase Audit (read-only, external)
+
+Audit date: 2026-05-31. Scope: entire `wiki-polis/` tree including gitignored
+folders and `.claude/`. Method: direct reading + `ruff` + `vulture` + `pytest`
++ `git`. Facts and evidence only; no recommendations.
+
+## Tooling detected
+
+- **Stack:** Python 3 / Flask. Two parallel Flask apps (root + `v2/`), SQLAlchemy
+  + Flask-SQLAlchemy, Flask-Migrate/Alembic, Flask-Session, Flask-WTF (v2 only),
+  Flask-Limiter (v2 only). Dependency manager: `uv` (`uv.lock` present in root and `v2/`).
+- **DB drivers:** `pymysql` (MariaDB/ToolsDB), `psycopg2-binary` (Polis Postgres, v2 only).
+- **Front end:** server-rendered Jinja2 + a vendored web-component bundle
+  (`v2/static/particiapp-web-components.js`, `particiapp-web-client.js`).
+- **Tests:** `pytest`, with `playwright` listed as a v2 dev dep.
+- **Audit tools available locally:** `ruff` (installed), `vulture` (run via `uvx`).
+  `knip`, `ts-prune`, `depcheck`, `madge`, `jscpd`, `pydeps` are **not installed**
+  (no JS/TS build graph to analyze anyway — the JS is a single vendored bundle).
+- **Vendored / non-source trees present in the working dir:** `.venv/`,
+  `v2/.venv/` (Python 3.14 site-packages), `tmp/node_modules/` (puppeteer +
+  deps), `__pycache__/`. These dominate the raw file counts
+  (2435 `.py`, 1507 `.js`, 1456 `.ts`) but are dependencies, not project code.
+  Non-vendored project Python totals ~6,167 lines.
+
+---
+
+## 1. What it actually does
+
+There are **two complete, independent Flask applications** in this repo.
+
+### Root app (`app.py` 618 lines, `db.py` 99 lines, `templates/`, `static/`)
+`app.py:1-6` describes itself as "Flask application for wiki-polis." It is a thin
+wrapper around a **hosted pol.is** conversation behind Wikimedia OAuth:
+- OAuth2 PKCE login against `meta.wikimedia.org` (`app.py:347-434`).
+- Conversation/Participation/Invite management; admin UI with participant search
+  + pagination (`app.py:444-464`), role grants (`admin`/`moderator`/`curator`,
+  `app.py:521`), per-conversation invite lists.
+- The conversation page (`app.py:289-306`) renders `index.html` and passes a raw
+  `xid` to the template — voting happens in an embedded hosted pol.is widget.
+- DB models: `Participant`, `Conversation`, `Participation`, `AdminRole`,
+  `ModAction`, `ConversationInvite` (`db.py`). `ModAction` is defined but never
+  used in `app.py` (imported, then unused — see §3).
+
+### v2 app (`v2/app.py` 1,897 lines, `v2/db.py` 226, `v2/polis_admin.py` 434)
+`v2/app.py:1-3` "Flask application for wiki-polis v2." A much larger system that
+**self-hosts** Polis via Particiapi and proxies voting through Flask:
+- Same OAuth2 PKCE login (`v2/app.py:1326-1417`).
+- A **statement-voting + argument-mapping** workflow: participants accept a
+  conversation under a generated pseudonym (`coolname`), vote via a proxied
+  Particiapi web component, optionally submit new statements under a quota, and
+  on "featured" statements propose/skip/vote pro-and-con arguments behind a gate
+  (`_build_featured_data` `v2/app.py:811-898`; argument routes `982-1173`).
+- A **browser↔Flask↔Particiapi reverse proxy** (`_proxy_to_particiapi`
+  `v2/app.py:278-359`) that renames the session cookie to `pa_session`, filters
+  query params, and rewrites a 403-on-`/results/` into an empty 200.
+- **Server-side Polis admin** (`v2/polis_admin.py`): conversation creation,
+  statement moderation, strict-moderation toggle, seed statements via Polis
+  `/api/v3` (`PolisServerClient`), plus **direct Postgres reads** for stats and
+  featured-statement candidates (raw SQL, `_STATEMENTS_SQL` etc.).
+- An **opt-in identity reveal** mechanism with a cooldown/nullify timeline
+  (`_REVEAL_COOLDOWN_DAYS=30`, `_REVEAL_NULLIFY_DAYS=30`, `v2/app.py:58-78`,
+  `919-964`, `1267-1322`).
+- Phase toggles per conversation (`phase_submission`, `phase_personal_results`,
+  `phase_argument_mapping`, `phase_public_results`, `v2/db.py:59-62`).
+- `/health` endpoint (`v2/app.py:1872-1891`).
+
+### Which app actually runs in production
+Despite `README.md:40` labelling root `app.py` as "Flask app (v1, live)" and
+`README.md:30`/`v1/README.md:3` calling v1 "the current live deployment," the
+**deploy path runs v2**:
+- `wsgi.py:5-7` inserts `v2/` onto `sys.path` and does `from app import app` —
+  i.e. it loads `v2/app.py`, not root `app.py`.
+- `deploy.sh:2` "Deploy wiki-polis v2"; `deploy.sh:36` `pip install -e ~/wiki-polis/v2`;
+  `deploy.sh:59-60` runs migrations from `~/wiki-polis/v2`.
+- `v2/deployment.md:270` `ln -s ~/wiki-polis/v2 ~/www/python/src`.
+
+No deploy artifact references root `app.py`. (See §6 for the README/reality drift.)
+
+---
+
+## 2. Competing implementations
+
+### 2a. Two whole apps implementing the same concerns
+Root and `v2/` define **28 identically-named functions** (`comm` on the two files):
+`_read_secret`, `_sanitise_text`, `_valid_polis_id`, `_valid_slug`,
+`_parse_conversation_form`, `_current_participant`, `_is_emailable`,
+`login_required`, `admin_required`, `_check_conversation_access`,
+`create_app`, `_register_routes`, `_inject_globals`, `index`, `login`, `logout`,
+`oauth_callback`, `accept`, `accept_post`, `admin`, `admin_conversation_new`,
+`admin_conversation_edit`, `admin_conversation_invites`, `admin_invite_add`,
+`admin_invite_remove`, `dev_login`, `conversation`, `wrapper`.
+The two implementations differ (e.g. `_read_secret` path is
+`/run/secrets/{TOOL_NAME}/` in root `app.py:59` vs hard-coded
+`/run/secrets/wiki-polis/` in `v2/app.py:49`; `_current_participant` caches on `g`
+in v2 `v2/app.py:129-137` but not in root `app.py:95-100`).
+
+### 2b. Authorization: global decorator vs per-conversation check
+- `@admin_required` (global admin only) — 10 occurrences in `v2/app.py`
+  (e.g. `1429`, `1468`, `1500`, `1517`, `1528`, `1541`, `1553`, `1569`, `1578`, `1607`).
+- `_require_mod_for_conv(conv_id)` (per-conversation moderator-or-global) — 14
+  occurrences (e.g. `1447`, `1617`, `1628`, `1649`, `1661`, `1699`, `1726`, `1742`,
+  `1777`, `1809`, `1828`, `1847`, `1862`).
+  Several admin POST routes (invites add/remove `1625/1646`, statement moderate
+  `1696`, featured add/remove `1825/1844`) use **only** `@login_required` +
+  `_require_mod_for_conv`, while conversation new/edit/pause/close/phases use
+  `@admin_required`.
+- A third variant is the inline `_can_moderate(conv)` check inside
+  `argument_hide`/`argument_unhide` (`v2/app.py:1153`, `1166`).
+- Root `app.py` uses a different role model again: `_is_admin()`
+  (`app.py:183-188`) reads `participant.is_admin`; v2 uses `is_global_admin`.
+
+### 2c. CSRF protection: global token vs origin check
+- Most v2 POST routes rely on Flask-WTF global CSRF (`csrf.init_app`, `v2/app.py:463`).
+- Two endpoints are `@csrf.exempt` and instead call `_validate_same_origin()`
+  (Sec-Fetch-Site / Origin check): `conversation_statement_new` (`1179-1184`)
+  and `proxy_particiapi` (`1261`). `_proxy_to_particiapi` also calls it inline
+  (`294`).
+
+### 2d. Data access to Polis statements — two clients, two shapes
+The same "get statements" concern has two implementations returning the same
+`(pending, approved, hidden)` tuple shape but different dict keys:
+- `PolisParticipantClient.get_statements` (HTTP, `v2/polis_admin.py:128-141`):
+  all statements forced into `approved`; dict key `txt`; pending/hidden always `[]`.
+- `PolisServerClient.get_statements` (raw Postgres, `v2/polis_admin.py:327-368`):
+  real `mod` state into pending/approved/hidden; dict has `txt`, `mod`,
+  `agree_count`, etc.
+`admin_conversation_statements` (`v2/app.py:1665-1672`) tries the Postgres one,
+then falls back to the HTTP one. Statement text is read with **two different key
+conventions** across call sites: `s.get('txt','')` (`v2/app.py:833`) vs
+`s.get('text') or s.get('txt','')` (`v2/app.py:1761`, `1801`).
+
+### 2e. Statement-text retrieval, three call sites
+`_build_featured_data` (`v2/app.py:829-833`), `_backfill_statement_texts`
+(`v2/app.py:1753-1772`), and `_fetch_statement_text` (`v2/app.py:1795-1804`) each
+independently instantiate `PolisParticipantClient`, call `get_statements`, and
+build a tid→text map — three near-duplicate blocks.
+
+### 2f. AJAX vs form response handling
+Argument routes branch on `request.headers.get('X-Requested-With') == 'fetch'`
+to return JSON vs redirect, repeated in `argument_submit`, `argument_skip`,
+`argument_vote`, `argument_unvote` (`v2/app.py:999-1001`, `1064-1066`,
+`1091-1131`, `1145-1147`). `conversation_statement_new` uses a different
+convention (always JSON, `1201`, `1245-1249`).
+
+### 2g. Postgres connection boilerplate, three copies
+`get_statements`, `get_featured_candidates`, `get_polis_stats`
+(`v2/polis_admin.py:340-350`, `385-395`, `406-421`) each repeat the same
+`import psycopg2 / connect / cursor / finally: close / except: log+return None`
+block verbatim.
+
+### 2h. `import` style: top-level vs in-function re-import
+`import random` at `v2/app.py:10` is **re-imported inside functions** at
+`v2/app.py:779` and `1014`; `from sqlalchemy.orm import joinedload` at top
+(`:29`) is re-imported at `:820`. (`subprocess` `:366` and `pathlib` `:552` are
+function-local imports with no top-level counterpart.)
+
+### 2i. DB-write idempotency / commit-error handling
+Variants coexist: bare `db.session.commit()` (most routes);
+`try/except IntegrityError → rollback + re-render` (`accept_post`
+`v2/app.py:753-760`); `try/except Exception → rollback` silently
+(`admin_invite_add` `v2/app.py:1640-1644`); `with_for_update()` row lock
+(`conversation_statement_new` `v2/app.py:1195-1197`).
+
+### 2j. Datetime handling
+`v2/db.py:7-9` documents storing **naive UTC**; code mixes
+`datetime.now(timezone.utc)` (aware) for writes and re-attaches tzinfo on read
+via `conv.closed_at.replace(tzinfo=timezone.utc)` (`v2/app.py:67`, `937`, `1284`,
+`1309`). `revealed_at` is written aware (`v2/app.py:1320`).
+
+---
+
+## 3. Dead / abandoned code
+
+### 3a. Broken/stale test module (uncollectable)
+`v2/tests/test_polis_admin.py:6` imports `PolisAdminClient, PolisAdminError,
+get_polis_stats` from `polis_admin` — **none of these names exist** (the module
+defines `PolisServerClient`, `PolisServerError`, `PolisParticipantClient`, and
+`get_polis_stats` is a *method*, not a module function). Pytest aborts collection:
+`ImportError: cannot import name 'PolisAdminClient'`. All 14 tests in this file
+are dead.
+
+### 3b. Six failing tests on current HEAD (test⇄code drift)
+Running `pytest --ignore=tests/test_polis_admin.py` from `v2/`:
+`6 failed, 87 passed, 24 warnings`.
+- `test_auth.py::test_oauth_callback_state_mismatch_returns_400` — asserts 400,
+  code now returns 302 (changed by commit `a46905f` "redirect to login instead
+  of 400"). `assert 302 == 400`.
+- `test_admin.py::test_create_conversation` and
+  `::test_create_conversation_invalid_polis_id_rejected` — fail because the test
+  config has Polis server vars set, so creation now attempts a live login to
+  `127.0.0.1:8001` and raises `PolisServerError` (Connection refused);
+  `assert None is not None`.
+- `test_arguments.py::test_moderator_can_delete_argument`,
+  `::test_participant_cannot_delete_argument`, `::test_admin_featured_remove` —
+  argument delete moved to admin panel (commit `64df218`); old routes/expectations
+  no longer hold.
+
+### 3c. Root app (`app.py`, `db.py`, `templates/`, `static/`)
+Not loaded by any deploy artifact (§1). `db.py:75` `ModAction` is **imported but
+unused** in `app.py:39` (ruff `F401`: "unused import 'ModAction'"; vulture 90%).
+Root templates `welcome.html`, `landing.html`, `index.html` are referenced only
+by root `app.py` (no references in `v2/`).
+
+### 3d. Unused locals (ruff `F841`, real positives in v2/app.py)
+`exc` assigned-but-unused in 6 `except ... as exc:` blocks that only call
+`logger.exception()`: lines `334`, `1481`, `1673`, `1717`, `1734`, `1746`.
+`fs` assigned-but-unused at `986`. `participant` assigned-but-unused at `1448`.
+(Plus 5 in `simulate_cats_vs_dogs.py`: `249-251`, `433`, `436`.)
+
+### 3e. Unimplemented vote method ("ranking") — schema present, code absent
+`v2/db.py:64-67` documents `argument_vote_method='kApproval'|'ranking'` and
+`ArgumentVote.value` (`v2/db.py:179-182`) is documented for ranking (rank
+position). No code ever sets `value` or branches on `'ranking'`; only `kApproval`
+(row-presence) is implemented. `value` is dead today.
+
+### 3f. Comment/default mismatch
+`v2/db.py:65` comment shows `vote_data={'k': 2}` (lowercase `k`), but the column
+default and all readers use uppercase `'K'` (`v2/db.py:67`,
+`v2/app.py:891`, `1098`, `1199`). The lowercase-`k` path is never read.
+
+### 3g. Vulture false positives (recorded for completeness)
+Vulture flags ~40 "unused function" in `v2/app.py` (all Flask route handlers
+registered by decorator) and ~25 "unused variable" in `v2/db.py` (SQLAlchemy
+columns/relationships). These are **not** dead — they are accessed via
+framework machinery, not direct references.
+
+### 3h. Working DB files committed-ignored but present on disk
+`v2/dev.db`, `v2/instance/dev.db`, `instance/dev.db`, `v2/screenshot.db` exist in
+the tree (gitignored via `*.db`). `instance/` is the root app's; `v2/instance/`
+is v2's.
+
+---
+
+## 4. Premature abstraction
+
+- **`update_conversation_settings(**kwargs)`** (`v2/polis_admin.py:247-269`) is a
+  generic Polis settings updater documenting many accepted fields, but its only
+  caller is `set_strict_moderation` (`v2/polis_admin.py:271-272`), which passes a
+  single field. `set_strict_moderation` in turn has one caller
+  (`v2/app.py:1745`). Two indirection layers for one concrete operation.
+- **`_proxy_to_particiapi`** (`v2/app.py:278-359`) is a module-level function with
+  a single caller, the one-line route `proxy_particiapi` (`v2/app.py:1262-1263`).
+- **`_backfill_statement_texts`** (`v2/app.py:1753-1772`): single caller
+  (`admin_conversation_featured` `1784`).
+- **`_git_version`** (`v2/app.py:364-373`): called once at import
+  (`_GIT_VERSION = _git_version()` `:375`).
+- **`_short_title`** (`v2/app.py:87-92`): single caller (`:881`).
+- `ADMIN_ROLES` is a one-element tuple `('moderator',)` (`v2/db.py:12`) used as if
+  extensible (Enum, membership checks `v2/app.py:1584`) but has exactly one value.
+
+---
+
+## 5. Test reality
+
+- **Suite:** `v2/tests/` — 9 files, 107 `def test_` functions total
+  (admin 18, arguments 32, polis_admin 14, conversations 15, reveal 13, auth 7,
+  security 8). Tests import `from app import create_app` / `from db import ...`,
+  i.e. they exercise **v2 only**. **The root app has no tests at all.**
+- **Current result:** `test_polis_admin.py` (14) is uncollectable (§3a); of the
+  rest, **87 pass, 6 fail** (§3b).
+- **Covered:** auth/session helpers, OAuth happy + several failure paths, access
+  policy (public/invite_only), pseudonym validation, argument gate/cap/hidden/own
+  rules (`test_arguments.py` is the largest, 32 tests), reveal-window state
+  transitions, several security checks (`test_security.py`: dev-DB isolation,
+  CSRF-exempt origin checks, path-traversal in proxy).
+- **Riskiest behavior with no/!broken coverage:**
+  - `polis_admin.py` Postgres reads and the raw SQL (`_STATEMENTS_SQL`,
+    `_FEATURED_CANDIDATES_SQL`, `_POLIS_STATS_SQL`) — the only test file targeting
+    this module (`test_polis_admin.py`) cannot import and references a removed API,
+    so the SQL/parse paths are effectively untested.
+  - `_proxy_to_particiapi` cookie-rename / 403→200 rewrite / param-filter logic
+    is exercised only indirectly (origin/traversal asserts in `test_security.py`);
+    the cookie mapping and upstream-error branches are not directly asserted.
+  - `conversation_statement_new` quota + `with_for_update` race path (`v2/app.py:
+    1177-1254`) — no concurrency test.
+  - `_nullify_expired_reveals` time-based nullification (`v2/app.py:62-78`) beyond
+    state labels.
+  - The `create_conversation`/moderation HTTP paths against the real Polis server
+    are unmocked in the failing admin tests (they hit `127.0.0.1:8001`).
+- **Deprecation noise:** tests emit `LegacyAPIWarning` for `Query.get()`
+  (SQLAlchemy 2.0) and `SESSION_FILE_DIR`/`FileSystemSessionInterface`
+  deprecations from Flask-Session.
+
+---
+
+## 6. Drift signal (git history)
+
+History: 141 commits total. Churn on core files:
+`v2/app.py` 42 commits, `v2/polis_admin.py` 16, `v2/db.py` 6;
+root `app.py` 6, root `db.py` 3 (root last touched 2026-05-10; v2 `app.py`
+2026-05-29).
+
+- **Argument/voting subsystem rewritten repeatedly.** 16 of the 42 `v2/app.py`
+  commits touch triad/vote/argument/statement/quota/phase/reveal, including a
+  visible back-and-forth: `7632efc` "Replace propose affordance with V2
+  three-option triad," `48b9a77` "Fix V2 triad regressions," `82eb9ec`/`a0dfe2a`
+  "Refine voting state machine," `f3dc972`/`d1d0851` quota/unlock formula,
+  `90b4f46` "Fix own-statement appearing in vote queue." The state machine and
+  gate logic (`v2/app.py:811-1254`) are the most-rewritten region.
+- **OAuth callback behavior flipped recently.** `a46905f` (HEAD) changed the
+  state-mismatch response from 400 to a 302 redirect; the test was not updated
+  (§3b) — a fresh drift between code and its test.
+- **API rename left a stale test.** `polis_admin.py` was reorganized into
+  `PolisParticipantClient` / `PolisServerClient`; `test_polis_admin.py` still
+  targets the pre-rename `PolisAdminClient` / `get_polis_stats` function (§3a).
+- **README vs reality (largest doc drift).** `README.md:9` "Architecture (v2, in
+  development)", `README.md:30` "`v1/` | Current live deployment",
+  `README.md:40` "app.py — Flask app (v1, live)", and `v1/README.md:3` "The
+  current live deployment" all assert root/v1 is live and v2 is unreleased —
+  while `wsgi.py`, `deploy.sh`, and `v2/deployment.md` all deploy **v2** (§1).
+  `v2/architecture.md:136` ("...working in v1") similarly frames v1 as the
+  shipped baseline.
+- **Access-policy model diverged between the two apps.** Root `db.py:11`
+  `ACCESS_POLICIES = ('public','link_based','invite_only')`; v2 `db.py:11`
+  `('public','invite_only')` — `link_based` was dropped in v2. Role sets also
+  diverged: root `('admin','moderator','curator')` (`app.py:521`) vs v2
+  `('moderator',)` (`v2/db.py:12`).
+- **Uncommitted working changes at audit time** (git status): modified
+  `v2/app.py`, `v2/templates/admin_featured.html`, `v2/templates/admin_statements.html`;
+  untracked `v2/phase_model_extension.md`.
+- **Structural growth without decomposition.** `_register_routes` in `v2/app.py`
+  is a single ~1,300-line nested function; ruff `C901` reports its cyclomatic
+  complexity at **182** (root `app.py`'s `_register_routes` is 46). `create_app`
+  (16), `_proxy_to_particiapi` (11), and `argument_vote` (11) also exceed the
+  threshold.
+
+---
+
+### Raw tool output references
+- `ruff check ... --select F401,F811,F841,F541` → unused `exc`/`fs`/`participant`
+  locals + unused `ModAction` import (details in §3c–3d).
+- `ruff check ... --select C901` → complexity figures in §6.
+- `uvx vulture --min-confidence 60` → route-handler/column false positives (§3g)
+  + the genuine `ArgumentVote.value`/`ranking` dead path corroborated by reading.
+- `pytest` (v2) → `1 error in collection` (test_polis_admin) + `6 failed, 87 passed`.

--- a/v2/audit/refactor-plan.md
+++ b/v2/audit/refactor-plan.md
@@ -46,7 +46,7 @@ block. Extracted to `_pg_query(sql, params, label)` on `PolisServerClient`.
 
 ## Step 5 — Lift non-route helpers to module level
 
-**GitHub issue:** #89  
+**GitHub issue:** #90  
 **Risk:** Medium | **Size:** M (~200 lines relocated, no logic change)
 
 `_register_routes` (`app.py:546`) is a 1,300-line closure with C901 = 177. It contains
@@ -71,7 +71,7 @@ drops materially; full test suite stays green.
 
 ## Step 6 — Consolidate statement-text fetch blocks
 
-**GitHub issue:** #90  
+**GitHub issue:** #89  
 **Risk:** Medium | **Size:** S-M (~40 lines)
 
 Three near-duplicate blocks each instantiate `PolisParticipantClient`, call

--- a/v2/audit/refactor-plan.md
+++ b/v2/audit/refactor-plan.md
@@ -1,0 +1,189 @@
+# wiki-polis v2 — Refactor Plan
+
+Generated 2026-05-31 from `codebase-audit.md` and `runtime-writes-audit.md`.
+Decision: **refactor, not rewrite** — the hard problems (OAuth PKCE, proxy cookie
+rename, argument gate, quota row-lock, reveal timeline) are solved and tested.
+
+Steps 1–4 landed in PR #88. Steps 5–9 are the structural blueprint decomposition.
+
+---
+
+## Steps 1–4 — Complete (PR #88)
+
+### Step 1 — Green test suite ✓
+
+Fixed 5 drifted tests, no production code changes.
+
+- `test_auth`: state-mismatch now asserts 302 → `/login` (code changed in `a46905f`)
+- `test_arguments`: delete route moved to `/admin/conversations/<id>/arguments/<id>/delete`
+- `test_admin`: mock `PolisServerClient.create_conversation`; replace stale
+  `invalid_polis_id_rejected` test with `polis_failure_redirects`
+
+**Result:** 108 passed, 0 failed (was 5 failed).
+
+### Step 2 — Dead locals and redundant imports ✓
+
+In `v2/app.py`:
+- 6 `except ... as exc:` bindings where `exc` was never read (lines 334, 1481, 1673,
+  1699, 1716, 1728 in baseline)
+- `fs =` in `argument_submit` — `first_or_404()` side effect is the point
+- `participant =` in `admin_conversation_detail` — never read
+- `import random` inside two functions + `from sqlalchemy.orm import joinedload` inside
+  one function — all already imported at module top
+
+### Step 3 — Collapse single-caller indirection ✓
+
+`update_conversation_settings(**kwargs)` in `polis_admin.py` had exactly one caller:
+`set_strict_moderation`. Inlined and deleted the generic wrapper.
+
+### Step 4 — Deduplicate psycopg2 boilerplate ✓
+
+`get_statements`, `get_featured_candidates`, `get_polis_stats` each duplicated the
+same `import psycopg2 / connect / cursor / fetchall / finally-close / except-log-return-None`
+block. Extracted to `_pg_query(sql, params, label)` on `PolisServerClient`.
+
+---
+
+## Step 5 — Lift non-route helpers to module level
+
+**GitHub issue:** #89  
+**Risk:** Medium | **Size:** M (~200 lines relocated, no logic change)
+
+`_register_routes` (`app.py:546`) is a 1,300-line closure with C901 = 177. It contains
+five functions that are not Flask route handlers and do not close over any local
+variable of `_register_routes`:
+
+| Function | Line (baseline) | Used by |
+|---|---|---|
+| `_get_or_create_side_state` | 772 | `_build_featured_data`, `argument_submit` |
+| `_build_featured_data` | 811 | `conversation` |
+| `_require_arg_participation` | 968 | all `argument_*` routes |
+| `_backfill_statement_texts` | 1735 | `admin_conversation_featured` |
+| `_fetch_statement_text` | 1776 | `admin_featured_confirm`, `admin_featured_add` |
+
+**Action:** Move all five to module level above `create_app`. No call-site edits
+needed — module-level names are in scope inside the closure.
+
+**Acceptance:** `ruff check app.py --select C901` shows complexity of `_register_routes`
+drops materially; full test suite stays green.
+
+---
+
+## Step 6 — Consolidate statement-text fetch blocks
+
+**GitHub issue:** #90  
+**Risk:** Medium | **Size:** S-M (~40 lines)
+
+Three near-duplicate blocks each instantiate `PolisParticipantClient`, call
+`get_statements`, and build a `tid → text` map:
+
+- `_build_featured_data` (`app.py:829-833`): uses `s.get('txt', '')`
+- `_backfill_statement_texts` (`app.py:~1742`): uses `s.get('text') or s.get('txt', '')`
+- `_fetch_statement_text` (`app.py:~1779`): uses `s.get('text') or s.get('txt', '')`
+
+The key convention is inconsistent between them. After Step 5 all three are at module
+level and can share one helper.
+
+**Action:** Add `_statement_text_map(conv_polis_id) -> dict[int, str]` at module level,
+using `s.get('text') or s.get('txt', '')` as the unified key rule. Rewrite the three
+callers to use it. Add a unit test asserting both `txt`-only and `text`-only payloads
+resolve correctly.
+
+**Acceptance:** New test passes; featured-data and backfill tests stay green.
+
+---
+
+## Step 7 — Extract proxy + statement-submit into a blueprint
+
+**GitHub issue:** #91  
+**Risk:** High | **Size:** M (~120 lines relocated + new tests)
+
+`_proxy_to_particiapi` is a module-level function with a single thin route caller
+(`proxy_particiapi`). The CSRF-exempt `conversation_statement_new` shares the same
+same-origin-check and `pa_session` cookie machinery. This is the highest-security
+cluster and benefits from being reviewed in isolation.
+
+**Affected routes:**
+- `POST/GET/PUT /proxy/particiapi/<path>`
+- `POST /c/<slug>/statements/new`
+
+**Key constraints:**
+- Both routes are `@csrf.exempt` with `_validate_same_origin()` as the compensating
+  control. Must be explicitly exempted on the blueprint.
+- The `pa_session` ↔ `session` rename is documented in `runtime-writes-audit.md` Step 6.
+  Behaviour must be byte-identical after extraction.
+- `SET-Cookie: pa_session=…` (Particiapi rename) and `session=…` (Flask session) must
+  both appear in the response.
+
+**Acceptance:** `test_security.py` green with no assertion changes; new direct tests
+for the 403→200 `/results/` rewrite and cookie rename pass.
+
+---
+
+## Step 8 — Extract admin routes into a blueprint
+
+**GitHub issue:** #92  
+**Risk:** High | **Size:** L (~400 lines relocated)
+
+All `/admin/…` routes (`app.py:1427-1844`, ~17 route handlers) into `Blueprint('admin')`.
+
+**Key constraints:**
+- Two auth conventions coexist and must not be merged in this step:
+  - `@admin_required` (global admin only): conversation new/edit/pause/close/phases,
+    global-admin add/remove, role add/remove
+  - `_require_mod_for_conv` (per-conversation moderator or global): invites, statements,
+    featured, argument-delete
+- `url_for` targets must not change. Use explicit `endpoint=` on each route or name the
+  blueprint to preserve the existing endpoint namespace.
+
+**Acceptance:** `test_admin.py` (18 tests) green with zero assertion changes.
+
+---
+
+## Step 9 — Extract participant-facing routes into a blueprint
+
+**GitHub issue:** #93  
+**Risk:** High | **Size:** L (~450 lines relocated)
+
+Routes: `accept`/`accept_post`/`accept_pseudonyms`, `conversation`, the full
+`argument_*` cluster, `reveal_identity`/`reveal_identity_post`.
+
+Auth/OAuth/`index`/`logout`/`health`/dev-login routes stay in `app.py` — they are
+tied to `_dev_login_user`/`_on_toolforge` closure variables in `_register_routes` and
+cannot be moved without a larger refactor.
+
+**Key constraints:**
+- The argument routes redirect with `url_for('conversation', slug=...) + '#tab-arguments'`
+  — preserve the `conversation` endpoint name.
+- The gate state machine (pro_gate/con_gate), K-cap (409), own/hidden (403) logic in
+  `argument_vote` must move verbatim. Covered by `test_arguments.py` (32 tests).
+- The `with_for_update()` row-lock in `conversation_statement_new` must be preserved.
+
+**Acceptance:** `test_arguments.py` (32), `test_conversations.py` (15), `test_reveal.py`
+(13) all green with zero assertion changes.
+
+---
+
+## Step 10 — Fix k/K comment in db.py
+
+**GitHub issue:** N/A — fold into any nearby PR  
+**Risk:** Low | **Size:** S (1 line)
+
+`v2/db.py:65` comment shows `vote_data={'k': 2}` (lowercase) but the column default
+and every reader use `'K'` (uppercase). The lowercase path is never read.
+
+**Action:** Correct the comment to `{'K': 2}`.
+
+---
+
+## Scope guard
+
+This plan does **not**:
+- Touch the data model (`db.py` models), migrations, or the `ArgumentVote.value` /
+  `ranking` dead path
+- Unify the two authorization conventions (`@admin_required` vs `_require_mod_for_conv`)
+- Unify the two CSRF conventions (the proxy's origin-check exemption is intentional)
+- Touch the retired root `app.py` / `db.py` / `templates/`
+- Reconcile naive vs aware datetime storage
+
+Each of those is a behaviour or product question, not a structure question.

--- a/v2/audit/runtime-writes-audit.md
+++ b/v2/audit/runtime-writes-audit.md
@@ -1,0 +1,425 @@
+# wiki-polis v2 — Runtime Writes Audit
+
+Audit date: 2026-05-31.
+Baseline: `auditbranch/202605` @ `eaa47a9` (Merge PR #86 fix/proxy-next-url-after-login).
+App: Flask dev server, port 5001, `FLASK_DEBUG=1`, `DEV_FAKE_LOGIN=1`.
+DB: `v2/instance/dev.db` (SQLite, disposable).
+Particiapi: `http://127.0.0.1:8002` (Docker, healthy). Polis server: `http://127.0.0.1:8003`.
+Non-admin participant: `dev-user-1` (mw_user_id=-1, id=2, is_global_admin=0).
+Admin participant: `DevUser` (id=1, listed in ADMIN_USERS env var).
+
+---
+
+## HEAD verification
+
+```
+Resolved HEAD: eaa47a97a343ee05142a5a369a1693f72087efda  eaa47a9
+Subject: Merge pull request #86 from lgelauff/fix/proxy-next-url-after-login
+```
+
+`main` was 3 commits ahead; stashed `v2/app.py`, `v2/templates/admin_featured.html`,
+`v2/templates/admin_statements.html` before checkout.
+
+---
+
+## Startup observations
+
+Flask log on start:
+```
+[WARNING] DEV MODE: SQLALCHEMY_DATABASE_URI forced to sqlite:///dev.db
+  (ignoring database-url secret / DATABASE_URL env)
+[WARNING] POLIS_PUBLIC_URL is not https:// — ignoring
+[UserWarning] Using the in-memory storage for tracking rate limits ...
+  not recommended for production use.
+```
+
+The DB isolation guard at `v2/app.py:392-402` fires correctly; dev.db in `instance/` is the
+live path (`sqlite:///dev.db` resolves relative to `v2/` → `v2/instance/dev.db`).
+Rate limiter state is in-process-memory only (default).
+
+---
+
+## Identifier map
+
+| Identifier | Column | Example value | Used by |
+|---|---|---|---|
+| URL slug | `conversations.slug` | `cats-vs-dogs-rtyhvm0czb` | Flask routes `/accept/<slug>`, `/c/<slug>` |
+| Polis zinvite | `conversations.polis_id` | `rtyhvm0czb` | Web component `conversation-id=`, proxy URL, Polis/Particiapi API calls |
+| Pseudonym | `participations.pseudonym` | `dainty-coot` | Template `data-my-pseudonym=`, argument `proposer` display |
+| xid | `participants.xid` | `4bc1ca6…` (sha256 of mw_user_id) | Passed to Particiapi as participant token; stored in session |
+
+**The URL slug and polis_id are distinct.** `/accept/<slug>` and `/c/<slug>` both resolve via
+`Conversation.query.filter_by(slug=slug)` (`v2/app.py:710`, `v2/app.py:905`). The web
+component on the conversation page receives `conversation-id="rtyhvm0czb"` (the `polis_id`),
+not the URL slug. The URL slug for the test conversation (`cats-vs-dogs-rtyhvm0czb`) embeds
+the polis_id as a suffix, but this is a naming convention in the test data, not a structural
+constraint — the slug field has its own unique constraint and value.
+
+---
+
+## Step 1 — POST /accept/\<slug\>
+
+**Request:** `POST /accept/cats-vs-dogs-rtyhvm0czb`, form fields:
+`csrf_token=<valid>`, `pseudonym=dainty-coot`, `notify_email=`, `notify_talk_page=`.
+
+**HTTP status:** 302 → `/c/cats-vs-dogs-rtyhvm0czb`.
+
+**DB write — `participations` table:**
+```
+id=3, participant_id=2, conversation_id=1,
+pseudonym="dainty-coot",
+accepted_at="2026-05-31 13:43:47.924365",
+notify_email=0, notify_talk_page=0,
+new_stmt_ids=[]
+```
+
+Tables written: `participations` (1 INSERT). No other tables.
+
+**First failed attempt (HTTP 400):** Initial `curl` attempt with `-c`/`-b` flags used
+stale CSRF token from a prior non-redirect GET. The second GET with `-L` follow-redirects
+produced a page with the session cookie active and a valid CSRF token. Observation: CSRF
+validation fires before pseudonym validation — an invalid CSRF returns 400 regardless of
+other field values.
+
+**No outbound calls** made for this route.
+
+**Side effect on `/c/<slug>` load:** Calling `GET /c/<slug>` after accept triggers
+`_build_featured_data` (`v2/app.py:811`), which creates `ArgumentSideState` rows as a side
+effect — one per (participant, featured_statement, side) combination. For 10 featured
+statements on conv_id=1, this created **20 rows** in `argument_side_states` (ids 21–40),
+all with `skipped=0` and `argument_order` pre-populated from existing arguments. This
+write occurs on the first GET of the conversation page, before any user action.
+
+---
+
+## Step 2 — Argument gate mechanics
+
+**Gate condition** (verified against `v2/app.py:1089-1095`):
+```
+pro_gate = bool(pro_proposed or (pro_state and pro_state.skipped))
+con_gate = bool(con_proposed or (con_state and con_state.skipped))
+if not (pro_gate and con_gate): → 403, reason="gate"
+```
+
+The gate is checked at the **vote** action, not on page load. Participants can see arguments
+but cannot vote until BOTH sides are unlocked for a given featured statement.
+
+**A side is unlocked by either:**
+1. Submitting an argument on that side (`pro_proposed` or `con_proposed` is set), or
+2. Explicitly skipping that side (`ArgumentSideState.skipped = True`).
+
+**Gate does NOT depend on Polis votes** (votes through the web component proxy). Polis voting
+and argument gating are completely independent state machines.
+
+**Verified gate state transitions:**
+
+| Action | pro_gate | con_gate | Vote attempt HTTP |
+|---|---|---|---|
+| Neither side done | False | False | 403 `reason="gate"` |
+| Pro skipped only | True | False | 403 `reason="gate"` |
+| Both sides skipped | True | True | 200 (vote succeeds) |
+
+**DB writes for skip (`v2/app.py:1038-1066`):**
+
+`POST /c/<slug>/arguments/<fs_id>/pro/skip` → HTTP 200 `{"ok":true}`
+DB: `argument_side_states` row for `(participant_id=2, fs_id=1, side='pro')` updated:
+`skipped: 0 → 1`. Idempotent: second skip call returns 200 with no change.
+
+**`ArgumentSideState` rows are created on page-load** (`_build_featured_data`), not on
+first skip. The skip endpoint finds the existing row and sets `skipped=True`.
+
+---
+
+## Step 3 — Argument writes
+
+### Argument submit (`v2/app.py:982-1036`)
+
+`POST /c/<slug>/arguments/<fs_id>/submit` with `side=pro`, `body=<text≤280 chars>`
+Headers: `X-Requested-With: fetch` (JSON path).
+
+**HTTP 200**, response shape: `{"ok": true, "id": <int>, "body": "<text>"}`.
+
+**DB writes:**
+1. `arguments` table: 1 INSERT — `(id=23, featured_statement_id=1, proposer_id=2, side='pro', hidden=0, body="Cats are low maintenance companions")`.
+2. `argument_side_states` table: UPDATE to `argument_order` for `(participant=2, fs=1, side='pro')` — new arg_id inserted at random position: `[23, 1]`.
+
+**Duplicate submit** (same participant, same FS, same side): returns existing argument without
+INSERT — `{"ok": true, "id": 23, "body": "..."}`. The `UNIQUE(featured_statement_id, proposer_id, side)` constraint on `arguments` is the enforcement point; the route checks with `.first()` before inserting (`v2/app.py:993-1001`).
+
+### Argument vote (`v2/app.py:1068-1131`)
+
+`POST /c/<slug>/arguments/<arg_id>/vote` with `X-Requested-With: fetch`.
+
+**HTTP 200**, response: `{"ok": true}`.
+
+**DB write:** `argument_votes` table: 1 INSERT — `(argument_id, participant_id, value=NULL)`.
+
+**`value` column confirmed NULL.** All 9 `argument_votes` rows for participant_id=2 have `value=''` (NULL). The ranking path (`value = rank position`) is never exercised; `argument_vote_data` has only `{"K": 2}` — no `vote_method: "ranking"` key in any conversation. Dead path confirmed at runtime.
+
+**Gate check fires at vote time** (`v2/app.py:1076-1095`): reads `ArgumentSideState` and
+`Argument` rows to compute `pro_gate`, `con_gate`. Aborts 403 `reason="gate"` if either is
+False.
+
+**Own-argument vote:** HTTP 403 `{"ok": false, "reason": "own"}`. DB not written.
+
+### K-cap enforcement (`v2/app.py:1097-1109`)
+
+K=2 (from `conv.argument_vote_data.get('K', 2)`). With 2 existing pro votes on fs_id=3
+(arg_ids 25, 26), voting on a 3rd pro argument (arg_id=27):
+
+**HTTP 409**, response: `{"ok": false, "reason": "cap"}`. DB not written.
+
+The cap is per-side per-FS, counted by querying all arguments for that (FS, side) and
+counting existing votes by this participant against those arg_ids.
+
+### Argument unvote (`v2/app.py:1133-1147`)
+
+`POST /c/<slug>/arguments/<arg_id>/unvote`.
+
+**HTTP 200**, response: `{"ok": true}`.
+
+**DB write:** `argument_votes` table: 1 DELETE matching `(participant_id, argument_id)`. If no
+vote existed, returns 200 silently (no-op).
+
+### Argument hide/unhide (`v2/app.py:1149-1173`)
+
+`POST /c/<slug>/arguments/<arg_id>/hide` — **mod-only** (checks `_can_moderate(conv)`).
+
+- Admin (DevUser): HTTP 302, `arguments.hidden` set `0→1` or `1→0`.
+- Non-mod with valid CSRF: HTTP 403. No DB write.
+- Non-mod with invalid/cross-session CSRF: HTTP 400 (CSRF check fires first).
+
+---
+
+## Step 4 — Statement submit + quota
+
+### Route: `POST /c/<slug>/statements/new` (`v2/app.py:1177-1254`)
+
+Decorated `@csrf.exempt`, validated via `_validate_same_origin()` (Sec-Fetch-Site /
+Origin header check).
+
+**Quota config:** `conv.argument_vote_data.get('new_stmt_max', 3)` — default 3. The test
+conversation has `argument_vote_data={"K": 2}` (no `new_stmt_max` key), so quota is 3.
+
+**Outbound calls per submission:**
+1. `POST http://127.0.0.1:8002/api/session?create=true` — gets `csrf_token` from Particiapi.
+2. `POST http://127.0.0.1:8002/api/conversations/rtyhvm0czb/statements/` with
+   `{"text": "..."}` and the Particiapi session cookie.
+
+Both calls made inside a single request handler; the Flask `with_for_update()` lock on the
+`participations` row (`v2/app.py:1195-1197`) spans both outbound calls and the DB update.
+
+**Response shape from Particiapi (passed through):**
+```json
+{"id": 34, "is_meta": false, "is_seed": false, "last_modified": "Sun, 31 May 2026 14:27:17 GMT"}
+```
+The `text` key is NOT returned in the passthrough response.
+
+**DB writes per successful submission:**
+`participations.new_stmt_ids` updated: `[] → [34] → [34,35] → [34,35,36]`.
+Each successful submission appends the Particiapi statement ID. No other table written.
+
+**Quota exceeded (4th submission):**
+HTTP 403, `{"error": "quota_exceeded"}`. DB not written. The quota check fires BEFORE
+the outbound Particiapi calls (`v2/app.py:1199-1201`).
+
+**HTTP status codes:**
+- Successful: 201 (Flask passes through Particiapi's 201).
+- Quota exceeded: 403 (Flask, before hitting Particiapi).
+- Particiapi unreachable: 502 (not exercised).
+
+---
+
+## Step 5 — Identity reveal
+
+### Route: `POST /c/<slug>/reveal` (`v2/app.py:1293-1322`)
+
+Requires: `conversation.closed_at` set, `age >= REVEAL_COOLDOWN_DAYS (30)`,
+`age < REVEAL_COOLDOWN_DAYS + REVEAL_NULLIFY_DAYS (60)`, `participation.public_username` is
+NULL, `confirm=1` in form.
+
+**Setup:** `closed_at` set to 35 days ago via direct DB write (window: [30, 60] days).
+
+**HTTP 302** on success → `/c/<slug>`.
+
+**DB write — `participations`:**
+```
+public_username: NULL → "dev-user-1"   (mw_username of the participant)
+revealed_at:     NULL → "2026-05-31 14:34:20.888256"  (naive UTC datetime)
+```
+
+`revealed_at` is written as a naive datetime via `datetime.now(timezone.utc)` but stored
+without timezone metadata — consistent with the rest of the schema (`v2/db.py:7-9`).
+
+**Edge cases verified:**
+
+| Condition | HTTP |
+|---|---|
+| `public_username` already set (double reveal) | 400 |
+| `age < REVEAL_COOLDOWN_DAYS` (1 day ago) | 400 |
+| `age >= COOLDOWN + NULLIFY` (65 days ago) | 400 |
+| `confirm` field absent | 302 → GET /c/<slug>/reveal (no reveal written) |
+
+All 400s are `abort(400)` — no response body. No DB write on any failed path.
+
+---
+
+## Step 6 — Proxy cookie rename
+
+### Route: `POST /proxy/particiapi/api/session` (`v2/app.py:1258-1263`, calls `_proxy_to_particiapi`)
+
+**Request direction (browser → Flask → Particiapi):**
+Code at `v2/app.py:303-305`:
+```python
+pa_cookie = request.cookies.get('pa_session')
+if pa_cookie:
+    forwarded_cookies['session'] = pa_cookie
+```
+Browser sends `pa_session=X`; Flask extracts the value and forwards as `session=X` to
+Particiapi. Verified by code; not observable directly in curl response headers from Flask.
+
+**Response direction (Particiapi → Flask → browser):**
+Code at `v2/app.py:350-357`:
+```python
+if 'session' in upstream.cookies:
+    flask_resp.set_cookie('pa_session', upstream.cookies['session'], ...)
+```
+Confirmed at runtime: response headers include:
+```
+Set-Cookie: pa_session=<value>; HttpOnly; Path=/; SameSite=Lax
+```
+No `Secure` flag — correct, since `secure=not current_app.debug` and debug=True.
+
+Flask's own session cookie is also set in the same response:
+```
+Set-Cookie: session=<value>; Expires=…; HttpOnly; Path=/; SameSite=Lax
+```
+
+**Two `Set-Cookie` headers coexist** in the response: `pa_session` (Particiapi's renamed
+session) and `session` (Flask's own session). These have different names and values and
+serve distinct purposes.
+
+**Response body shape** (from `POST /api/session`):
+```json
+{"authenticated": false, "csrf_token": "<token>"}
+```
+The csrf_token is Particiapi's token, used in `X-CSRF-Token` headers on subsequent
+Particiapi API calls through the proxy.
+
+---
+
+## Admin routes — additional observations
+
+### `POST /admin/conversations/<id>/strict-moderation` / `/moderate` / `/seed`
+
+All three routes reach Polis server at `http://127.0.0.1:8003`. The dev Polis server
+returned HTTP 403 for moderate and strict-moderation:
+```
+PolisServerError: Polis moderation failed (HTTP 403): polis_err_update_comment_auth
+PolisServerError: Polis conversation settings update failed (HTTP 403): polis_err_update_conversation_permission
+```
+The Flask routes return **302** in all error cases (flash message + redirect). The 403
+from Polis is **silently swallowed** from the user's perspective — the redirect goes to
+the admin page which shows a flash error. HTTP 302 is returned to the browser regardless
+of whether the Polis operation succeeded or failed.
+
+### `POST /admin/conversations/new`
+
+Created conversation `audit-test-conv` with polis_id `2fn6tfpfdy` (Polis server was
+reachable and created the conversation). Response: 302.
+
+Tables written: `conversations` (1 INSERT).
+
+Outbound call: `POST http://127.0.0.1:8003/api/v3/auth/login` (login), then
+`POST http://127.0.0.1:8003/api/v3/conversations` (create). Both logged in Flask error
+output (exception trace visible for failed calls).
+
+---
+
+## POST-route reachability table
+
+All 29 POST routes in `v2/app.py` at `eaa47a9`. Routes requiring Polis server are marked;
+403s from Polis do not prevent the Flask route from being reached.
+
+| Route | Exercised | HTTP returned | Notes |
+|---|---|---|---|
+| `POST /accept/<slug>` | ✓ | 302 | CSRF required |
+| `POST /c/<slug>/arguments/<fs_id>/submit` | ✓ | 200 | JSON response with `X-Requested-With: fetch` |
+| `POST /c/<slug>/arguments/<fs_id>/<side>/skip` | ✓ | 200 | Idempotent |
+| `POST /c/<slug>/arguments/<arg_id>/vote` | ✓ | 200, 403, 409 | gate/own/cap reasons |
+| `POST /c/<slug>/arguments/<arg_id>/unvote` | ✓ | 200 | No-op if not voted |
+| `POST /c/<slug>/arguments/<arg_id>/hide` | ✓ | 302, 403 | Mod-only |
+| `POST /c/<slug>/arguments/<arg_id>/unhide` | ✓ | 302 | Mod-only |
+| `POST /c/<slug>/statements/new` | ✓ | 201, 403 | CSRF-exempt; Particiapi outbound |
+| `POST /proxy/particiapi/<path>` | ✓ (POST) | 200 | PUT not exercised |
+| `POST /c/<slug>/reveal` | ✓ | 302, 400 | Window + double-reveal checks |
+| `POST /logout` | ✓ | 302 | Session cleared |
+| `POST /admin/conversations/new` | ✓ | 302 | Polis server creates conv |
+| `POST /admin/conversations/<id>/edit` | ✓ | 302 | |
+| `POST /admin/conversations/<id>/pause` | ✓ | 302 | Toggles paused flag |
+| `POST /admin/conversations/<id>/close` | ✓ | 302 | Sets active=0, closed_at |
+| `POST /admin/conversations/<id>/phases` | ✓ | 302 | |
+| `POST /admin/global-admins/add` | ✓ | 302 | |
+| `POST /admin/global-admins/<id>/remove` | ✓ | 302 | |
+| `POST /admin/roles/add` | ✓ | 302 | |
+| `POST /admin/roles/<id>/remove` | ✓ | 302 | |
+| `POST /admin/conversations/<id>/invites/add` | ✓ | 302 | Bulk (newline-separated) |
+| `POST /admin/conversations/<id>/invites/<id>/remove` | ✓ | 302 | |
+| `POST /admin/conversations/<id>/statements/<tid>/moderate` | ✓ | 302 | Polis 403 in test env |
+| `POST /admin/conversations/<id>/statements/seed` | ✓ | 302 | Polis outbound |
+| `POST /admin/conversations/<id>/strict-moderation` | ✓ | 302 | Polis 403 in test env |
+| `POST /admin/conversations/<id>/featured/confirm` | ✓ | 302 | |
+| `POST /admin/conversations/<id>/featured/add` | ✓ | 302 | |
+| `POST /admin/conversations/<id>/featured/<fs_id>/remove` | ✓ | 302 | |
+| `POST /admin/conversations/<id>/arguments/<arg_id>/delete` | ✓ | 302 | Admin-only |
+
+**Not exercised:** `PUT /proxy/particiapi/<path>` — this is the same `proxy_particiapi`
+route handler but via PUT method. No app UI element was observed to trigger a PUT; the
+`_proxy_to_particiapi` handler is generic and would pass it through if called.
+
+---
+
+## DB tables written during audit
+
+| Table | Operations | Notes |
+|---|---|---|
+| `participations` | INSERT (1), UPDATE (new_stmt_ids 3x, reveal 1x) | |
+| `argument_side_states` | INSERT (20, on page load), UPDATE (skipped flag) | Side effect of GET /c/<slug> |
+| `arguments` | INSERT (3 submitted, 3 seed inserted directly) | |
+| `argument_votes` | INSERT (9), DELETE (2) | value=NULL for all inserts |
+| `conversations` | INSERT (1 audit-test), UPDATE (phases, pause, close, closed_at manipulation) | |
+| `conversation_invites` | INSERT (2), DELETE (1) | 1 remaining after audit |
+| `admin_roles` | INSERT (1), DELETE (1) | |
+| `participants` | UPDATE (is_global_admin 1x) | |
+
+---
+
+## Verified gate state machine (plain language)
+
+The argument gate is per-participant per-featured-statement. For each featured statement:
+
+1. **On first `GET /c/<slug>`:** `ArgumentSideState` rows are created for both `pro` and
+   `con` sides, with `skipped=False` and `argument_order` populated from current visible
+   arguments.
+
+2. **Gate locked** (neither side done): voting on any argument for this FS returns
+   403 `reason="gate"`.
+
+3. **One side unlocked:** Either (a) participant submits an argument on a side, or (b)
+   calls `POST .../skip` for that side. The other side remains locked.
+
+4. **Both sides unlocked** (gate open): participant may vote on arguments. Gate state is
+   checked on every vote request; it does not require a page reload.
+
+5. **Voting rules once gate is open:**
+   - Cannot vote on own argument → 403 `reason="own"`.
+   - Cannot vote on hidden argument → 403 `reason="hidden"`.
+   - Cannot exceed K votes per side (K from `conv.argument_vote_data["K"]`, default 2)
+     → 409 `reason="cap"`.
+   - All votes are binary row-presence (kApproval); `ArgumentVote.value` is always NULL.
+
+6. **Gate persists:** After closing and re-opening a conversation page, gate state is read
+   from DB — it does not reset on navigation.
+
+The gate does NOT interact with Polis voting (votes through the web component proxy go to
+Particiapi independently; those votes have no effect on `ArgumentSideState` or the gate).


### PR DESCRIPTION
Three separate commits, one per file.

## Commit 1 — Static codebase audit (`codebase-audit.md`)

Read-only pass at `eaa47a9`. Six sections: what it does, competing implementations, dead/abandoned code, premature abstraction, test reality, drift signal. All findings have `file:line` evidence.

Key findings: `_register_routes` complexity 177; 5 failing tests; `ArgumentVote.value` dead (ranking never implemented); 3 copies of psycopg2 boilerplate; root `app.py` / `db.py` are retired but README said "live".

## Commit 2 — Runtime writes audit (`runtime-writes-audit.md`)

All 29 POST routes exercised against dev SQLite. Documents:
- Verified gate state machine (propose-or-skip, not argument count)
- Identifier map: URL slug ≠ polis_id
- DB writes per route
- Proxy cookie rename (`pa_session` ↔ `session`) confirmed in both directions
- Statement quota path and `with_for_update` row-lock
- Reveal edge cases (double-reveal, before/after window)
- K-cap 409 and `ArgumentVote.value = NULL` (ranking path dead, confirmed at runtime)

## Commit 3 — Refactor plan (`refactor-plan.md`)

Steps 1–4 are complete (PR #88). Steps 5–9 have GitHub issues:

| Step | Issue | Description |
|---|---|---|
| 5 | [#89](https://github.com/lgelauff/wiki-polis/issues/89) | Lift non-route helpers to module level |
| 6 | [#90](https://github.com/lgelauff/wiki-polis/issues/90) | Consolidate statement-text fetch blocks |
| 7 | [#91](https://github.com/lgelauff/wiki-polis/issues/91) | Proxy + statement-submit blueprint |
| 8 | [#92](https://github.com/lgelauff/wiki-polis/issues/92) | Admin routes blueprint |
| 9 | [#93](https://github.com/lgelauff/wiki-polis/issues/93) | Participant-facing routes blueprint |

🤖 Generated with [Claude Code](https://claude.com/claude-code)