### PR TITLE
refactor(app): blueprint prep steps 5–6 — lift helpers (#90) + dedupe statement-text fetch (#89)

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -375,6 +375,180 @@ def _git_version() -> str:
 _GIT_VERSION = _git_version()
 
 
+# ── Route helpers (lifted from _register_routes; issue #90) ─────────────────
+
+def _get_or_create_side_state(participant_id, fs_id, side, current_args):
+    """Return ArgumentSideState, creating it on first view.
+
+    On creation: randomise argument_order from current_args.
+    On subsequent views: append any new arguments at a random position.
+    Commits to DB if any change is made.
+    """
+    state = ArgumentSideState.query.filter_by(
+        participant_id=participant_id,
+        featured_statement_id=fs_id,
+        side=side,
+    ).first()
+    changed = False
+    if state is None:
+        order = [a.id for a in current_args]
+        random.shuffle(order)
+        state = ArgumentSideState(
+            participant_id=participant_id,
+            featured_statement_id=fs_id,
+            side=side,
+            argument_order=order,
+        )
+        db.session.add(state)
+        changed = True
+    else:
+        known = set(state.argument_order)
+        new_ids = [a.id for a in current_args if a.id not in known]
+        if new_ids:
+            order = list(state.argument_order)
+            for aid in new_ids:
+                pos = random.randint(0, len(order))
+                order.insert(pos, aid)
+            state.argument_order = order
+            changed = True
+    if changed:
+        db.session.commit()
+    return state
+
+def _build_featured_data(conv, participation, can_mod=False):
+    """Return list of dicts for the argument tab, one per confirmed FS.
+
+    Each dict: {fs, text, short_title, pro_args, con_args, pro_state,
+                con_state, voted_ids, pro_gate, con_gate}
+    Creates/updates ArgumentSideState records as a side effect.
+    Moderators see hidden arguments (marked); participants never see them.
+    Order is deterministically randomised per participant.
+    """
+    fss = (FeaturedStatement.query
+           .filter_by(conversation_id=conv.id, confirmed_by_admin=True)
+           .options(joinedload(FeaturedStatement.arguments))
+           .order_by(FeaturedStatement.created_at)
+           .all())
+    if not fss:
+        return []
+
+    stmt_texts = {}
+    try:
+        client = PolisParticipantClient(current_app.config['PARTICIAPI_BASE'])
+        _, approved, _ = client.get_statements(conv.polis_id)
+        stmt_texts = {s['tid']: s.get('txt', '') for s in approved}
+    except Exception:
+        pass
+
+    pid = participation.participant_id
+    voted_ids = {av.argument_id for av in
+                 ArgumentVote.query.filter_by(participant_id=pid).all()}
+
+    # Proposer pseudonyms: one query for all proposers across all FSs.
+    all_proposer_ids = {a.proposer_id for fs in fss for a in fs.arguments
+                        if a.proposer_id is not None}
+    if all_proposer_ids:
+        proposer_parts = Participation.query.filter(
+            Participation.participant_id.in_(all_proposer_ids),
+            Participation.conversation_id == conv.id,
+        ).all()
+        proposer_pseudonym_map = {p.participant_id: p.pseudonym for p in proposer_parts}
+    else:
+        proposer_pseudonym_map = {}
+
+    result = []
+    for fs in fss:
+        pro_args = [a for a in fs.arguments if a.side == 'pro' and (can_mod or not a.hidden)]
+        con_args = [a for a in fs.arguments if a.side == 'con' and (can_mod or not a.hidden)]
+
+        pro_state = _get_or_create_side_state(pid, fs.id, 'pro', pro_args)
+        con_state = _get_or_create_side_state(pid, fs.id, 'con', con_args)
+
+        def _ordered(args, state):
+            arg_map = {a.id: a for a in args}
+            return [arg_map[aid] for aid in state.argument_order if aid in arg_map]
+
+        pro_proposed = Argument.query.filter_by(
+            proposer_id=pid, featured_statement_id=fs.id, side='pro').first()
+        con_proposed = Argument.query.filter_by(
+            proposer_id=pid, featured_statement_id=fs.id, side='con').first()
+
+        ordered_pro = _ordered(pro_args, pro_state)
+        ordered_con = _ordered(con_args, con_state)
+        pro_voted_count = sum(1 for a in ordered_pro if a.id in voted_ids)
+        con_voted_count = sum(1 for a in ordered_con if a.id in voted_ids)
+
+        text_value = (stmt_texts.get(fs.polis_statement_id)
+                      or fs.statement_text
+                      or f'Statement #{fs.polis_statement_id}')
+        result.append({
+            'fs':          fs,
+            'text':        text_value,
+            'short_title': _short_title(text_value),
+            'pro_args':  ordered_pro,
+            'con_args':  ordered_con,
+            'pro_state': pro_state,
+            'con_state': con_state,
+            'voted_ids': voted_ids,
+            'pro_gate':  bool(pro_proposed or pro_state.skipped),
+            'con_gate':  bool(con_proposed or con_state.skipped),
+            'pro_proposed': pro_proposed,
+            'con_proposed': con_proposed,
+            'k': conv.argument_vote_data.get('K', 2),
+            'pro_voted_count': pro_voted_count,
+            'con_voted_count': con_voted_count,
+            'proposer_pseudonyms': proposer_pseudonym_map,
+        })
+
+    random.Random(pid).shuffle(result)
+    return result
+
+def _require_arg_participation(slug):
+    """Return (conv, participation) or abort. Checks active + argument phase."""
+    conv = Conversation.query.filter_by(slug=slug).first_or_404()
+    if not conv.active or conv.paused or not conv.phase_argument_mapping:
+        abort(403)
+    participant = _current_participant()
+    if not participant:
+        abort(403)
+    part = Participation.query.filter_by(
+        participant_id=participant.id,
+        conversation_id=conv.id,
+    ).first_or_404()
+    return conv, part
+
+def _backfill_statement_texts(conv, confirmed: list) -> bool:
+    """Fetch and store statement_text for any confirmed FS that is missing it."""
+    missing = [fs for fs in confirmed if not fs.statement_text]
+    if not missing:
+        return False
+    client = PolisParticipantClient(current_app.config['PARTICIAPI_BASE'])
+    try:
+        _, approved, _ = client.get_statements(conv.polis_id)
+        text_by_tid = {s['tid']: (s.get('text') or s.get('txt', '')) for s in approved}
+    except PolisParticipantError:
+        return False
+    changed = False
+    for fs in missing:
+        text = text_by_tid.get(fs.polis_statement_id, '')
+        if text:
+            fs.statement_text = text
+            changed = True
+    if changed:
+        db.session.commit()
+    return changed
+
+def _fetch_statement_text(conv_polis_id: str, tid: int) -> str:
+    client = PolisParticipantClient(current_app.config['PARTICIAPI_BASE'])
+    try:
+        _, approved, _ = client.get_statements(conv_polis_id)
+        for s in approved:
+            if s.get('tid') == tid:
+                return s.get('text') or s.get('txt', '')
+    except PolisParticipantError:
+        pass
+    return ''
+
 def create_app(test_config: dict | None = None) -> Flask:
     app = Flask(__name__)
 
@@ -769,132 +943,6 @@ def _register_routes(app: Flask) -> None:
 
     # ── Argument helpers ──────────────────────────────────────────────────────
 
-    def _get_or_create_side_state(participant_id, fs_id, side, current_args):
-        """Return ArgumentSideState, creating it on first view.
-
-        On creation: randomise argument_order from current_args.
-        On subsequent views: append any new arguments at a random position.
-        Commits to DB if any change is made.
-        """
-        state = ArgumentSideState.query.filter_by(
-            participant_id=participant_id,
-            featured_statement_id=fs_id,
-            side=side,
-        ).first()
-        changed = False
-        if state is None:
-            order = [a.id for a in current_args]
-            random.shuffle(order)
-            state = ArgumentSideState(
-                participant_id=participant_id,
-                featured_statement_id=fs_id,
-                side=side,
-                argument_order=order,
-            )
-            db.session.add(state)
-            changed = True
-        else:
-            known = set(state.argument_order)
-            new_ids = [a.id for a in current_args if a.id not in known]
-            if new_ids:
-                order = list(state.argument_order)
-                for aid in new_ids:
-                    pos = random.randint(0, len(order))
-                    order.insert(pos, aid)
-                state.argument_order = order
-                changed = True
-        if changed:
-            db.session.commit()
-        return state
-
-    def _build_featured_data(conv, participation, can_mod=False):
-        """Return list of dicts for the argument tab, one per confirmed FS.
-
-        Each dict: {fs, text, short_title, pro_args, con_args, pro_state,
-                    con_state, voted_ids, pro_gate, con_gate}
-        Creates/updates ArgumentSideState records as a side effect.
-        Moderators see hidden arguments (marked); participants never see them.
-        Order is deterministically randomised per participant.
-        """
-        fss = (FeaturedStatement.query
-               .filter_by(conversation_id=conv.id, confirmed_by_admin=True)
-               .options(joinedload(FeaturedStatement.arguments))
-               .order_by(FeaturedStatement.created_at)
-               .all())
-        if not fss:
-            return []
-
-        stmt_texts = {}
-        try:
-            client = PolisParticipantClient(current_app.config['PARTICIAPI_BASE'])
-            _, approved, _ = client.get_statements(conv.polis_id)
-            stmt_texts = {s['tid']: s.get('txt', '') for s in approved}
-        except Exception:
-            pass
-
-        pid = participation.participant_id
-        voted_ids = {av.argument_id for av in
-                     ArgumentVote.query.filter_by(participant_id=pid).all()}
-
-        # Proposer pseudonyms: one query for all proposers across all FSs.
-        all_proposer_ids = {a.proposer_id for fs in fss for a in fs.arguments
-                            if a.proposer_id is not None}
-        if all_proposer_ids:
-            proposer_parts = Participation.query.filter(
-                Participation.participant_id.in_(all_proposer_ids),
-                Participation.conversation_id == conv.id,
-            ).all()
-            proposer_pseudonym_map = {p.participant_id: p.pseudonym for p in proposer_parts}
-        else:
-            proposer_pseudonym_map = {}
-
-        result = []
-        for fs in fss:
-            pro_args = [a for a in fs.arguments if a.side == 'pro' and (can_mod or not a.hidden)]
-            con_args = [a for a in fs.arguments if a.side == 'con' and (can_mod or not a.hidden)]
-
-            pro_state = _get_or_create_side_state(pid, fs.id, 'pro', pro_args)
-            con_state = _get_or_create_side_state(pid, fs.id, 'con', con_args)
-
-            def _ordered(args, state):
-                arg_map = {a.id: a for a in args}
-                return [arg_map[aid] for aid in state.argument_order if aid in arg_map]
-
-            pro_proposed = Argument.query.filter_by(
-                proposer_id=pid, featured_statement_id=fs.id, side='pro').first()
-            con_proposed = Argument.query.filter_by(
-                proposer_id=pid, featured_statement_id=fs.id, side='con').first()
-
-            ordered_pro = _ordered(pro_args, pro_state)
-            ordered_con = _ordered(con_args, con_state)
-            pro_voted_count = sum(1 for a in ordered_pro if a.id in voted_ids)
-            con_voted_count = sum(1 for a in ordered_con if a.id in voted_ids)
-
-            text_value = (stmt_texts.get(fs.polis_statement_id)
-                          or fs.statement_text
-                          or f'Statement #{fs.polis_statement_id}')
-            result.append({
-                'fs':          fs,
-                'text':        text_value,
-                'short_title': _short_title(text_value),
-                'pro_args':  ordered_pro,
-                'con_args':  ordered_con,
-                'pro_state': pro_state,
-                'con_state': con_state,
-                'voted_ids': voted_ids,
-                'pro_gate':  bool(pro_proposed or pro_state.skipped),
-                'con_gate':  bool(con_proposed or con_state.skipped),
-                'pro_proposed': pro_proposed,
-                'con_proposed': con_proposed,
-                'k': conv.argument_vote_data.get('K', 2),
-                'pro_voted_count': pro_voted_count,
-                'con_voted_count': con_voted_count,
-                'proposer_pseudonyms': proposer_pseudonym_map,
-            })
-
-        random.Random(pid).shuffle(result)
-        return result
-
     # ── Conversation ─────────────────────────────────────────────────────────
 
     @app.get('/c/<slug>')
@@ -962,20 +1010,6 @@ def _register_routes(app: Flask) -> None:
                                new_stmt_ids=participation.new_stmt_ids if participation else [])
 
     # ── Arguments ────────────────────────────────────────────────────────────
