### PR TITLE
refactor(app): extract proxy + statement-submit into a blueprint (#91)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,6 +163,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# Flask-Session filesystem/sqlalchemy session store (runtime artifact)
+flask_session/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/v2/app.py
+++ b/v2/app.py
@@ -17,8 +17,9 @@ import coolname
 import nh3
 import requests
 from dotenv import load_dotenv
-from flask import (Flask, abort, current_app, flash, g, jsonify, make_response,
-                   redirect, render_template, request, session, url_for)
+from flask import (Blueprint, Flask, abort, current_app, flash, g, jsonify,
+                   make_response, redirect, render_template, request, session,
+                   url_for)
 from flask_migrate import Migrate
 from flask_session import Session
 from flask_limiter import Limiter
@@ -556,6 +557,99 @@ def _fetch_statement_text(conv_polis_id: str, tid: int) -> str:
     except PolisParticipantError:
         return ''
 
+
+# ── Proxy + statement-submit blueprint (issue #91, step 7) ──────────────────
+# The security-sensitive cluster: both routes are CSRF-exempt with
+# _validate_same_origin() as the compensating control, and both bridge the
+# browser's renamed 'pa_session' cookie to Particiapi's 'session'. They live on a
+# blueprint (CSRF-exempted in create_app via csrf.exempt(proxy_bp)) instead of the
+# _register_routes closure. Behaviour is byte-identical to the prior inline routes.
+proxy_bp = Blueprint('proxy', __name__)
+
+@proxy_bp.post('/c/<slug>/statements/new')
+@login_required
+def conversation_statement_new(slug):
+    """Submit an entirely new statement; enforces per-participant quota and
+    records the Polis statement ID for novelty tracking."""
+    # Origin validation (same compensating control as the proxy).
+    _validate_same_origin()
+
+    conv = Conversation.query.filter_by(slug=slug).first_or_404()
+    if not conv.active or conv.paused or not conv.phase_submission:
+        abort(403)
+    participant = _current_participant()
+    if not participant:
+        abort(401)
+
+    # Lock the participation row for the duration of this transaction to
+    # prevent two concurrent requests from both passing the quota check.
+    part = Participation.query.filter_by(
+        participant_id=participant.id, conversation_id=conv.id,
+    ).with_for_update().first_or_404()
+
+    new_stmt_max = conv.argument_vote_data.get('new_stmt_max', 3) if conv.argument_vote_data else 3
+    if len(part.new_stmt_ids or []) >= new_stmt_max:
+        return jsonify({'error': 'quota_exceeded'}), 403
+
+    body = request.get_json(silent=True) or {}
+    text = (body.get('text') or '').strip()
+    if not text or len(text) > 280:
+        abort(400)
+
+    # Get CSRF token for this Particiapi session, then submit the statement.
+    pa_cookie = request.cookies.get('pa_session')
+    forwarded = {'session': pa_cookie} if pa_cookie else {}
+    base = current_app.config['PARTICIAPI_BASE']
+
+    try:
+        sess_resp = requests.post(
+            f'{base}/api/session',
+            cookies=forwarded,
+            params={'create': 'true'},
+            timeout=5,
+        )
+        if not sess_resp.ok:
+            current_app.logger.error('Particiapi session error: %s', sess_resp.status_code)
+            abort(502)
+        csrf_token = sess_resp.json().get('csrf_token', '')
+        new_pa_cookie = sess_resp.cookies.get('session')
+        submit_cookies = {'session': new_pa_cookie or pa_cookie} if (new_pa_cookie or pa_cookie) else {}
+
+        stmt_resp = requests.post(
+            f'{base}/api/conversations/{conv.polis_id}/statements/',
+            json={'text': text},
+            cookies=submit_cookies,
+            headers={'X-CSRF-Token': csrf_token},
+            timeout=10,
+        )
+    except requests.RequestException:
+        current_app.logger.exception('Particiapi error in conversation_statement_new')
+        abort(502)
+
+    if stmt_resp.status_code == 201:
+        stmt_id = stmt_resp.json().get('id')
+        if stmt_id is not None:
+            ids = list(part.new_stmt_ids or [])
+            ids.append(stmt_id)
+            part.new_stmt_ids = ids
+            db.session.commit()
+        flask_resp = make_response(stmt_resp.content, 201)
+        flask_resp.headers['Content-Type'] = 'application/json'
+    else:
+        current_app.logger.error('Particiapi statement error: %s', stmt_resp.status_code)
+        flask_resp = make_response(jsonify({'error': 'upstream_error'}), 502)
+
+    if new_pa_cookie:
+        flask_resp.set_cookie('pa_session', new_pa_cookie, httponly=True,
+                              samesite='Lax', secure=not current_app.debug)
+    return flask_resp
+
+@proxy_bp.route('/proxy/particiapi/<path:pa_path>',
+                methods=['GET', 'POST', 'PUT'])
+@login_required
+def proxy_particiapi(pa_path):
+    return _proxy_to_particiapi(pa_path)
+
 def create_app(test_config: dict | None = None) -> Flask:
     app = Flask(__name__)
 
@@ -719,6 +813,13 @@ def create_app(test_config: dict | None = None) -> Flask:
         return response
 
     _register_routes(app)
+
+    # Proxy + statement-submit blueprint (#91). Both routes are CSRF-exempt with
+    # _validate_same_origin() as the compensating control; exempt the whole
+    # blueprint explicitly rather than per-route.
+    app.register_blueprint(proxy_bp)
+    csrf.exempt(proxy_bp)
+
     return app
 
 
@@ -1209,96 +1310,6 @@ def _register_routes(app: Flask) -> None:
         arg.hidden = False
         db.session.commit()
         return redirect(url_for('conversation', slug=slug) + '#tab-arguments')
-
-    # ── New statement submission (quota-tracked) ──────────────────────────────
-
-    @app.post('/c/<slug>/statements/new')
-    @login_required
-    @csrf.exempt
-    def conversation_statement_new(slug):
-        """Submit an entirely new statement; enforces per-participant quota and
-        records the Polis statement ID for novelty tracking."""
-        # Origin validation (same compensating control as the proxy).
-        _validate_same_origin()
-
-        conv = Conversation.query.filter_by(slug=slug).first_or_404()
-        if not conv.active or conv.paused or not conv.phase_submission:
-            abort(403)
-        participant = _current_participant()
-        if not participant:
-            abort(401)
-
-        # Lock the participation row for the duration of this transaction to
-        # prevent two concurrent requests from both passing the quota check.
-        part = Participation.query.filter_by(
-            participant_id=participant.id, conversation_id=conv.id,
-        ).with_for_update().first_or_404()
-
-        new_stmt_max = conv.argument_vote_data.get('new_stmt_max', 3) if conv.argument_vote_data else 3
-        if len(part.new_stmt_ids or []) >= new_stmt_max:
-            return jsonify({'error': 'quota_exceeded'}), 403
-
-        body = request.get_json(silent=True) or {}
-        text = (body.get('text') or '').strip()
-        if not text or len(text) > 280:
-            abort(400)
-
-        # Get CSRF token for this Particiapi session, then submit the statement.
-        pa_cookie = request.cookies.get('pa_session')
-        forwarded = {'session': pa_cookie} if pa_cookie else {}
-        base = current_app.config['PARTICIAPI_BASE']
-
-        try:
-            sess_resp = requests.post(
-                f'{base}/api/session',
-                cookies=forwarded,
-                params={'create': 'true'},
-                timeout=5,
-            )
-            if not sess_resp.ok:
-                current_app.logger.error('Particiapi session error: %s', sess_resp.status_code)
-                abort(502)
-            csrf_token = sess_resp.json().get('csrf_token', '')
-            new_pa_cookie = sess_resp.cookies.get('session')
-            submit_cookies = {'session': new_pa_cookie or pa_cookie} if (new_pa_cookie or pa_cookie) else {}
-
-            stmt_resp = requests.post(
-                f'{base}/api/conversations/{conv.polis_id}/statements/',
-                json={'text': text},
-                cookies=submit_cookies,
-                headers={'X-CSRF-Token': csrf_token},
-                timeout=10,
-            )
-        except requests.RequestException:
-            current_app.logger.exception('Particiapi error in conversation_statement_new')
-            abort(502)
-
-        if stmt_resp.status_code == 201:
-            stmt_id = stmt_resp.json().get('id')
-            if stmt_id is not None:
-                ids = list(part.new_stmt_ids or [])
-                ids.append(stmt_id)
-                part.new_stmt_ids = ids
-                db.session.commit()
-            flask_resp = make_response(stmt_resp.content, 201)
-            flask_resp.headers['Content-Type'] = 'application/json'
-        else:
-            current_app.logger.error('Particiapi statement error: %s', stmt_resp.status_code)
-            flask_resp = make_response(jsonify({'error': 'upstream_error'}), 502)
-
-        if new_pa_cookie:
-            flask_resp.set_cookie('pa_session', new_pa_cookie, httponly=True,
-                                  samesite='Lax', secure=not current_app.debug)
-        return flask_resp
-
-    # ── Particiapi proxy ──────────────────────────────────────────────────────
-
-    @app.route('/proxy/particiapi/<path:pa_path>',
-               methods=['GET', 'POST', 'PUT'])
-    @login_required
-    @csrf.exempt
-    def proxy_particiapi(pa_path):
-        return _proxy_to_particiapi(pa_path)
 
     # ── Identity reveal ───────────────────────────────────────────────────────
 

--- a/v2/guide_runbook.md
+++ b/v2/guide_runbook.md
@@ -29,10 +29,44 @@ them:
 
 ## Logs
 
-- **Toolforge (Flask):** `/data/project/wiki-polis/uwsgi.log` — filter the rotation
-  noise: `tail -50 /data/project/wiki-polis/uwsgi.log | grep -v lseek`.
-- **VPS (Polis / Particiapi / Postgres):** `docker logs <container>` or
-  `docker-compose logs <service>` from the `particiapp-docker` directory.
+- **Toolforge (Flask):** `/data/project/wiki-polis/uwsgi.log` (staging:
+  `/data/project/wiki-polis-dev/uwsgi.log`). The file can contain non-text bytes, so
+  **force text mode with `grep -a`** or matches are silently hidden ("binary file
+  matches"). Filter rotation noise: `tail -50 …/uwsgi.log | grep -av lseek`. See
+  [Investigating a 5xx](#investigating-a-5xx) for reading the status code correctly.
+- **VPS (Polis / Particiapi / Postgres):** `docker logs <container>`, or
+  `docker-compose logs <service>` from the `particiapp-docker` directory for
+  **production**. For **staging** the stack runs under a non-default compose project
+  name — use `docker-compose -p wiki-polis-staging logs <service>` (see
+  [Staging environment](#staging-environment)).
+
+## Investigating a 5xx
+
+When a 5xx is reported (by a soak run, monitoring, or a user), work outside-in:
+
+1. **Did it even reach the Flask app?** Grep the uwsgi log (with `-a`, see above):
+
+       grep -a "<path fragment>" /data/project/<tool>/uwsgi.log | tail -20
+
+   **⚠️ Read the status correctly.** A uwsgi access line ends with the real status in
+   `(HTTP/1.1 NNN)`. The `req: 503/1521` field near the *start* of the line is uwsgi's
+   request counter — **not** an HTTP 503. Don't be fooled by grepping for `503`.
+   - request appears with `(HTTP/1.1 5xx)` → the app (or a backend it proxied to)
+     produced it → go to step 2.
+   - request is **absent** (its neighbours are logged, it isn't) → **Toolforge's front
+     proxy** returned the 5xx (usually 503) because the webservice pod was momentarily
+     unavailable/saturated. The app never saw it. Transient; if frequent, raise the
+     uwsgi `processes`/`threads` in `~/www/python/uwsgi.ini`.
+2. **Proxy or upstream?** The Particiapi proxy returns **502** on any upstream failure
+   (`abort(502)` on `requests.RequestException`) and **never** emits 503. So a logged
+   502 + a `Particiapi proxy error` traceback (timestamp must match the incident!) means
+   the proxy couldn't reach Particiapi; a logged 503 that *did* reach the app was relayed
+   from upstream Polis/Particiapi → check the backend.
+3. **Backend (VPS).** SSH to `wiki-polis-backend`; `docker ps` — anything restarting /
+   unhealthy / OOMKilled? For staging remember the project flag:
+   `docker-compose -p wiki-polis-staging logs --since 30m particiapi`.
+4. **Reproduce.** `v2/synthetic_traffic.py` drives the real proxy under load and exits
+   non-zero on any 5xx — use it to confirm a fix or to decide a one-off 5xx was noise.
 
 ## Backups & restore
 
@@ -49,10 +83,49 @@ them:
 
 ## Staging environment
 
-`wiki-polis-dev.toolforge.org` is a **permanent** staging tool (decision D-MON). It
-differs from production: dev-login / `DEV_FAKE_LOGIN` enabled, a separate ToolsDB
-database, and it may point at a dev backend. Validate changes here before deploying to
-the `wiki-polis` production tool. *(pending — document the exact prod-vs-staging config once both are settled)*
+`wiki-polis-dev.toolforge.org` is a **permanent** staging tool (decision D-MON) with its
+own backend stack — **fully isolated from production**. Validate changes here before
+deploying to the `wiki-polis` production tool.
+
+**Topology.** One VPS host (`wiki-polis-backend`) runs **two complete particiapp stacks**
+side by side; staging and production never share a database:
+
+| Stack | particiapi | polis-server | postgres | compose project |
+|---|---|---|---|---|
+| **production** | 8000 | 8001 | 5432 | `particiapp-docker` (dir default) |
+| **staging** | 8010 | 8011 | 5442 | `wiki-polis-staging` |
+
+`wiki-polis-dev`'s `PARTICIAPI_BASE_URL` points at `…:8010` (the staging particiapi), so
+staging conversation/vote data lives in the **staging** Polis Postgres. Mutating staging —
+e.g. synthetic traffic on the `test` conversation — never touches production.
+
+**⚠️ Gotcha — the staging compose project name.** The staging stack was brought up under
+project name **`wiki-polis-staging`**, not its directory name (`particiapp-docker-staging`).
+So `docker-compose ps` *inside that directory shows nothing*. Manage it with the project
+flag (or `docker ps`, which always shows the truth — staging containers are
+`wiki-polis-staging_*`):
+
+    docker-compose -p wiki-polis-staging ps
+    docker-compose -p wiki-polis-staging logs --since 30m <service>
+    # or export COMPOSE_PROJECT_NAME=wiki-polis-staging
+
+**Logging in to staging (headless or browser).** `DEV_FAKE_LOGIN=1` is set on the
+`wiki-polis-dev` tool, enabling `GET /dev/login/<username>` for three fixed identities —
+`dev-user-1`, `dev-user-2`, `dev-user-3` (distinct xids, negative user-ids that cannot
+collide with real accounts). This is how `synthetic_traffic.py` and headless tests
+authenticate. **This path is OFF on production** (`/dev/login/...` → 404 there) — never
+set `DEV_FAKE_LOGIN` on the `wiki-polis` tool. (The single-user `/dev-login` variant is
+local-only; it never registers on Toolforge.)
+
+**Deploying to staging.** `become wiki-polis-dev`, then
+`bash ~/wiki-polis/deploy.sh <branch>` (add `--migrate` only for schema changes). Confirm
+the printed commit hash is what you intended; it also appears in the page footer.
+
+**Load note.** Under sustained synthetic load (~6 req/s) staging occasionally returns a
+single ingress `503` (~1 in 3000) — Toolforge's front proxy when the pod is briefly
+saturated, **not** the app (see [Investigating a 5xx](#investigating-a-5xx)). For a
+prototype this is harmless; raise uwsgi `processes`/`threads` only if real bursty traffic
+is expected.
 
 ## Secrets rotation
 

--- a/v2/synthetic_traffic.py
+++ b/v2/synthetic_traffic.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""
+synthetic_traffic.py — Drive realistic traffic at a *deployed* wiki-polis instance
+through the real Flask stack (auth → /proxy/particiapi → statement submit), and fail
+loudly on any anomaly.
+
+Why this exists
+---------------
+wiki-polis has too few real users to "soak" a change by waiting for organic traffic.
+This tool *generates* that traffic so a regression surfaces in minutes, not weeks.
+
+It is the proxy-facing complement to `simulate_cats_vs_dogs.py`: that script talks
+**directly to Particiapi** (and Postgres) to build Polis clustering data; this one
+goes **through the Flask app's proxy** — so it exercises exactly the code the proxy
+blueprint (#91) owns: the pa_session↔session cookie rename, the CSRF-exempt +
+same-origin posture, the 403→200 /results/ rewrite, and the quota-tracked
+statement-submit route. Reuse it for any future change: smoke a deploy, soak a
+refactor, or load-test, against local or staging.
+
+What a worker does, in a loop, through the proxy
+------------------------------------------------
+  1. auth         GET  /dev/login/dev-user-N            (needs DEV_FAKE_LOGIN=1)
+  2. accept       POST /accept/<slug>                   (once, for the submit action)
+  3. discover     GET  /c/<slug>  → <pa-conversation conversation-id="...">
+  4. pa-session   POST /proxy/particiapi/api/session?create=true  → csrf_token
+  5. statements   GET  /proxy/particiapi/api/conversations/<cid>/statements/
+  6. vote         PUT  /proxy/particiapi/api/conversations/<cid>/votes/<tid>
+  7. results      GET  /proxy/particiapi/api/conversations/<cid>/results/
+  8. submit       POST /c/<slug>/statements/new
+
+Health invariants (any violation = recorded failure, non-zero exit)
+  * never a 5xx;
+  * /results/ always returns 200 (the proxy must rewrite a pre-math 403);
+  * proxy Set-Cookie never leaks a bare `session=` (only the renamed `pa_session`);
+  * statement quota returns a clean 403, never a 500.
+
+Prerequisites
+-------------
+  * The target must have DEV_FAKE_LOGIN=1 (local: in .env; staging: a Toolforge
+    envvar on the wiki-polis-dev tool). NEVER enable DEV_FAKE_LOGIN on production.
+  * A votable conversation slug (default "test" — free to mutate on staging).
+  * The vote/results actions need only login, so they soak the proxy on any deployed
+    instance. Auto-discovery (slug→id) and the `submit` action additionally need a
+    resolvable Participation for the dev-fake user; where that isn't set up (e.g. a
+    dev-fake row whose username drifted), pass --conversation-id (read it from the
+    page's <pa-conversation conversation-id="…">) and the soak runs on vote/results.
+
+Usage
+-----
+  # Local smoke (one of each action, then stop)
+  python synthetic_traffic.py --dry-run
+
+  # Staging soak: 3 identities, 10 minutes, ~2 req/s each
+  python synthetic_traffic.py \
+      --base-url https://wiki-polis-dev.toolforge.org \
+      --slug test --workers 3 --duration 600 --rate 2
+
+  # Bypass slug→id discovery (e.g. invite-only conv) by passing the Polis id
+  python synthetic_traffic.py --conversation-id 9r7fkvxyjb ...
+
+Exit codes: 0 = clean; 1 = ran but a health invariant was violated; 2 = could not
+authenticate (dev fake-login disabled / no valid --session-cookie) so nothing was sent.
+
+If the dev fake-login path is ever disabled for security (DEV_FAKE_LOGIN turned off, or
+the route removed), the tool detects that in a preflight probe and exits 2 with
+instructions to restore access — rather than firing traffic that all bounces to /login.
+"""
+import argparse
+import os
+import random
+import re
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from urllib.parse import urlparse
+
+import requests
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).with_name(".env"))
+
+DEFAULT_BASE = os.environ.get("WIKI_POLIS_FLASK_URL", "http://127.0.0.1:5001").rstrip("/")
+DEV_USERS = ["dev-user-1", "dev-user-2", "dev-user-3"]  # /dev/login/<username> (DEV_FAKE_LOGIN=1)
+VOTE_VALUES = [-1, 0, 1]                                 # disagree / pass / agree
+PSEUDONYM_RE = re.compile(r"^[a-z]+-[a-z]+$")            # matches the app's _PSEUDONYM_RE shape
+CONV_ID_RE = re.compile(r'conversation-id="([^"]+)"')
+CSRF_RE = re.compile(r'name="csrf_token"[^>]*value="([^"]+)"')
+
+
+class Health:
+    """Thread-safe collector of requests, latencies, and invariant violations."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self.records = []          # (action, status, latency_ms)
+        self.failures = []         # (action, method, path, status, detail)
+
+    def record(self, action, method, path, resp, latency_ms, *, expect_2xx=True,
+               results=False, allow_status=()):
+        with self._lock:
+            self.records.append((action, resp.status_code, latency_ms))
+            sc = resp.status_code
+            if sc >= 500:
+                self._fail(action, method, path, sc, "5xx server error")
+            elif results and sc != 200:
+                self._fail(action, method, path, sc,
+                           "/results/ not rewritten to 200 (proxy regression)")
+            elif sc == 429:
+                pass  # rate limited — expected under load, not a regression
+            elif expect_2xx and not (200 <= sc < 300) and sc not in allow_status:
+                self._fail(action, method, path, sc, f"unexpected status (body: {resp.text[:120]!r})")
+
+    def _fail(self, action, method, path, status, detail):
+        self.failures.append((action, method, path, status, detail))
+
+    def summary(self, elapsed_s):
+        by_action = {}
+        for action, status, lat in self.records:
+            d = by_action.setdefault(action, {"n": 0, "lat": [], "status": {}})
+            d["n"] += 1
+            d["lat"].append(lat)
+            d["status"][status] = d["status"].get(status, 0) + 1
+        lines = []
+        lines.append(f"\n{'='*72}\nSYNTHETIC TRAFFIC SUMMARY  ({len(self.records)} requests in {elapsed_s:.1f}s, "
+                     f"{len(self.records)/elapsed_s:.1f} req/s)\n{'='*72}")
+        lines.append(f"{'action':<12}{'n':>6}  {'p50':>7}{'p95':>7}{'p99':>7}  status")
+        for action, d in sorted(by_action.items()):
+            lat = sorted(d["lat"])
+            p = lambda q: lat[min(len(lat) - 1, int(q * len(lat)))]  # noqa: E731
+            statuses = " ".join(f"{s}×{c}" for s, c in sorted(d["status"].items()))
+            lines.append(f"{action:<12}{d['n']:>6}  {p(.5):>6.0f}m{p(.95):>6.0f}m{p(.99):>6.0f}m  {statuses}")
+        if self.failures:
+            lines.append(f"\n  !! {len(self.failures)} HEALTH VIOLATION(S):")
+            for action, method, path, status, detail in self.failures[:40]:
+                lines.append(f"     [{status}] {method} {path}  ({action}) — {detail}")
+            if len(self.failures) > 40:
+                lines.append(f"     ... and {len(self.failures) - 40} more")
+        else:
+            lines.append("\n  OK — no health invariant violated.")
+        return "\n".join(lines)
+
+
+def _origin(base_url):
+    u = urlparse(base_url)
+    return f"{u.scheme}://{u.netloc}"
+
+
+class Worker:
+    """One synthetic participant: its own requests.Session (cookie jar) and identity."""
+
+    def __init__(self, idx, args, health, deadline, stop):
+        self.idx = idx
+        self.args = args
+        self.health = health
+        self.deadline = deadline
+        self.stop = stop
+        self.s = requests.Session()
+        self.s.headers["User-Agent"] = "wiki-polis-synthetic-traffic/1.0"
+        self.s.verify = not args.insecure
+        self.origin = _origin(args.base_url)
+        self.pa_csrf = None
+        self.tids = []
+        self.cid = args.conversation_id
+        self.n_submit = 0
+
+    # ── one timed request with health checking ───────────────────────────────
+    def _req(self, action, method, path, **kw):
+        health = kw.pop("health", {})
+        url = self.args.base_url + path
+        t0 = time.monotonic()
+        resp = self.s.request(method, url, timeout=20, allow_redirects=False, **kw)
+        lat = (time.monotonic() - t0) * 1000
+        self.health.record(action, method, path, resp, lat, **health)
+        return resp
+
+    def _proxy(self, action, method, sub, **kw):
+        headers = kw.pop("headers", {})
+        if method in ("POST", "PUT"):
+            headers["Origin"] = self.origin           # mirror a real browser
+            if self.pa_csrf:
+                headers["X-CSRF-Token"] = self.pa_csrf
+        results = sub.endswith("/results/")
+        return self._req(action, method, f"/proxy/particiapi/{sub}", headers=headers,
+                         health={"results": results, "expect_2xx": True}, **kw)
+
+    # ── setup ────────────────────────────────────────────────────────────────
+    def auth(self):
+        # Availability is confirmed by preflight() before any worker starts; here we
+        # just establish this worker's identity. Stay quiet on failure — preflight owns
+        # the user-facing explanation.
+        if self.args.session_cookie:
+            self.s.headers["Cookie"] = self.args.session_cookie
+            return True
+        user = DEV_USERS[self.idx % len(DEV_USERS)]
+        r = self._req("auth", "GET", f"/dev/login/{user}", health={"allow_status": (302,)})
+        return r.status_code in (302, 200) and "login" not in r.headers.get("Location", "")
+
+    def accept(self):
+        """Ensure a Participation exists (needed for the submit action)."""
+        r = self._req("accept", "GET", f"/accept/{self.args.slug}",
+                      health={"allow_status": (302,)})
+        if r.status_code == 302:        # already participating
+            return True
+        if r.status_code != 200:
+            return False
+        m = CSRF_RE.search(r.text)
+        if not m:
+            return False
+        pj = self._req("accept", "GET", f"/accept/{self.args.slug}/pseudonyms")
+        choices = pj.json().get("pseudonyms", []) if pj.ok else []
+        pseudonym = next((p for p in choices if PSEUDONYM_RE.match(p)), None)
+        if not pseudonym:
+            return False
+        r = self._req("accept", "POST", f"/accept/{self.args.slug}",
+                      data={"csrf_token": m.group(1), "pseudonym": pseudonym},
+                      headers={"Origin": self.origin,
+                               "Referer": f"{self.args.base_url}/accept/{self.args.slug}"},
+                      health={"allow_status": (302, 400, 401, 404)})  # best-effort setup
+        return r.status_code in (302, 200)
+
+    def discover(self):
+        if self.cid:
+            return True
+        r = self._req("discover", "GET", f"/c/{self.args.slug}", health={"allow_status": (302,)})
+        m = CONV_ID_RE.search(r.text or "")
+        if m:
+            self.cid = m.group(1)
+            return True
+        print(f"  !! could not find conversation-id for slug '{self.args.slug}' "
+              "(status %d). Pass --conversation-id." % r.status_code, file=sys.stderr)
+        return False
+
+    def pa_session(self):
+        r = self._proxy("session", "POST", "api/session?create=true", json={})
+        if r.ok:
+            try:
+                self.pa_csrf = r.json().get("csrf_token")
+            except ValueError:
+                self.pa_csrf = None
+        return r.ok
+
+    def refresh_tids(self):
+        r = self._proxy("statements", "GET", f"api/conversations/{self.cid}/statements/")
+        if r.ok:
+            try:
+                self.tids = [int(t) for t in r.json().keys()]
+            except (ValueError, AttributeError):
+                self.tids = []
+
+    # ── actions ──────────────────────────────────────────────────────────────
+    def act_vote(self):
+        if not self.tids:
+            self.refresh_tids()
+        if not self.tids:
+            return
+        tid = random.choice(self.tids)
+        self._proxy("vote", "PUT", f"api/conversations/{self.cid}/votes/{tid}",
+                    json={"value": random.choice(VOTE_VALUES)})
+
+    def act_results(self):
+        self._proxy("results", "GET", f"api/conversations/{self.cid}/results/")
+
+    def act_submit(self):
+        self.n_submit += 1
+        text = f"{self.args.submit_text_prefix} w{self.idx} #{self.n_submit} — synthetic statement"
+        # 403 quota_exceeded and 404 (no participation) are acceptable, not failures.
+        # 201 created; 403 quota_exceeded; 401/404 no Participation — all acceptable.
+        self._req("submit", "POST", f"/c/{self.args.slug}/statements/new",
+                  json={"text": text}, headers={"Origin": self.origin,
+                  "Referer": f"{self.args.base_url}/c/{self.args.slug}"},
+                  health={"allow_status": (401, 403, 404)})
+
+    # ── loop ─────────────────────────────────────────────────────────────────
+    def run(self):
+        if not self.auth():
+            return
+        self.accept()  # idempotent; ensures Participation (submit) + a renderable /c/<slug>
+        if not self.discover():
+            return
+        self.pa_session()
+        self.refresh_tids()
+
+        if self.args.dry_run:
+            for a in ("vote", "results", "submit"):
+                if a in self.args.actions:
+                    getattr(self, f"act_{a}")()
+            return
+
+        interval = 1.0 / self.args.rate if self.args.rate > 0 else 0
+        iters = 0
+        while not self.stop.is_set():
+            if self.deadline and time.monotonic() >= self.deadline:
+                break
+            if self.args.iterations and iters >= self.args.iterations:
+                break
+            t0 = time.monotonic()
+            getattr(self, f"act_{random.choices(self.args.actions, self.args.weights)[0]}")()
+            iters += 1
+            sleep = interval - (time.monotonic() - t0)
+            if sleep > 0:
+                self.stop.wait(sleep)
+
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(description="Drive synthetic traffic at wiki-polis through the Flask proxy.")
+    p.add_argument("--base-url", default=DEFAULT_BASE,
+                   help=f"target base URL (default: {DEFAULT_BASE})")
+    p.add_argument("--slug", default="test", help="conversation slug (default: test)")
+    p.add_argument("--conversation-id", help="Polis conversation id (skip slug→id discovery)")
+    p.add_argument("--workers", type=int, default=3, help="concurrent identities (default: 3)")
+    p.add_argument("--duration", type=float, help="seconds to run")
+    p.add_argument("--iterations", type=int, help="actions per worker (instead of --duration)")
+    p.add_argument("--rate", type=float, default=2.0, help="requests/sec per worker (default: 2)")
+    p.add_argument("--actions", default="vote,results,submit",
+                   help="comma list with optional weights, e.g. 'vote:5,results:2,submit:1'")
+    p.add_argument("--session-cookie", help="raw Cookie header to use instead of dev-fake-login")
+    p.add_argument("--submit-text-prefix", default="[synthetic]", help="tag for submitted statements")
+    p.add_argument("--insecure", action="store_true", help="skip TLS verification")
+    p.add_argument("--dry-run", action="store_true",
+                   help="auth + discover + one of each action, then stop")
+    args = p.parse_args(argv)
+    args.base_url = args.base_url.rstrip("/")
+
+    actions, weights = [], []
+    for part in args.actions.split(","):
+        name, _, w = part.strip().partition(":")
+        if name not in ("vote", "results", "submit"):
+            p.error(f"unknown action '{name}'")
+        actions.append(name)
+        weights.append(float(w) if w else 1.0)
+    args.actions, args.weights = actions, weights
+
+    if not args.session_cookie and args.workers > len(DEV_USERS):
+        print(f"  note: capping --workers to {len(DEV_USERS)} (only {len(DEV_USERS)} "
+              "dev-fake-login identities; use --session-cookie for more).", file=sys.stderr)
+        args.workers = len(DEV_USERS)
+    if not args.dry_run and not args.duration and not args.iterations:
+        args.duration = 60.0
+    return args
+
+
+def preflight(args):
+    """One probe to confirm we can actually authenticate, BEFORE sending traffic.
+
+    Catches the case where the dev fake-login path has been disabled for security
+    (DEV_FAKE_LOGIN off, or the route removed) — otherwise every request would 302 to
+    /login and the run would look "successful" while testing nothing. Returns
+    (ok, human_detail).
+    """
+    s = requests.Session()
+    s.headers["User-Agent"] = "wiki-polis-synthetic-traffic/1.0 (preflight)"
+    s.verify = not args.insecure
+    try:
+        if args.session_cookie:
+            s.headers["Cookie"] = args.session_cookie
+            r = s.get(f"{args.base_url}/c/{args.slug}", allow_redirects=False, timeout=15)
+            loc = r.headers.get("Location", "").lower()
+            if r.status_code in (301, 302) and ("login" in loc or "oauth" in loc):
+                return False, (f"--session-cookie is not authenticated "
+                               f"(GET /c/{args.slug} -> {r.status_code} {loc}); it may be expired")
+            return True, "using supplied --session-cookie"
+        user = DEV_USERS[0]
+        r = s.get(f"{args.base_url}/dev/login/{user}", allow_redirects=False, timeout=15)
+    except requests.RequestException as e:
+        return False, f"could not reach {args.base_url}: {e}"
+    loc = r.headers.get("Location", "").lower()
+    ok = r.status_code in (200, 302) and "login" not in loc and "oauth" not in loc
+    return ok, f"GET /dev/login/{user} -> {r.status_code} {r.headers.get('Location', '')}".strip()
+
+
+def main(argv=None):
+    args = parse_args(argv)
+
+    ok, detail = preflight(args)
+    if not ok:
+        print(
+            f"\n  AUTH UNAVAILABLE — sending no traffic.\n"
+            f"  probe: {detail}\n\n"
+            f"  The login path needed to drive {args.base_url} is not available. This is\n"
+            f"  expected if dev fake-login was disabled for security. To run the soak,\n"
+            f"  restore access one of these ways:\n"
+            f"    • non-production target: enable fake-login — DEV_FAKE_LOGIN=1 (local .env,\n"
+            f"      or `toolforge envvars create DEV_FAKE_LOGIN 1` on wiki-polis-dev). Never on prod.\n"
+            f"    • any target: pass --session-cookie \"<cookie from an authenticated browser>\".\n",
+            file=sys.stderr)
+        return 2
+
+    health = Health()
+    stop = threading.Event()
+    deadline = (time.monotonic() + args.duration) if args.duration and not args.dry_run else None
+
+    mode = "dry-run" if args.dry_run else (f"{args.duration:.0f}s" if args.duration
+                                           else f"{args.iterations} iters")
+    print(f"→ {args.base_url}  slug={args.slug}  workers={args.workers}  "
+          f"actions={args.actions}  mode={mode}")
+
+    t0 = time.monotonic()
+    workers = [Worker(i, args, health, deadline, stop) for i in range(args.workers)]
+    try:
+        with ThreadPoolExecutor(max_workers=args.workers) as ex:
+            futures = [ex.submit(w.run) for w in workers]
+            for f in as_completed(futures):
+                f.result()
+    except KeyboardInterrupt:
+        print("\n  interrupted — stopping workers...", file=sys.stderr)
+        stop.set()
+    elapsed = time.monotonic() - t0
+
+    print(health.summary(elapsed))
+    return 1 if health.failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -1040,7 +1040,7 @@
     var text = newstmtInput.value.trim();
     if (!text) return;
     newstmtSubmit.disabled = true;
-    fetch('{{ url_for("conversation_statement_new", slug=conversation.slug) }}', {
+    fetch('{{ url_for("proxy.conversation_statement_new", slug=conversation.slug) }}', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'fetch' },
       body: JSON.stringify({ text: text }),

--- a/v2/tests/test_proxy_blueprint.py
+++ b/v2/tests/test_proxy_blueprint.py
@@ -1,0 +1,194 @@
+"""Direct tests for the proxy + statement-submit blueprint (issue #91, step 7).
+
+These cover the security-critical behaviours the main suite does NOT exercise. The
+shared `app` fixture runs with `WTF_CSRF_ENABLED=False`, so it cannot catch a broken
+`csrf.exempt(proxy_bp)` — yet CSRF exemption (with same-origin as the compensating
+control) is the whole security posture of these two routes. The extraction onto a
+blueprint must keep all of this byte-identical to the prior inline routes:
+
+- CSRF exemption is active on the blueprint;
+- the same-origin check still gates state-changing requests;
+- the pa_session <-> session cookie rename is preserved in both directions;
+- the 403->200 rewrite on /results/ that keeps the web component usable.
+"""
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+from cachelib.file import FileSystemCache
+
+from app import create_app
+from db import Conversation, Participation, db
+
+
+def _fake_upstream(status_code=200, content=b'{}', cookies=None,
+                   content_type='application/json'):
+    """Stand-in for a `requests` Response from Particiapi."""
+    m = MagicMock()
+    m.status_code = status_code
+    m.content = content
+    m.headers = {'Content-Type': content_type}
+    m.cookies = cookies or {}
+    return m
+
+
+# ── CSRF exemption — needs a CSRF-ENABLED app (the shared fixture disables it) ────
+
+@pytest.fixture
+def csrf_client(tmp_path):
+    session_dir = tmp_path / 'sessions'
+    session_dir.mkdir()
+    app = create_app({
+        'TESTING': True,
+        'SQLALCHEMY_DATABASE_URI': f'sqlite:///{tmp_path}/t.db',
+        'WTF_CSRF_ENABLED': True,
+        'RATELIMIT_ENABLED': False,
+        'SECRET_KEY': 'test-secret',
+        'SESSION_TYPE': 'cachelib',
+        'SESSION_CACHELIB': FileSystemCache(str(session_dir)),
+    })
+    with app.app_context():
+        db.create_all()
+        yield app.test_client()
+        db.session.remove()
+
+
+@pytest.mark.parametrize('path', ['/proxy/particiapi/api/foo',
+                                  '/c/any-slug/statements/new'])
+def test_blueprint_routes_are_csrf_exempt(csrf_client, path):
+    # No CSRF token, not logged in. If the blueprint were NOT exempt, Flask-WTF would
+    # reject at before_request with 400 'CSRF token missing'. Because it IS exempt the
+    # request reaches the view, where @login_required redirects to login (302). So a
+    # 400 here would mean the exemption silently broke in the extraction.
+    resp = csrf_client.post(path, json={'text': 'x'})
+    assert resp.status_code != 400, 'CSRF exemption broke — request rejected pre-view'
+    assert resp.status_code == 302  # login redirect from inside the view
+
+
+# ── Proxy cookie rename (both directions) ────────────────────────────────────────
+
+def test_proxy_renames_upstream_session_to_pa_session(auth_client):
+    up = _fake_upstream(cookies={'session': 'UPSTREAM123'})
+    with patch('app.requests.request', return_value=up):
+        resp = auth_client.get('/proxy/particiapi/api/conversations/abc/')
+    set_cookies = resp.headers.getlist('Set-Cookie')
+    # Particiapi's 'session' is re-emitted to the browser as 'pa_session', never raw.
+    assert any(c.startswith('pa_session=UPSTREAM123') for c in set_cookies)
+    assert not any(c.startswith('session=UPSTREAM123') for c in set_cookies)
+
+
+def test_proxy_forwards_pa_session_as_session(auth_client):
+    auth_client.set_cookie('pa_session', 'BROWSER456')
+    up = _fake_upstream()
+    with patch('app.requests.request', return_value=up) as req:
+        auth_client.get('/proxy/particiapi/api/conversations/abc/')
+    # The browser's 'pa_session' is forwarded upstream as Particiapi's 'session'.
+    assert req.call_args.kwargs['cookies'] == {'session': 'BROWSER456'}
+
+
+# ── 403 -> 200 rewrite (only on /results/) ───────────────────────────────────────
+
+def test_proxy_rewrites_results_403_to_200(auth_client):
+    up = _fake_upstream(status_code=403, content=b'forbidden')
+    with patch('app.requests.request', return_value=up):
+        resp = auth_client.get(
+            '/proxy/particiapi/api/conversations/abc/math/results/')
+    # Pre-math /results/ 403 would blank the UI; rewrite to an empty 200 instead.
+    assert resp.status_code == 200
+    assert resp.get_data() == b'{}'
+
+
+def test_proxy_passes_through_non_results_403(auth_client):
+    up = _fake_upstream(status_code=403, content=b'nope')
+    with patch('app.requests.request', return_value=up):
+        resp = auth_client.get('/proxy/particiapi/api/conversations/abc/')
+    assert resp.status_code == 403  # the rewrite is scoped to /results/ only
+
+
+# ── Same-origin compensating control ─────────────────────────────────────────────
+
+def test_proxy_post_blocks_cross_origin(auth_client):
+    resp = auth_client.post('/proxy/particiapi/api/foo',
+                            headers={'Sec-Fetch-Site': 'cross-site'}, json={})
+    assert resp.status_code == 403
+
+
+def test_proxy_post_allows_same_origin(auth_client):
+    up = _fake_upstream()
+    with patch('app.requests.request', return_value=up):
+        resp = auth_client.post('/proxy/particiapi/api/foo',
+                                headers={'Sec-Fetch-Site': 'same-origin'}, json={})
+    assert resp.status_code == 200
+
+
+# ── statement-submit route on the blueprint ──────────────────────────────────────
+
+def test_proxy_rejects_path_traversal_and_non_api(auth_client):
+    # CRIT-1 guard: only /api/ paths, no '..' segments — must never reach upstream.
+    with patch('app.requests.request') as req:
+        assert auth_client.get('/proxy/particiapi/api/../secret').status_code == 404
+        assert auth_client.get('/proxy/particiapi/etc/passwd').status_code == 404
+    req.assert_not_called()
+
+
+def test_proxy_strips_unknown_query_params(auth_client):
+    # HIGH-5 allowlist: only known-safe params are forwarded to Particiapi.
+    up = _fake_upstream()
+    with patch('app.requests.request', return_value=up) as req:
+        auth_client.get('/proxy/particiapi/api/conversations/abc/'
+                        '?zinvite=ok&evil=DROP&tid=3')
+    assert req.call_args.kwargs['params'] == {'zinvite': 'ok', 'tid': '3'}
+
+
+def test_statement_new_enforces_quota(auth_client, participant):
+    conv = Conversation(slug='q', polis_id='qxxxxxxxxx', title='Q', active=True,
+                        access_policy='public', phase_submission=True,
+                        argument_vote_data={'new_stmt_max': 1})
+    db.session.add(conv)
+    db.session.commit()
+    db.session.add(Participation(participant_id=participant.id,
+                                 conversation_id=conv.id, pseudonym='p',
+                                 new_stmt_ids=[101]))  # already at the cap of 1
+    db.session.commit()
+    with patch('app.requests.post') as post:
+        resp = auth_client.post('/c/q/statements/new',
+                                headers={'Sec-Fetch-Site': 'same-origin'},
+                                json={'text': 'one too many'})
+    assert resp.status_code == 403
+    assert resp.get_json() == {'error': 'quota_exceeded'}
+    post.assert_not_called()  # quota rejected before any upstream call
+
+
+def test_statement_new_blocks_cross_origin(auth_client):
+    resp = auth_client.post('/c/any/statements/new',
+                            headers={'Sec-Fetch-Site': 'cross-site'},
+                            json={'text': 'hi'})
+    assert resp.status_code == 403
+
+
+def test_statement_new_happy_path_records_polis_id(auth_client, participant):
+    conv = Conversation(slug='sub', polis_id='subxxxxxxx', title='Sub', active=True,
+                        access_policy='public', phase_submission=True,
+                        argument_vote_data={'new_stmt_max': 3})
+    db.session.add(conv)
+    db.session.commit()
+    db.session.add(Participation(participant_id=participant.id,
+                                 conversation_id=conv.id, pseudonym='p'))
+    db.session.commit()
+
+    sess_resp = _fake_upstream(cookies={'session': 'NEWPA'})
+    sess_resp.ok = True
+    sess_resp.json = lambda: {'csrf_token': 'TOK'}
+    stmt_resp = _fake_upstream(status_code=201, content=b'{"id":555}')
+    stmt_resp.json = lambda: {'id': 555}
+
+    with patch('app.requests.post', side_effect=[sess_resp, stmt_resp]):
+        resp = auth_client.post('/c/sub/statements/new',
+                                headers={'Sec-Fetch-Site': 'same-origin'},
+                                json={'text': 'A genuinely new idea'})
+
+    assert resp.status_code == 201
+    part = Participation.query.filter_by(conversation_id=conv.id).first()
+    assert 555 in (part.new_stmt_ids or [])  # Polis id recorded for novelty tracking
+    assert any(c.startswith('pa_session=NEWPA')
+               for c in resp.headers.getlist('Set-Cookie'))


### PR DESCRIPTION
Step 7 of the blueprint refactor (steps 5–6 landed in #97). **Behaviour-preserving**: the two CSRF-exempt routes move out of the 1,300-line `_register_routes` closure onto a module-level `Blueprint('proxy')`, with no logic change.

## What changed
- `POST /c/<slug>/statements/new` and `GET/POST/PUT /proxy/particiapi/<path>` now live on `proxy_bp`. The statement-submit body is byte-identical; the proxy view is a thin delegate to the **untouched** module-level `_proxy_to_particiapi` / `_validate_same_origin` helpers.
- Per-route `@csrf.exempt` → one explicit `csrf.exempt(proxy_bp)` in `create_app`.
- One template `url_for` updated → `proxy.conversation_statement_new` (proxy route is reached by literal path, unaffected).
- `_register_routes` cyclomatic complexity 153 → 142.
- Layout: module-level blueprint in `app.py` (lowest-risk for this security-sensitive step); a later pass moves the isolated blueprints into `v2/blueprints/*.py` + `extensions.py`.

## Tests — closes a real gap
The shared test app runs with `WTF_CSRF_ENABLED=False`, so the suite **never exercised the CSRF exemption** that is these routes' entire security posture. New `tests/test_proxy_blueprint.py` (13 tests):
- CSRF exemption is live on the blueprint (token-less POST reaches the view → 302, not 400) — via a CSRF-**enabled** fixture;
- same-origin control blocks cross-site / allows same-origin;
- `pa_session` ↔ `session` cookie rename both directions (no raw `session` leak);
- 403→200 rewrite scoped to `/results/` only;
- path-traversal / non-`api/` → 404 guard; query-param allowlist;
- statement `quota_exceeded` → 403 short-circuits before any upstream call;
- statement-submit happy path records the Polis id.

**133 passed** (was 120). `test_security.py` unchanged (zero assertion changes). `ruff` clean (one pre-existing E741).

## Review
Senior-engineer + security-expert agents (Opus) with mutual cross-review: **SHIP-WITH-NITS**, no behavioural or security regression. The CSRF exemption was mutation-verified (removing `csrf.exempt(proxy_bp)` makes the guard test fail). Two **pre-existing, out-of-scope** observations (proxy skips origin-check on GET; `with_for_update` is a SQLite no-op) are tracked in `.claude/todo-proxy-security-followups.md`.

## Relationships
- **Depends on:** #90 (merged via #97 — helpers at module level).
- **Ship alone, soak before** #92 (step 8 · admin routes) and #93 (step 9 · participant routes) — highest security sensitivity, so it lands and soaks on its own.
- **Touches shared code:** the proxy is the path all voting flows take — relevant to #69 (Change-vote), #64 (vote footer), #83 (Phase-6 voting).

Closes #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also in this PR — `v2/synthetic_traffic.py` (soak harness)

Because wiki-polis has too few real users to *soak* a proxy change via organic traffic, this PR also adds a reusable load/soak tool (sibling to `simulate_cats_vs_dogs.py`). Unlike the simulator (which drives Particiapi directly), it drives a **deployed** instance through the real Flask stack — dev-fake-login → `/proxy/particiapi` → statement-submit — so it exercises exactly this blueprint: the `pa_session`↔`session` rename, CSRF-exempt + same-origin posture, and the 403→200 `/results/` rewrite.

- Concurrent workers loop vote/results/submit at a configurable rate/duration, asserting health invariants (never a 5xx; `/results/` always 200; quota a clean 403) with a non-zero exit on any violation.
- **Preflight** detects a disabled fake-login path (`DEV_FAKE_LOGIN` off / removed for security) and exits 2 with instructions, rather than firing traffic that bounces to `/login`.
- Verified on staging (3 workers × 15s = 64 votes + 20 results, all 200, zero violations) and the disabled-path detection against prod (clean exit 2).

Use it to soak this PR on staging before promoting to prod.

**Also:** `guide_runbook.md` updated — staging topology (two VPS stacks, ports, the `wiki-polis-staging` compose-project gotcha, `DEV_FAKE_LOGIN` headless login) and an "Investigating a 5xx" playbook, harvested from soaking this PR. Closes the runbook's pending D-MON staging item.