-
-    def _require_arg_participation(slug):
-        """Return (conv, participation) or abort. Checks active + argument phase."""
-        conv = Conversation.query.filter_by(slug=slug).first_or_404()
-        if not conv.active or conv.paused or not conv.phase_argument_mapping:
-            abort(403)
-        participant = _current_participant()
-        if not participant:
-            abort(403)
-        part = Participation.query.filter_by(
-            participant_id=participant.id,
-            conversation_id=conv.id,
-        ).first_or_404()
-        return conv, part
 
     @app.post('/c/<slug>/arguments/<int:fs_id>/submit')
     @login_required
@@ -1728,27 +1762,6 @@ def _register_routes(app: Flask) -> None:
 
     # ── Featured statements ───────────────────────────────────────────────────
 
-    def _backfill_statement_texts(conv, confirmed: list) -> bool:
-        """Fetch and store statement_text for any confirmed FS that is missing it."""
-        missing = [fs for fs in confirmed if not fs.statement_text]
-        if not missing:
-            return False
-        client = PolisParticipantClient(current_app.config['PARTICIAPI_BASE'])
-        try:
-            _, approved, _ = client.get_statements(conv.polis_id)
-            text_by_tid = {s['tid']: (s.get('text') or s.get('txt', '')) for s in approved}
-        except PolisParticipantError:
-            return False
-        changed = False
-        for fs in missing:
-            text = text_by_tid.get(fs.polis_statement_id, '')
-            if text:
-                fs.statement_text = text
-                changed = True
-        if changed:
-            db.session.commit()
-        return changed
-
     @app.get('/admin/conversations/<int:conv_id>/featured')
     @login_required
     def admin_conversation_featured(conv_id):
@@ -1768,17 +1781,6 @@ def _register_routes(app: Flask) -> None:
                                conversation=conv,
                                confirmed=confirmed,
                                candidates=candidates)
-
-    def _fetch_statement_text(conv_polis_id: str, tid: int) -> str:
-        client = PolisParticipantClient(current_app.config['PARTICIAPI_BASE'])
-        try:
-            _, approved, _ = client.get_statements(conv_polis_id)
-            for s in approved:
-                if s.get('tid') == tid:
-                    return s.get('text') or s.get('txt', '')
-        except PolisParticipantError:
-            pass
-        return ''
 
     @app.post('/admin/conversations/<int:conv_id>/featured/confirm')
     @login_required

--- a/v2/app.py
+++ b/v2/app.py
@@ -415,6 +415,22 @@ def _get_or_create_side_state(participant_id, fs_id, side, current_args):
         db.session.commit()
     return state
 
+def _statement_text_map(conv_polis_id: str) -> dict[int, str]:
+    """Map Polis tid -> approved-statement text for a conversation.
+
+    Single source for the three call sites that fetch statement text. Unified key
+    rule: prefer the 'text' field, fall back to 'txt'. Does not catch fetch errors —
+    callers decide how to degrade (PolisParticipantError propagates).
+
+    Note on the key rule: PolisParticipantClient.get_statements returns both 'text'
+    and 'txt' set to the same value, so the choice is a no-op there. The 'txt'
+    fallback is load-bearing only for admin-client-shaped payloads (PolisAdminClient
+    emits 'txt' without 'text') — keep it if this helper is ever pointed at that path.
+    """
+    client = PolisParticipantClient(current_app.config['PARTICIAPI_BASE'])
+    _, approved, _ = client.get_statements(conv_polis_id)
+    return {s['tid']: (s.get('text') or s.get('txt', '')) for s in approved}
+
 def _build_featured_data(conv, participation, can_mod=False):
     """Return list of dicts for the argument tab, one per confirmed FS.
 
@@ -434,9 +450,7 @@ def _build_featured_data(conv, participation, can_mod=False):
 
     stmt_texts = {}
     try:
-        client = PolisParticipantClient(current_app.config['PARTICIAPI_BASE'])
-        _, approved, _ = client.get_statements(conv.polis_id)
-        stmt_texts = {s['tid']: s.get('txt', '') for s in approved}
+        stmt_texts = _statement_text_map(conv.polis_id)
     except Exception:
         pass
 
@@ -522,10 +536,8 @@ def _backfill_statement_texts(conv, confirmed: list) -> bool:
     missing = [fs for fs in confirmed if not fs.statement_text]
     if not missing:
         return False
-    client = PolisParticipantClient(current_app.config['PARTICIAPI_BASE'])
     try:
-        _, approved, _ = client.get_statements(conv.polis_id)
-        text_by_tid = {s['tid']: (s.get('text') or s.get('txt', '')) for s in approved}
+        text_by_tid = _statement_text_map(conv.polis_id)
     except PolisParticipantError:
         return False
     changed = False
@@ -539,15 +551,10 @@ def _backfill_statement_texts(conv, confirmed: list) -> bool:
     return changed
 
 def _fetch_statement_text(conv_polis_id: str, tid: int) -> str:
-    client = PolisParticipantClient(current_app.config['PARTICIAPI_BASE'])
     try:
-        _, approved, _ = client.get_statements(conv_polis_id)
-        for s in approved:
-            if s.get('tid') == tid:
-                return s.get('text') or s.get('txt', '')
+        return _statement_text_map(conv_polis_id).get(tid, '')
     except PolisParticipantError:
-        pass
-    return ''
+        return ''
 
 def create_app(test_config: dict | None = None) -> Flask:
     app = Flask(__name__)

--- a/v2/tests/test_helpers_argument.py
+++ b/v2/tests/test_helpers_argument.py
@@ -1,0 +1,190 @@
+"""Unit characterization of the argument-tab helpers that issue #90 lifted to module
+level (`_get_or_create_side_state`, `_build_featured_data`, `_require_arg_participation`).
+
+Promoted from #90's scratch suite after the senior + security review. Includes two
+gap-fillers the reviewers asked for: the post-visit hide path (the production path that
+enforces hidden-argument confidentiality once a participant's side-state already
+exists) and the paused / phase-off authorization branches of the participation gate.
+"""
+import pytest
+from werkzeug.exceptions import Forbidden
+
+from app import (_build_featured_data, _get_or_create_side_state,
+                 _require_arg_participation)
+from db import (Argument, ArgumentSideState, ArgumentVote, Conversation,
+                FeaturedStatement, Participation, db)
+
+
+@pytest.fixture
+def conv(app):
+    c = Conversation(
+        slug='s5-conv', polis_id='s5xxxxxxxx', title='S5', active=True,
+        access_policy='public', phase_argument_mapping=True,
+        argument_vote_data={'K': 2},
+    )
+    db.session.add(c)
+    db.session.commit()
+    return c
+
+
+@pytest.fixture
+def part(app, participant, conv):
+    p = Participation(participant_id=participant.id, conversation_id=conv.id,
+                      pseudonym='s5-fox')
+    db.session.add(p)
+    db.session.commit()
+    return p
+
+
+@pytest.fixture
+def fs(app, conv):
+    f = FeaturedStatement(conversation_id=conv.id, polis_statement_id=42,
+                          statement_text='Seed statement', confirmed_by_admin=True)
+    db.session.add(f)
+    db.session.commit()
+    return f
+
+
+def _args(fs_id, side, n):
+    for i in range(n):
+        db.session.add(Argument(featured_statement_id=fs_id, proposer_id=None,
+                                body=f'{side} {i}', side=side))
+    db.session.commit()
+    return Argument.query.filter_by(featured_statement_id=fs_id, side=side).all()
+
+
+def _participation(part, conv):
+    return Participation.query.filter_by(
+        participant_id=part.participant_id, conversation_id=conv.id).first()
+
+
+# ── _get_or_create_side_state ───────────────────────────────────────────────────
+
+def test_side_state_created_with_full_permutation(part, fs):
+    args = _args(fs.id, 'pro', 4)
+    ids = {a.id for a in args}
+    state = _get_or_create_side_state(part.participant_id, fs.id, 'pro', args)
+    assert state.id is not None                      # persisted
+    assert set(state.argument_order) == ids          # all ids, no extras
+    assert len(state.argument_order) == 4            # a permutation, not a subset
+
+
+def test_side_state_appends_only_new_ids_and_is_idempotent(part, fs):
+    args = _args(fs.id, 'pro', 2)
+    s1 = _get_or_create_side_state(part.participant_id, fs.id, 'pro', args)
+    order_before = list(s1.argument_order)
+
+    # No new args → no change (idempotent).
+    s2 = _get_or_create_side_state(part.participant_id, fs.id, 'pro', args)
+    assert list(s2.argument_order) == order_before
+
+    # One new arg → inserted; existing order otherwise preserved as a subsequence.
+    _args(fs.id, 'pro', 1)                   # add 1 → 3 total (2 old + 1 new)
+    more = Argument.query.filter_by(featured_statement_id=fs.id, side='pro').all()
+    new_id = (set(a.id for a in more) - set(order_before)).pop()
+    s3 = _get_or_create_side_state(part.participant_id, fs.id, 'pro', more)
+    assert new_id in s3.argument_order
+    assert len(s3.argument_order) == 3
+    assert [i for i in s3.argument_order if i in order_before] == order_before
+
+
+# ── _build_featured_data ────────────────────────────────────────────────────────
+
+def test_build_featured_data_deterministic_per_participant(part, fs, conv):
+    _args(fs.id, 'pro', 2)
+    _args(fs.id, 'con', 2)
+    r1 = _build_featured_data(conv, _participation(part, conv))
+    r2 = _build_featured_data(conv, _participation(part, conv))
+    # random.Random(pid) → stable ordering across calls for the same participant.
+    assert [d['fs'].id for d in r1] == [d['fs'].id for d in r2]
+
+
+def test_build_featured_data_gates_and_text_fallback(part, fs, conv):
+    _args(fs.id, 'pro', 1)
+    _args(fs.id, 'con', 1)
+    data = _build_featured_data(conv, _participation(part, conv))
+    assert len(data) == 1
+    entry = data[0]
+    # Participant has neither proposed nor skipped → both gates closed.
+    assert entry['pro_gate'] is False and entry['con_gate'] is False
+    # No Polis reachable in tests → text falls back to stored statement_text.
+    assert entry['text'] == 'Seed statement'
+    assert entry['k'] == 2
+
+
+def test_build_featured_data_hidden_excluded_for_participant(part, fs, conv):
+    pro = _args(fs.id, 'pro', 2)
+    pro[0].hidden = True
+    db.session.commit()
+    # Non-moderator must not see hidden arguments.
+    entry = _build_featured_data(conv, _participation(part, conv), can_mod=False)[0]
+    assert pro[0].id not in {a.id for a in entry['pro_args']}
+    # Moderator view includes them.
+    entry_mod = _build_featured_data(conv, _participation(part, conv), can_mod=True)[0]
+    assert pro[0].id in {a.id for a in entry_mod['pro_args']}
+
+
+def test_build_featured_data_hides_argument_after_state_exists(part, fs, conv):
+    """Production confidentiality path: participant visits first (side-state written
+    with both ids), THEN a moderator hides an argument. On revisit it must drop out of
+    the non-moderator view even though its id is still in the persisted argument_order
+    — enforcement is the `if aid in arg_map` filter at render, not state mutation."""
+    pro = _args(fs.id, 'pro', 2)
+    # First visit creates the side-state containing both argument ids.
+    _build_featured_data(conv, _participation(part, conv))
+    state = ArgumentSideState.query.filter_by(
+        participant_id=part.participant_id, featured_statement_id=fs.id,
+        side='pro').first()
+    assert pro[0].id in state.argument_order
+
+    # Moderator hides the argument AFTER the participant's state exists.
+    pro[0].hidden = True
+    db.session.commit()
+
+    entry = _build_featured_data(conv, _participation(part, conv), can_mod=False)[0]
+    assert pro[0].id not in {a.id for a in entry['pro_args']}
+    # The persisted order is untouched; filtering happens only at render time.
+    refreshed = ArgumentSideState.query.filter_by(
+        participant_id=part.participant_id, featured_statement_id=fs.id,
+        side='pro').first()
+    assert pro[0].id in refreshed.argument_order
+
+
+def test_build_featured_data_reflects_votes(part, fs, conv):
+    pro = _args(fs.id, 'pro', 2)
+    db.session.add(ArgumentVote(argument_id=pro[0].id,
+                                participant_id=part.participant_id))
+    db.session.commit()
+    entry = _build_featured_data(conv, _participation(part, conv))[0]
+    assert pro[0].id in entry['voted_ids']
+
+
+# ── _require_arg_participation (authorization gate) ─────────────────────────────
+
+def test_require_arg_participation_gate_branches(app, participant, conv, part):
+    """Happy path returns (conv, participation); paused or phase-off must abort 403."""
+    from flask import session
+
+    # Active + in the argument phase + participating → returns the pair.
+    with app.test_request_context():
+        session['username'] = participant.mw_username
+        got_conv, got_part = _require_arg_participation(conv.slug)
+        assert got_conv.id == conv.id
+        assert got_part.participant_id == participant.id
+
+    # Paused conversation → 403.
+    conv.paused = True
+    db.session.commit()
+    with app.test_request_context():
+        session['username'] = participant.mw_username
+        with pytest.raises(Forbidden):
+            _require_arg_participation(conv.slug)
+
+    # Not in the argument-mapping phase → 403.
+    conv.paused = False
+    conv.phase_argument_mapping = False
+    db.session.commit()
+    with app.test_request_context():
+        session['username'] = participant.mw_username
+        with pytest.raises(Forbidden):
+            _require_arg_participation(conv.slug)

--- a/v2/tests/test_helpers_argument.py
+++ b/v2/tests/test_helpers_argument.py
@@ -9,10 +9,31 @@ exists) and the paused / phase-off authorization branches of the participation g
 import pytest
 from werkzeug.exceptions import Forbidden
 
-from app import (_build_featured_data, _get_or_create_side_state,
-                 _require_arg_participation)
+from app import (_backfill_statement_texts, _build_featured_data,
+                 _fetch_statement_text, _get_or_create_side_state,
+                 _require_arg_participation, _statement_text_map)
 from db import (Argument, ArgumentSideState, ArgumentVote, Conversation,
                 FeaturedStatement, Participation, db)
+from polis_admin import PolisParticipantError
+
+
+def _fake_statements_client(approved):
+    """Build a PolisParticipantClient stand-in returning a fixed approved list."""
+    class FakeClient:
+        def __init__(self, base):
+            pass
+
+        def get_statements(self, conv_polis_id):
+            return (None, approved, None)
+    return FakeClient
+
+
+class _FailingClient:
+    def __init__(self, base):
+        pass
+
+    def get_statements(self, conv_polis_id):
+        raise PolisParticipantError('backend down')
 
 
 @pytest.fixture
@@ -188,3 +209,67 @@ def test_require_arg_participation_gate_branches(app, participant, conv, part):
         session['username'] = participant.mw_username
         with pytest.raises(Forbidden):
             _require_arg_participation(conv.slug)
+
+
+# ── _statement_text_map (#89 — unified tid -> text source) ──────────────────────
+
+def test_statement_text_map_key_conventions(app, monkeypatch):
+    """Unified key rule across the three former call sites: prefer 'text', fall back
+    to 'txt'. Asserts both single-key conventions resolve, plus precedence/fallback."""
+    approved = [
+        {'tid': 1, 'txt': 'only-txt'},                       # txt-only payload
+        {'tid': 2, 'text': 'only-text'},                     # text-only payload
+        {'tid': 3, 'text': 'both-text', 'txt': 'both-txt'},  # text wins when both set
+        {'tid': 4, 'text': '', 'txt': 'fallback'},           # empty text -> txt
+        {'tid': 5},                                          # neither -> ''
+    ]
+
+    monkeypatch.setattr('app.PolisParticipantClient', _fake_statements_client(approved))
+    m = _statement_text_map('conv-1')
+
+    assert m[1] == 'only-txt'
+    assert m[2] == 'only-text'
+    assert m[3] == 'both-text'
+    assert m[4] == 'fallback'
+    assert m[5] == ''
+
+
+def test_statement_text_map_propagates_fetch_error(app, monkeypatch):
+    """Contract: the helper does NOT swallow fetch errors — callers decide to degrade."""
+    monkeypatch.setattr('app.PolisParticipantClient', _FailingClient)
+    with pytest.raises(PolisParticipantError):
+        _statement_text_map('conv-1')
+
+
+def test_fetch_statement_text_hit_miss_error(app, monkeypatch):
+    """_fetch_statement_text: matching tid -> text; missing tid -> ''; fetch error -> ''."""
+    monkeypatch.setattr('app.PolisParticipantClient',
+                        _fake_statements_client([{'tid': 7, 'text': 'lucky'}]))
+    assert _fetch_statement_text('c', 7) == 'lucky'      # hit
+    assert _fetch_statement_text('c', 999) == ''         # miss
+
+    monkeypatch.setattr('app.PolisParticipantClient', _FailingClient)
+    assert _fetch_statement_text('c', 7) == ''           # error degrades to ''
+
+
+def test_backfill_statement_texts_fills_missing_and_noops(app, monkeypatch, conv):
+    """_backfill fills only FSs lacking statement_text, commits, and returns whether
+    it changed anything; a fetch error degrades to False without raising."""
+    fs_missing = FeaturedStatement(conversation_id=conv.id, polis_statement_id=7,
+                                   statement_text='', confirmed_by_admin=True)
+    db.session.add(fs_missing)
+    db.session.commit()
+
+    monkeypatch.setattr('app.PolisParticipantClient',
+                        _fake_statements_client([{'tid': 7, 'text': 'filled-in'}]))
+    assert _backfill_statement_texts(conv, [fs_missing]) is True
+    assert fs_missing.statement_text == 'filled-in'
+
+    # Already populated → nothing missing → no fetch, returns False.
+    assert _backfill_statement_texts(conv, [fs_missing]) is False
+
+    # Fetch error on a genuinely-missing FS degrades to False (no raise).
+    fs_missing.statement_text = ''
+    db.session.commit()
+    monkeypatch.setattr('app.PolisParticipantClient', _FailingClient)
+    assert _backfill_statement_texts(conv, [fs_missing]) is False


### PR DESCRIPTION
Blueprint-refactor **steps 5–6**, prep for the blueprint extractions (#91–#93). Both are structural with no behavior change; the suite stays green and gains coverage (108 → 120).

## #90 — lift 5 route helpers to module level (step 5)
Moves `_get_or_create_side_state`, `_build_featured_data`, `_require_arg_participation`, `_backfill_statement_texts`, `_fetch_statement_text` out of the `_register_routes` closure to module level. Verified they reference only module-level names (`current_app`, db models, module imports) and close over **none** of the closure locals.

**Precise nature of the change — relocation only:** 3 of the 5 functions are byte-for-byte AST-identical to `main`. The other 2 (`_get_or_create_side_state`, `_build_featured_data`) differ **solely** in docstring continuation-line indentation (8→4 spaces) — a mechanical consequence of de-indenting one scope level. No executable code, logic, or string/message value changed.

Effect: `_register_routes` cyclomatic complexity **177 → 153**.

## #89 — dedupe statement-text fetch into `_statement_text_map` (step 6)
Replaces three near-duplicate "fetch approved statements → `{tid: text}`" blocks with one module-level helper using the unified key rule `s.get('text') or s.get('txt','')`. The helper does **not** catch fetch errors; each caller keeps its prior degradation (broad `except` → `{}`; `PolisParticipantError` → `False`; → `''`). Behaviorally neutral against the real `PolisParticipantClient` (its `get_statements` sets `txt == text`); the `txt` fallback is retained and documented for admin-client-shaped payloads (`PolisAdminClient` emits `txt` only).

## Tests
New `tests/test_helpers_argument.py` (12 tests): characterization of the moved helpers (side-state ordering/append, featured-data determinism, gate defaults, hidden-argument visibility, **post-visit hidden-argument confidentiality**, **paused / phase-off auth gate**, vote reflection) plus `_statement_text_map` key conventions, error-propagation contract, `_fetch_statement_text` hit/miss/error, and `_backfill_statement_texts` fill/no-op/error.

## Verification
- `pytest`: **120 passed** (108 baseline + 12 new), zero assertion changes to existing tests.
- `ruff check app.py`: no new lint (one pre-existing E741 unchanged).
- Endpoint map unchanged (44 routes). Reviewed by senior-engineer + security agents with cross-review — security-neutral, SHIP.

## Relationships
- **Refactor series:** part of the 9-step blueprint refactor (audit + plan in #94; steps 1–4 landed in #88). This PR is **steps 5–6**.
- **Unblocks** the remaining blueprint extractions — #91 (step 7 · proxy + statement-submit), #92 (step 8 · admin routes), #93 (step 9 · participant routes). Per their issues each **ships alone and soaks** before the next, so they are intentionally **not** bundled here.
- **Touches shared code:** `_build_featured_data` is the arguments-tab data path central to #80 (argument mapping tab explanation) and #77 (document argument state machine); the lifted gate/auth helpers underpin the `argument_*` routes that those and related product issues (#69, #64, #11, #12) modify.

Closes #90, closes #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)