### PR TITLE
refactor(app): extract admin routes into a blueprint (#92)

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -650,6 +650,397 @@ def conversation_statement_new(slug):
 def proxy_particiapi(pa_path):
     return _proxy_to_particiapi(pa_path)
 
+admin_bp = Blueprint('admin', __name__)
+
+# ── Admin ─────────────────────────────────────────────────────────────────
+
+@admin_bp.get('/admin')
+@login_required
+@admin_required
+def admin():
+    conversations  = (Conversation.query
+                      .order_by(Conversation.created_at.desc()).all())
+    participants   = (Participant.query
+                      .order_by(Participant.mw_username).all())
+    global_admins  = (Participant.query
+                      .filter_by(is_global_admin=True)
+                      .order_by(Participant.mw_username).all())
+    return render_template('admin.html',
+                           conversations=conversations,
+                           participants=participants,
+                           global_admins=global_admins,
+                           )
+
+@admin_bp.get('/admin/conversations/<int:conv_id>')
+@login_required
+def admin_conversation_detail(conv_id):
+    conv       = _require_mod_for_conv(conv_id)
+    conv_roles = (AdminRole.query
+                   .filter_by(conversation_id=conv_id)
+                   .all())
+    participants      = Participant.query.order_by(Participant.mw_username).all()
+    invite_count      = ConversationInvite.query.filter_by(conversation_id=conv_id).count()
+    participant_count = Participation.query.filter_by(conversation_id=conv_id).count()
+    polis_stats       = _polis_server_client().get_polis_stats(conv.polis_id)
+    return render_template('admin_conversation.html',
+                           conversation=conv,
+                           conv_roles=conv_roles,
+                           participants=participants,
+                           invite_count=invite_count,
+                           participant_count=participant_count,
+                           polis_stats=polis_stats,
+                           polis_public_url=current_app.config.get('POLIS_PUBLIC_URL', ''),
+                           admin_roles=ADMIN_ROLES)
+
+@admin_bp.post('/admin/conversations/new')
+@login_required
+@admin_required
+def admin_conversation_new():
+    slug   = request.form.get('slug', '').strip().lower()
+    fields = _parse_conversation_form()
+
+    if not fields['title'] or not _valid_slug(slug):
+        abort(400)
+
+    polis_configured = all(current_app.config.get(k) for k in (
+        'POLIS_SERVER_URL', 'POLIS_ADMIN_EMAIL', 'POLIS_ADMIN_PASSWORD'))
+    if polis_configured:
+        try:
+            polis_id = _polis_server_client().create_conversation(fields['title'], strict_moderation=True)
+        except PolisServerError:
+            current_app.logger.exception('Polis conversation creation failed')
+            flash('Could not create the Polis conversation. Check server logs for details.', 'error')
+            return redirect(url_for('admin.admin'))
+    else:
+        # Fallback: accept manually supplied polis_id (local dev / misconfigured prod)
+        polis_id = request.form.get('polis_id', '').strip()
+        if not _valid_polis_id(polis_id):
+            return redirect(url_for('admin.admin', error=(
+                'POLIS_SERVER_URL / POLIS_ADMIN_EMAIL / POLIS_ADMIN_PASSWORD not configured. '
+                'Pass a polis_id manually or set the env vars.'
+            )))
+
+    db.session.add(Conversation(slug=slug, active=True, polis_id=polis_id, **fields))
+    db.session.commit()
+    return redirect(url_for('admin.admin'))
+
+@admin_bp.post('/admin/conversations/<int:conv_id>/edit')
+@login_required
+@admin_required
+def admin_conversation_edit(conv_id):
+    conv   = Conversation.query.get_or_404(conv_id)
+    fields = _parse_conversation_form()
+
+    if not fields['title']:
+        abort(400)
+
+    conv.title         = fields['title']
+    conv.intro_text    = fields['intro_text']
+    conv.outro_text    = fields['outro_text']
+    conv.access_policy = fields['access_policy']
+    db.session.commit()
+    return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
+
+@admin_bp.post('/admin/conversations/<int:conv_id>/pause')
+@login_required
+@admin_required
+def admin_conversation_pause(conv_id):
+    conv = Conversation.query.get_or_404(conv_id)
+    if not conv.active:
+        abort(400)
+    conv.paused = not conv.paused
+    db.session.commit()
+    return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
+
+@admin_bp.post('/admin/conversations/<int:conv_id>/close')
+@login_required
+@admin_required
+def admin_conversation_close(conv_id):
+    conv = Conversation.query.get_or_404(conv_id)
+    if not conv.active:
+        abort(400)
+    conv.active    = False
+    conv.paused    = False
+    conv.closed_at = datetime.now(timezone.utc)
+    db.session.commit()
+    return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
+
+@admin_bp.post('/admin/conversations/<int:conv_id>/phases')
+@login_required
+@admin_required
+def admin_conversation_phases(conv_id):
+    conv = Conversation.query.get_or_404(conv_id)
+    conv.phase_submission       = bool(request.form.get('phase_submission'))
+    conv.phase_personal_results = bool(request.form.get('phase_personal_results'))
+    conv.phase_argument_mapping = bool(request.form.get('phase_argument_mapping'))
+    conv.phase_public_results   = bool(request.form.get('phase_public_results'))
+    db.session.commit()
+    return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
+
+@admin_bp.post('/admin/global-admins/add')
+@login_required
+@admin_required
+def admin_global_admin_add():
+    mw_username = (request.form.get('mw_username') or '').strip()
+    if not mw_username:
+        flash('Enter a Wikimedia username.', 'error')
+        return redirect(url_for('admin.admin'))
+    p = Participant.query.filter_by(mw_username=mw_username).first()
+    if not p:
+        flash(f'No account found for "{mw_username}". They must log in at least once first.', 'error')
+        return redirect(url_for('admin.admin'))
+    p.is_global_admin = True
+    db.session.commit()
+    return redirect(url_for('admin.admin'))
+
+@admin_bp.post('/admin/global-admins/<int:participant_id>/remove')
+@login_required
+@admin_required
+def admin_global_admin_remove(participant_id):
+    p = Participant.query.get_or_404(participant_id)
+    p.is_global_admin = False
+    db.session.commit()
+    return redirect(url_for('admin.admin'))
+
+@admin_bp.post('/admin/roles/add')
+@login_required
+@admin_required
+def admin_role_add():
+    participant_id  = request.form.get('participant_id', type=int)
+    conversation_id = request.form.get('conversation_id', type=int)
+    role            = request.form.get('role', '').strip()
+
+    if role not in ADMIN_ROLES or not conversation_id:
+        abort(400)
+    Participant.query.get_or_404(participant_id)
+    Conversation.query.get_or_404(conversation_id)
+
+    existing = AdminRole.query.filter_by(
+        participant_id=participant_id,
+        conversation_id=conversation_id,
+        role=role,
+    ).first()
+    if not existing:
+        grantor = _current_participant()
+        db.session.add(AdminRole(
+            participant_id=participant_id,
+            conversation_id=conversation_id,
+            role=role,
+            granted_by=grantor.id if grantor else None,
+        ))
+        db.session.commit()
+    return redirect(_safe_redirect(request.form.get('redirect_to', ''), url_for('admin.admin')))
+
+@admin_bp.post('/admin/roles/<int:role_id>/remove')
+@login_required
+@admin_required
+def admin_role_remove(role_id):
+    role = AdminRole.query.get_or_404(role_id)
+    db.session.delete(role)
+    db.session.commit()
+    return redirect(_safe_redirect(request.form.get('redirect_to', ''), url_for('admin.admin')))
+
+@admin_bp.get('/admin/conversations/<int:conv_id>/invites')
+@login_required
+def admin_conversation_invites(conv_id):
+    conv    = _require_mod_for_conv(conv_id)
+    invites = (ConversationInvite.query
+               .filter_by(conversation_id=conv_id)
+               .order_by(ConversationInvite.mw_username)
+               .all())
+    return render_template('admin_invites.html',
+                           conversation=conv, invites=invites)
+
+@admin_bp.post('/admin/conversations/<int:conv_id>/invites/add')
+@login_required
+def admin_invite_add(conv_id):
+    _require_mod_for_conv(conv_id)
+    raw = [l.strip() for l in
+           request.form.get('mw_usernames', '').splitlines() if l.strip()]
+    usernames = [u for u in raw if 1 <= len(u) <= 255]
+    if not usernames:
+        return redirect(url_for('admin.admin_conversation_invites', conv_id=conv_id))
+    existing = {inv.mw_username for inv in
+                ConversationInvite.query.filter_by(conversation_id=conv_id).all()}
+    for username in usernames:
+        if username not in existing:
+            db.session.add(ConversationInvite(
+                conversation_id=conv_id, mw_username=username))
+    try:
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+    return redirect(url_for('admin.admin_conversation_invites', conv_id=conv_id))
+
+@admin_bp.post('/admin/conversations/<int:conv_id>/invites/<int:invite_id>/remove')
+@login_required
+def admin_invite_remove(conv_id, invite_id):
+    _require_mod_for_conv(conv_id)
+    invite = ConversationInvite.query.filter_by(
+        id=invite_id, conversation_id=conv_id).first_or_404()
+    db.session.delete(invite)
+    db.session.commit()
+    return redirect(url_for('admin.admin_conversation_invites', conv_id=conv_id))
+
+# ── Admin: Polis statement moderation ─────────────────────────────────────
+
+@admin_bp.get('/admin/conversations/<int:conv_id>/statements')
+@login_required
+def admin_conversation_statements(conv_id):
+    conv     = _require_mod_for_conv(conv_id)
+    pending = approved = hidden = []
+    settings = {}
+    # Prefer Postgres for accurate mod state; fall back to Particiapi when unavailable.
+    result = _polis_server_client().get_statements(conv.polis_id)
+    if result is not None:
+        pending, approved, hidden = result
+    else:
+        try:
+            pending, approved, hidden = PolisParticipantClient(
+                current_app.config['PARTICIAPI_BASE']
+            ).get_statements(conv.polis_id)
+        except PolisParticipantError:
+            current_app.logger.exception('get_statements failed')
+            flash('Could not load statements. Check server logs.', 'error')
+    try:
+        settings = PolisParticipantClient(
+            current_app.config['PARTICIAPI_BASE']
+        ).get_settings(conv.polis_id)
+    except PolisParticipantError:
+        pass
+    return render_template('admin_statements.html',
+                           conversation=conv,
+                           pending=pending,
+                           approved=approved,
+                           hidden=hidden,
+                           settings=settings,
+                           polis_public_url=current_app.config.get('POLIS_PUBLIC_URL') or 'https://pol.is')
+
+@admin_bp.post('/admin/conversations/<int:conv_id>/statements/<int:tid>/moderate')
+@login_required
+def admin_statement_moderate(conv_id, tid):
+    conv = _require_mod_for_conv(conv_id)
+    mod  = request.form.get('mod', type=int)
+    if mod not in (-1, 0, 1):
+        abort(400)
+    try:
+        _polis_server_client().moderate(conv.polis_id, tid, mod)
+    except PolisServerError:
+        current_app.logger.exception('moderate failed')
+        flash('Moderation action failed. Check server logs for details.', 'error')
+        return redirect(url_for('admin.admin_conversation_statements', conv_id=conv_id))
+    return redirect(url_for('admin.admin_conversation_statements', conv_id=conv_id))
+
+@admin_bp.post('/admin/conversations/<int:conv_id>/statements/seed')
+@login_required
+def admin_statement_seed(conv_id):
+    conv = _require_mod_for_conv(conv_id)
+    text = request.form.get('txt', '').strip()
+    text = nh3.clean(text, tags=frozenset())
+    if not text or len(text) > 280:
+        abort(400)
+    try:
+        _polis_server_client().add_seed(conv.polis_id, text)
+        flash('Seed statement added.', 'success')
+    except PolisServerError:
+        current_app.logger.exception('add_seed failed')
+        flash('Could not add seed statement. Check server logs for details.', 'error')
+    return redirect(url_for('admin.admin_conversation_statements', conv_id=conv_id))
+
+@admin_bp.post('/admin/conversations/<int:conv_id>/strict-moderation')
+@login_required
+def admin_conversation_strict_moderation(conv_id):
+    conv    = _require_mod_for_conv(conv_id)
+    enabled = request.form.get('strict_moderation') == '1'
+    try:
+        _polis_server_client().set_strict_moderation(conv.polis_id, enabled)
+    except PolisServerError:
+        current_app.logger.exception('set_strict_moderation failed')
+        flash('Could not update moderation settings. Check server logs for details.', 'error')
+    return redirect(url_for('admin.admin_conversation_statements', conv_id=conv_id))
+
+# ── Featured statements ───────────────────────────────────────────────────
+
+@admin_bp.get('/admin/conversations/<int:conv_id>/featured')
+@login_required
+def admin_conversation_featured(conv_id):
+    conv        = _require_mod_for_conv(conv_id)
+    confirmed   = (FeaturedStatement.query
+                   .filter_by(conversation_id=conv_id)
+                   .options(joinedload(FeaturedStatement.arguments))
+                   .order_by(FeaturedStatement.created_at).all())
+    for fs in confirmed:
+        fs.arguments.sort(key=lambda a: a.side if isinstance(a.side, str) else a.side.value or '')
+    _backfill_statement_texts(conv, confirmed)
+    confirmed_tids = {fs.polis_statement_id for fs in confirmed}
+    candidates   = _polis_server_client().get_featured_candidates(conv.polis_id)
+    if candidates is not None:
+        candidates = [c for c in candidates if c['tid'] not in confirmed_tids]
+    return render_template('admin_featured.html',
+                           conversation=conv,
+                           confirmed=confirmed,
+                           candidates=candidates)
+
+@admin_bp.post('/admin/conversations/<int:conv_id>/featured/confirm')
+@login_required
+def admin_featured_confirm(conv_id):
+    conv = _require_mod_for_conv(conv_id)
+    tid  = request.form.get('tid', type=int)
+    if tid is None:
+        abort(400)
+    if not FeaturedStatement.query.filter_by(
+            conversation_id=conv_id, polis_statement_id=tid).first():
+        db.session.add(FeaturedStatement(
+            conversation_id=conv_id,
+            polis_statement_id=tid,
+            statement_text=_fetch_statement_text(conv.polis_id, tid),
+            suggested_by_system=request.form.get('system_suggested') == '1',
+            confirmed_by_admin=True,
+        ))
+        db.session.commit()
+    return redirect(url_for('admin.admin_conversation_featured', conv_id=conv_id))
+
+@admin_bp.post('/admin/conversations/<int:conv_id>/featured/add')
+@login_required
+def admin_featured_add(conv_id):
+    conv = _require_mod_for_conv(conv_id)
+    tid  = request.form.get('tid', type=int)
+    if tid is None or tid < 0:
+        abort(400)
+    if not FeaturedStatement.query.filter_by(
+            conversation_id=conv_id, polis_statement_id=tid).first():
+        db.session.add(FeaturedStatement(
+            conversation_id=conv_id,
+            polis_statement_id=tid,
+            statement_text=_fetch_statement_text(conv.polis_id, tid),
+            suggested_by_system=False,
+            confirmed_by_admin=True,
+        ))
+        db.session.commit()
+    return redirect(url_for('admin.admin_conversation_featured', conv_id=conv_id))
+
+@admin_bp.post('/admin/conversations/<int:conv_id>/featured/<int:fs_id>/remove')
+@login_required
+def admin_featured_remove(conv_id, fs_id):
+    _require_mod_for_conv(conv_id)
+    fs = FeaturedStatement.query.filter_by(
+        id=fs_id, conversation_id=conv_id).first_or_404()
+    db.session.delete(fs)
+    db.session.commit()
+    return redirect(url_for('admin.admin_conversation_featured', conv_id=conv_id))
+
+@admin_bp.post('/admin/conversations/<int:conv_id>/arguments/<int:arg_id>/delete')
+@login_required
+def admin_argument_delete(conv_id, arg_id):
+    conv = _require_mod_for_conv(conv_id)
+    arg  = Argument.query.filter_by(id=arg_id).first_or_404()
+    FeaturedStatement.query.filter_by(
+        id=arg.featured_statement_id, conversation_id=conv.id).first_or_404()
+    db.session.delete(arg)
+    db.session.commit()
+    return redirect(url_for('admin.admin_conversation_featured', conv_id=conv_id))
+
+
 def create_app(test_config: dict | None = None) -> Flask:
     app = Flask(__name__)
 
@@ -818,6 +1209,7 @@ def create_app(test_config: dict | None = None) -> Flask:
     # _validate_same_origin() as the compensating control; exempt the whole
     # blueprint explicitly rather than per-route.
     app.register_blueprint(proxy_bp)
+    app.register_blueprint(admin_bp)
     csrf.exempt(proxy_bp)
 
     return app
@@ -1470,394 +1862,6 @@ def _register_routes(app: Flask) -> None:
     def logout():
         session.clear()
         return redirect(url_for('index'))
-
-    # ── Admin ─────────────────────────────────────────────────────────────────
-
-    @app.get('/admin')
-    @login_required
-    @admin_required
-    def admin():
-        conversations  = (Conversation.query
-                          .order_by(Conversation.created_at.desc()).all())
-        participants   = (Participant.query
-                          .order_by(Participant.mw_username).all())
-        global_admins  = (Participant.query
-                          .filter_by(is_global_admin=True)
-                          .order_by(Participant.mw_username).all())
-        return render_template('admin.html',
-                               conversations=conversations,
-                               participants=participants,
-                               global_admins=global_admins,
-                               )
-
-    @app.get('/admin/conversations/<int:conv_id>')
-    @login_required
-    def admin_conversation_detail(conv_id):
-        conv       = _require_mod_for_conv(conv_id)
-        conv_roles = (AdminRole.query
-                       .filter_by(conversation_id=conv_id)
-                       .all())
-        participants      = Participant.query.order_by(Participant.mw_username).all()
-        invite_count      = ConversationInvite.query.filter_by(conversation_id=conv_id).count()
-        participant_count = Participation.query.filter_by(conversation_id=conv_id).count()
-        polis_stats       = _polis_server_client().get_polis_stats(conv.polis_id)
-        return render_template('admin_conversation.html',
-                               conversation=conv,
-                               conv_roles=conv_roles,
-                               participants=participants,
-                               invite_count=invite_count,
-                               participant_count=participant_count,
-                               polis_stats=polis_stats,
-                               polis_public_url=current_app.config.get('POLIS_PUBLIC_URL', ''),
-                               admin_roles=ADMIN_ROLES)
-
-    @app.post('/admin/conversations/new')
-    @login_required
-    @admin_required
-    def admin_conversation_new():
-        slug   = request.form.get('slug', '').strip().lower()
-        fields = _parse_conversation_form()
-
-        if not fields['title'] or not _valid_slug(slug):
-            abort(400)
-
-        polis_configured = all(current_app.config.get(k) for k in (
-            'POLIS_SERVER_URL', 'POLIS_ADMIN_EMAIL', 'POLIS_ADMIN_PASSWORD'))
-        if polis_configured:
-            try:
-                polis_id = _polis_server_client().create_conversation(fields['title'], strict_moderation=True)
-            except PolisServerError:
-                current_app.logger.exception('Polis conversation creation failed')
-                flash('Could not create the Polis conversation. Check server logs for details.', 'error')
-                return redirect(url_for('admin'))
-        else:
-            # Fallback: accept manually supplied polis_id (local dev / misconfigured prod)
-            polis_id = request.form.get('polis_id', '').strip()
-            if not _valid_polis_id(polis_id):
-                return redirect(url_for('admin', error=(
-                    'POLIS_SERVER_URL / POLIS_ADMIN_EMAIL / POLIS_ADMIN_PASSWORD not configured. '
-                    'Pass a polis_id manually or set the env vars.'
-                )))
-
-        db.session.add(Conversation(slug=slug, active=True, polis_id=polis_id, **fields))
-        db.session.commit()
-        return redirect(url_for('admin'))
-
-    @app.post('/admin/conversations/<int:conv_id>/edit')
-    @login_required
-    @admin_required
-    def admin_conversation_edit(conv_id):
-        conv   = Conversation.query.get_or_404(conv_id)
-        fields = _parse_conversation_form()
-
-        if not fields['title']:
-            abort(400)
-
-        conv.title         = fields['title']
-        conv.intro_text    = fields['intro_text']
-        conv.outro_text    = fields['outro_text']
-        conv.access_policy = fields['access_policy']
-        db.session.commit()
-        return redirect(url_for('admin_conversation_detail', conv_id=conv_id))
-
-    @app.post('/admin/conversations/<int:conv_id>/pause')
-    @login_required
-    @admin_required
-    def admin_conversation_pause(conv_id):
-        conv = Conversation.query.get_or_404(conv_id)
-        if not conv.active:
-            abort(400)
-        conv.paused = not conv.paused
-        db.session.commit()
-        return redirect(url_for('admin_conversation_detail', conv_id=conv_id))
-
-    @app.post('/admin/conversations/<int:conv_id>/close')
-    @login_required
-    @admin_required
-    def admin_conversation_close(conv_id):
-        conv = Conversation.query.get_or_404(conv_id)
-        if not conv.active:
-            abort(400)
-        conv.active    = False
-        conv.paused    = False
-        conv.closed_at = datetime.now(timezone.utc)
-        db.session.commit()
-        return redirect(url_for('admin_conversation_detail', conv_id=conv_id))
-
-    @app.post('/admin/conversations/<int:conv_id>/phases')
-    @login_required
-    @admin_required
-    def admin_conversation_phases(conv_id):
-        conv = Conversation.query.get_or_404(conv_id)
-        conv.phase_submission       = bool(request.form.get('phase_submission'))
-        conv.phase_personal_results = bool(request.form.get('phase_personal_results'))
-        conv.phase_argument_mapping = bool(request.form.get('phase_argument_mapping'))
-        conv.phase_public_results   = bool(request.form.get('phase_public_results'))
-        db.session.commit()
-        return redirect(url_for('admin_conversation_detail', conv_id=conv_id))
-
-    @app.post('/admin/global-admins/add')
-    @login_required
-    @admin_required
-    def admin_global_admin_add():
-        mw_username = (request.form.get('mw_username') or '').strip()
-        if not mw_username:
-            flash('Enter a Wikimedia username.', 'error')
-            return redirect(url_for('admin'))
-        p = Participant.query.filter_by(mw_username=mw_username).first()
-        if not p:
-            flash(f'No account found for "{mw_username}". They must log in at least once first.', 'error')
-            return redirect(url_for('admin'))
-        p.is_global_admin = True
-        db.session.commit()
-        return redirect(url_for('admin'))
-
-    @app.post('/admin/global-admins/<int:participant_id>/remove')
-    @login_required
-    @admin_required
-    def admin_global_admin_remove(participant_id):
-        p = Participant.query.get_or_404(participant_id)
-        p.is_global_admin = False
-        db.session.commit()
-        return redirect(url_for('admin'))
-
-    @app.post('/admin/roles/add')
-    @login_required
-    @admin_required
-    def admin_role_add():
-        participant_id  = request.form.get('participant_id', type=int)
-        conversation_id = request.form.get('conversation_id', type=int)
-        role            = request.form.get('role', '').strip()
-
-        if role not in ADMIN_ROLES or not conversation_id:
-            abort(400)
-        Participant.query.get_or_404(participant_id)
-        Conversation.query.get_or_404(conversation_id)
-
-        existing = AdminRole.query.filter_by(
-            participant_id=participant_id,
-            conversation_id=conversation_id,
-            role=role,
-        ).first()
-        if not existing:
-            grantor = _current_participant()
-            db.session.add(AdminRole(
-                participant_id=participant_id,
-                conversation_id=conversation_id,
-                role=role,
-                granted_by=grantor.id if grantor else None,
-            ))
-            db.session.commit()
-        return redirect(_safe_redirect(request.form.get('redirect_to', ''), url_for('admin')))
-
-    @app.post('/admin/roles/<int:role_id>/remove')
-    @login_required
-    @admin_required
-    def admin_role_remove(role_id):
-        role = AdminRole.query.get_or_404(role_id)
-        db.session.delete(role)
-        db.session.commit()
-        return redirect(_safe_redirect(request.form.get('redirect_to', ''), url_for('admin')))
-
-    @app.get('/admin/conversations/<int:conv_id>/invites')
-    @login_required
-    def admin_conversation_invites(conv_id):
-        conv    = _require_mod_for_conv(conv_id)
-        invites = (ConversationInvite.query
-                   .filter_by(conversation_id=conv_id)
-                   .order_by(ConversationInvite.mw_username)
-                   .all())
-        return render_template('admin_invites.html',
-                               conversation=conv, invites=invites)
-
-    @app.post('/admin/conversations/<int:conv_id>/invites/add')
-    @login_required
-    def admin_invite_add(conv_id):
-        _require_mod_for_conv(conv_id)
-        raw = [l.strip() for l in
-               request.form.get('mw_usernames', '').splitlines() if l.strip()]
-        usernames = [u for u in raw if 1 <= len(u) <= 255]
-        if not usernames:
-            return redirect(url_for('admin_conversation_invites', conv_id=conv_id))
-        existing = {inv.mw_username for inv in
-                    ConversationInvite.query.filter_by(conversation_id=conv_id).all()}
-        for username in usernames:
-            if username not in existing:
-                db.session.add(ConversationInvite(
-                    conversation_id=conv_id, mw_username=username))
-        try:
-            db.session.commit()
-        except Exception:
-            db.session.rollback()
-        return redirect(url_for('admin_conversation_invites', conv_id=conv_id))
-
-    @app.post('/admin/conversations/<int:conv_id>/invites/<int:invite_id>/remove')
-    @login_required
-    def admin_invite_remove(conv_id, invite_id):
-        _require_mod_for_conv(conv_id)
-        invite = ConversationInvite.query.filter_by(
-            id=invite_id, conversation_id=conv_id).first_or_404()
-        db.session.delete(invite)
-        db.session.commit()
-        return redirect(url_for('admin_conversation_invites', conv_id=conv_id))
-
-    # ── Admin: Polis statement moderation ─────────────────────────────────────
-
-    @app.get('/admin/conversations/<int:conv_id>/statements')
-    @login_required
-    def admin_conversation_statements(conv_id):
-        conv     = _require_mod_for_conv(conv_id)
-        pending = approved = hidden = []
-        settings = {}
-        # Prefer Postgres for accurate mod state; fall back to Particiapi when unavailable.
-        result = _polis_server_client().get_statements(conv.polis_id)
-        if result is not None:
-            pending, approved, hidden = result
-        else:
-            try:
-                pending, approved, hidden = PolisParticipantClient(
-                    current_app.config['PARTICIAPI_BASE']
-                ).get_statements(conv.polis_id)
-            except PolisParticipantError:
-                current_app.logger.exception('get_statements failed')
-                flash('Could not load statements. Check server logs.', 'error')
-        try:
-            settings = PolisParticipantClient(
-                current_app.config['PARTICIAPI_BASE']
-            ).get_settings(conv.polis_id)
-        except PolisParticipantError:
-            pass
-        return render_template('admin_statements.html',
-                               conversation=conv,
-                               pending=pending,
-                               approved=approved,
-                               hidden=hidden,
-                               settings=settings,
-                               polis_public_url=current_app.config.get('POLIS_PUBLIC_URL') or 'https://pol.is')
-
-    @app.post('/admin/conversations/<int:conv_id>/statements/<int:tid>/moderate')
-    @login_required
-    def admin_statement_moderate(conv_id, tid):
-        conv = _require_mod_for_conv(conv_id)
-        mod  = request.form.get('mod', type=int)
-        if mod not in (-1, 0, 1):
-            abort(400)
-        try:
-            _polis_server_client().moderate(conv.polis_id, tid, mod)
-        except PolisServerError:
-            current_app.logger.exception('moderate failed')
-            flash('Moderation action failed. Check server logs for details.', 'error')
-            return redirect(url_for('admin_conversation_statements', conv_id=conv_id))
-        return redirect(url_for('admin_conversation_statements', conv_id=conv_id))
-
-    @app.post('/admin/conversations/<int:conv_id>/statements/seed')
-    @login_required
-    def admin_statement_seed(conv_id):
-        conv = _require_mod_for_conv(conv_id)
-        text = request.form.get('txt', '').strip()
-        text = nh3.clean(text, tags=frozenset())
-        if not text or len(text) > 280:
-            abort(400)
-        try:
-            _polis_server_client().add_seed(conv.polis_id, text)
-            flash('Seed statement added.', 'success')
-        except PolisServerError:
-            current_app.logger.exception('add_seed failed')
-            flash('Could not add seed statement. Check server logs for details.', 'error')
-        return redirect(url_for('admin_conversation_statements', conv_id=conv_id))
-
-    @app.post('/admin/conversations/<int:conv_id>/strict-moderation')
-    @login_required
-    def admin_conversation_strict_moderation(conv_id):
-        conv    = _require_mod_for_conv(conv_id)
-        enabled = request.form.get('strict_moderation') == '1'
-        try:
-            _polis_server_client().set_strict_moderation(conv.polis_id, enabled)
-        except PolisServerError:
-            current_app.logger.exception('set_strict_moderation failed')
-            flash('Could not update moderation settings. Check server logs for details.', 'error')
-        return redirect(url_for('admin_conversation_statements', conv_id=conv_id))
-
-    # ── Featured statements ───────────────────────────────────────────────────
-
-    @app.get('/admin/conversations/<int:conv_id>/featured')
-    @login_required
-    def admin_conversation_featured(conv_id):
-        conv        = _require_mod_for_conv(conv_id)
-        confirmed   = (FeaturedStatement.query
-                       .filter_by(conversation_id=conv_id)
-                       .options(joinedload(FeaturedStatement.arguments))
-                       .order_by(FeaturedStatement.created_at).all())
-        for fs in confirmed:
-            fs.arguments.sort(key=lambda a: a.side if isinstance(a.side, str) else a.side.value or '')
-        _backfill_statement_texts(conv, confirmed)
-        confirmed_tids = {fs.polis_statement_id for fs in confirmed}
-        candidates   = _polis_server_client().get_featured_candidates(conv.polis_id)
-        if candidates is not None:
-            candidates = [c for c in candidates if c['tid'] not in confirmed_tids]
-        return render_template('admin_featured.html',
-                               conversation=conv,
-                               confirmed=confirmed,
-                               candidates=candidates)
-
-    @app.post('/admin/conversations/<int:conv_id>/featured/confirm')
-    @login_required
-    def admin_featured_confirm(conv_id):
-        conv = _require_mod_for_conv(conv_id)
-        tid  = request.form.get('tid', type=int)
-        if tid is None:
-            abort(400)
-        if not FeaturedStatement.query.filter_by(
-                conversation_id=conv_id, polis_statement_id=tid).first():
-            db.session.add(FeaturedStatement(
-                conversation_id=conv_id,
-                polis_statement_id=tid,
-                statement_text=_fetch_statement_text(conv.polis_id, tid),
-                suggested_by_system=request.form.get('system_suggested') == '1',
-                confirmed_by_admin=True,
-            ))
-            db.session.commit()
-        return redirect(url_for('admin_conversation_featured', conv_id=conv_id))
-
-    @app.post('/admin/conversations/<int:conv_id>/featured/add')
-    @login_required
-    def admin_featured_add(conv_id):
-        conv = _require_mod_for_conv(conv_id)
-        tid  = request.form.get('tid', type=int)
-        if tid is None or tid < 0:
-            abort(400)
-        if not FeaturedStatement.query.filter_by(
-                conversation_id=conv_id, polis_statement_id=tid).first():
-            db.session.add(FeaturedStatement(
-                conversation_id=conv_id,
-                polis_statement_id=tid,
-                statement_text=_fetch_statement_text(conv.polis_id, tid),
-                suggested_by_system=False,
-                confirmed_by_admin=True,
-            ))
-            db.session.commit()
-        return redirect(url_for('admin_conversation_featured', conv_id=conv_id))
-
-    @app.post('/admin/conversations/<int:conv_id>/featured/<int:fs_id>/remove')
-    @login_required
-    def admin_featured_remove(conv_id, fs_id):
-        _require_mod_for_conv(conv_id)
-        fs = FeaturedStatement.query.filter_by(
-            id=fs_id, conversation_id=conv_id).first_or_404()
-        db.session.delete(fs)
-        db.session.commit()
-        return redirect(url_for('admin_conversation_featured', conv_id=conv_id))
-
-    @app.post('/admin/conversations/<int:conv_id>/arguments/<int:arg_id>/delete')
-    @login_required
-    def admin_argument_delete(conv_id, arg_id):
-        conv = _require_mod_for_conv(conv_id)
-        arg  = Argument.query.filter_by(id=arg_id).first_or_404()
-        FeaturedStatement.query.filter_by(
-            id=arg.featured_statement_id, conversation_id=conv.id).first_or_404()
-        db.session.delete(arg)
-        db.session.commit()
-        return redirect(url_for('admin_conversation_featured', conv_id=conv_id))
 
     # ── Health ────────────────────────────────────────────────────────────────
 

--- a/v2/templates/admin.html
+++ b/v2/templates/admin.html
@@ -34,7 +34,7 @@
           {% endif %}
         </td>
         <td>
-          <a href="{{ url_for('admin_conversation_detail', conv_id=c.id) }}"
+          <a href="{{ url_for('admin.admin_conversation_detail', conv_id=c.id) }}"
              class="btn-small">manage</a>
         </td>
       </tr>
@@ -45,7 +45,7 @@
   <!-- ── New conversation ──────────────────────────── -->
   <div class="edit-form">
     <h3>New conversation</h3>
-    <form method="post" action="{{ url_for('admin_conversation_new') }}">
+    <form method="post" action="{{ url_for('admin.admin_conversation_new') }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="edit-row-fields">
         <label>Slug (URL-safe, immutable)
@@ -96,7 +96,7 @@
         <td>{{ p.mw_username }}</td>
         <td>
           <form method="post"
-                action="{{ url_for('admin_global_admin_remove', participant_id=p.id) }}"
+                action="{{ url_for('admin.admin_global_admin_remove', participant_id=p.id) }}"
                 style="display:inline">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit" class="btn-small btn-danger">remove</button>
@@ -112,7 +112,7 @@
 
   <div class="edit-form">
     <h3>Grant global admin</h3>
-    <form method="post" action="{{ url_for('admin_global_admin_add') }}">
+    <form method="post" action="{{ url_for('admin.admin_global_admin_add') }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="edit-row-fields">
         <label>Wikimedia username

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -4,7 +4,7 @@
 <div class="container">
 
   <p class="muted" style="margin-bottom:1.5rem">
-    <a href="{{ url_for('admin') }}">← admin panel</a>
+    <a href="{{ url_for('admin.admin') }}">← admin panel</a>
   </p>
 
   <div style="display:flex;align-items:baseline;gap:1rem;flex-wrap:wrap;margin-bottom:.25rem">
@@ -59,7 +59,7 @@
   <div class="edit-form">
     {% if is_admin %}
     <form method="post"
-          action="{{ url_for('admin_conversation_phases', conv_id=conversation.id) }}"
+          action="{{ url_for('admin.admin_conversation_phases', conv_id=conversation.id) }}"
           class="phases-form" style="flex-wrap:wrap;gap:.75rem">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <label title="Submission open">
@@ -101,13 +101,13 @@
   <h3 class="section-heading">Content &amp; access</h3>
   <div class="conv-action-grid">
 
-    <a href="{{ url_for('admin_conversation_statements', conv_id=conversation.id) }}"
+    <a href="{{ url_for('admin.admin_conversation_statements', conv_id=conversation.id) }}"
        class="conv-action-card">
       <div class="conv-action-title">Statements</div>
       <div class="conv-action-desc">Review, approve or hide participant statements; add seed statements</div>
     </a>
 
-    <a href="{{ url_for('admin_conversation_invites', conv_id=conversation.id) }}"
+    <a href="{{ url_for('admin.admin_conversation_invites', conv_id=conversation.id) }}"
        class="conv-action-card">
       <div class="conv-action-title">Invites</div>
       <div class="conv-action-desc">
@@ -115,7 +115,7 @@
       </div>
     </a>
 
-    <a href="{{ url_for('admin_conversation_featured', conv_id=conversation.id) }}"
+    <a href="{{ url_for('admin.admin_conversation_featured', conv_id=conversation.id) }}"
        class="conv-action-card">
       <div class="conv-action-title">Featured statements</div>
       <div class="conv-action-desc">
@@ -142,7 +142,7 @@
     <!-- Pause / Resume -->
     <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.25rem">
       <form method="post"
-            action="{{ url_for('admin_conversation_pause', conv_id=conversation.id) }}"
+            action="{{ url_for('admin.admin_conversation_pause', conv_id=conversation.id) }}"
             style="display:inline">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <button type="submit"
@@ -169,7 +169,7 @@
         consultation.
       </p>
       <form id="close-permanently-form" method="post"
-            action="{{ url_for('admin_conversation_close', conv_id=conversation.id) }}"
+            action="{{ url_for('admin.admin_conversation_close', conv_id=conversation.id) }}"
             style="display:inline">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         <button type="submit" class="btn-small btn-danger">Close permanently</button>
@@ -191,7 +191,7 @@
   <h3 class="section-heading">Settings</h3>
   <div class="edit-form">
     <form method="post"
-          action="{{ url_for('admin_conversation_edit', conv_id=conversation.id) }}">
+          action="{{ url_for('admin.admin_conversation_edit', conv_id=conversation.id) }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="edit-row-fields">
         <label>Title
@@ -239,11 +239,11 @@
         <td>{{ role.role }}</td>
         <td>
           <form method="post"
-                action="{{ url_for('admin_role_remove', role_id=role.id) }}"
+                action="{{ url_for('admin.admin_role_remove', role_id=role.id) }}"
                 style="display:inline">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="redirect_to"
-                   value="{{ url_for('admin_conversation_detail', conv_id=conversation.id) }}">
+                   value="{{ url_for('admin.admin_conversation_detail', conv_id=conversation.id) }}">
             <button type="submit" class="btn-small btn-danger">remove</button>
           </form>
         </td>
@@ -257,11 +257,11 @@
 
   <div class="edit-form">
     <h3>Add moderator</h3>
-    <form method="post" action="{{ url_for('admin_role_add') }}">
+    <form method="post" action="{{ url_for('admin.admin_role_add') }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <input type="hidden" name="conversation_id" value="{{ conversation.id }}">
       <input type="hidden" name="redirect_to"
-             value="{{ url_for('admin_conversation_detail', conv_id=conversation.id) }}">
+             value="{{ url_for('admin.admin_conversation_detail', conv_id=conversation.id) }}">
       <div class="edit-row-fields">
         <label>Participant
           <select name="participant_id" required>

--- a/v2/templates/admin_featured.html
+++ b/v2/templates/admin_featured.html
@@ -6,7 +6,7 @@
 
   <h2>Featured statements — {{ conversation.title }}</h2>
   <p class="muted" style="margin-bottom:1.5rem">
-    <a href="{{ url_for('admin_conversation_detail', conv_id=conversation.id) }}">← conversation</a>
+    <a href="{{ url_for('admin.admin_conversation_detail', conv_id=conversation.id) }}">← conversation</a>
   </p>
 
   <p class="muted" style="font-size:13px;margin-bottom:1.5rem">
@@ -42,7 +42,7 @@
               <span style="color:var(--muted);white-space:nowrap">{{ arg.proposer.mw_username if arg.proposer else '—' }}</span>
               <span style="color:var(--muted);white-space:nowrap">{{ arg.created_at.strftime('%Y-%m-%d') if arg.created_at else '' }}</span>
               <form method="post"
-                    action="{{ url_for('admin_argument_delete', conv_id=conversation.id, arg_id=arg.id) }}"
+                    action="{{ url_for('admin.admin_argument_delete', conv_id=conversation.id, arg_id=arg.id) }}"
                     style="display:inline;flex-shrink:0">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <button type="submit" class="btn-small btn-danger"
@@ -57,7 +57,7 @@
         </td>
         <td style="vertical-align:top">
           <form method="post"
-                action="{{ url_for('admin_featured_remove', conv_id=conversation.id, fs_id=fs.id) }}"
+                action="{{ url_for('admin.admin_featured_remove', conv_id=conversation.id, fs_id=fs.id) }}"
                 style="display:inline">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit" class="btn-small btn-danger"
@@ -109,7 +109,7 @@
         <td>{{ c.n_votes }}</td>
         <td>
           <form method="post"
-                action="{{ url_for('admin_featured_confirm', conv_id=conversation.id) }}"
+                action="{{ url_for('admin.admin_featured_confirm', conv_id=conversation.id) }}"
                 style="display:inline">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="tid" value="{{ c.tid }}">
@@ -129,7 +129,7 @@
     <p class="muted" style="font-size:13px;margin-bottom:.75rem">
       Enter the Polis statement ID (TID) to feature it directly.
     </p>
-    <form method="post" action="{{ url_for('admin_featured_add', conv_id=conversation.id) }}">
+    <form method="post" action="{{ url_for('admin.admin_featured_add', conv_id=conversation.id) }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <div class="edit-row-fields">
         <label>Statement TID

--- a/v2/templates/admin_invites.html
+++ b/v2/templates/admin_invites.html
@@ -9,7 +9,7 @@
   <p class="muted" style="margin-bottom: 1.25rem;">
     Access policy: <strong>{{ conversation.access_policy }}</strong>
     &nbsp;·&nbsp;
-    <a href="{{ url_for('admin') }}">← back to admin</a>
+    <a href="{{ url_for('admin.admin') }}">← back to admin</a>
   </p>
 
   {% if conversation.access_policy != 'invite_only' %}
@@ -24,7 +24,7 @@
   <div class="edit-form">
     <h3>Add invites</h3>
     <form method="post"
-          action="{{ url_for('admin_invite_add', conv_id=conversation.id) }}">
+          action="{{ url_for('admin.admin_invite_add', conv_id=conversation.id) }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <label>Wikimedia usernames (one per line)
         <textarea name="mw_usernames" rows="6"
@@ -49,7 +49,7 @@
         <td class="muted">{{ inv.created_at.strftime('%Y-%m-%d') }}</td>
         <td>
           <form method="post"
-                action="{{ url_for('admin_invite_remove', conv_id=conversation.id, invite_id=inv.id) }}"
+                action="{{ url_for('admin.admin_invite_remove', conv_id=conversation.id, invite_id=inv.id) }}"
                 style="display:inline">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button type="submit" class="btn-small btn-danger">remove</button>

--- a/v2/templates/admin_statements.html
+++ b/v2/templates/admin_statements.html
@@ -5,7 +5,7 @@
 
   <h2>Statements — {{ conversation.title }}</h2>
   <p class="muted" style="margin-bottom:1.5rem">
-    <a href="{{ url_for('admin') }}">← admin</a>
+    <a href="{{ url_for('admin.admin') }}">← admin</a>
   </p>
 
   {% if polis_public_url %}
@@ -23,7 +23,7 @@
       Adds a statement that immediately appears in the vote view for all participants.
       Statements added here appear as regular participant statements (not seed-marked).
     </p>
-    <form method="post" action="{{ url_for('admin_statement_seed', conv_id=conversation.id) }}">
+    <form method="post" action="{{ url_for('admin.admin_statement_seed', conv_id=conversation.id) }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <label>Statement text (max 280 characters)
         <textarea name="txt" rows="3" maxlength="280" id="seed-txt" required
@@ -40,7 +40,7 @@
   <h3 class="section-heading">Moderation settings</h3>
   <div class="edit-form" style="margin-bottom:2rem">
     <form method="post"
-          action="{{ url_for('admin_conversation_strict_moderation', conv_id=conversation.id) }}">
+          action="{{ url_for('admin.admin_conversation_strict_moderation', conv_id=conversation.id) }}">
       <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <label class="checkbox-label" style="font-weight:normal;color:var(--text)">
         <input type="checkbox" name="strict_moderation" value="1"
@@ -83,13 +83,13 @@
         </td>
         <td class="stmt-actions">
           <form method="post" style="display:inline"
-                action="{{ url_for('admin_statement_moderate', conv_id=conversation.id, tid=s.tid) }}">
+                action="{{ url_for('admin.admin_statement_moderate', conv_id=conversation.id, tid=s.tid) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="mod" value="1">
             <button type="submit" class="btn-small btn-approve">approve</button>
           </form>
           <form method="post" style="display:inline"
-                action="{{ url_for('admin_statement_moderate', conv_id=conversation.id, tid=s.tid) }}">
+                action="{{ url_for('admin.admin_statement_moderate', conv_id=conversation.id, tid=s.tid) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="mod" value="-1">
             <button type="submit" class="btn-small btn-danger">hide</button>
@@ -131,13 +131,13 @@
         </td>
         <td class="stmt-actions">
           <form method="post" style="display:inline"
-                action="{{ url_for('admin_statement_moderate', conv_id=conversation.id, tid=s.tid) }}">
+                action="{{ url_for('admin.admin_statement_moderate', conv_id=conversation.id, tid=s.tid) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="mod" value="-1">
             <button type="submit" class="btn-small btn-danger">hide</button>
           </form>
           <form method="post" style="display:inline"
-                action="{{ url_for('admin_statement_moderate', conv_id=conversation.id, tid=s.tid) }}">
+                action="{{ url_for('admin.admin_statement_moderate', conv_id=conversation.id, tid=s.tid) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="mod" value="0">
             <button type="submit" class="btn-small">pending</button>
@@ -179,13 +179,13 @@
         </td>
         <td class="stmt-actions">
           <form method="post" style="display:inline"
-                action="{{ url_for('admin_statement_moderate', conv_id=conversation.id, tid=s.tid) }}">
+                action="{{ url_for('admin.admin_statement_moderate', conv_id=conversation.id, tid=s.tid) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="mod" value="1">
             <button type="submit" class="btn-small btn-approve">approve</button>
           </form>
           <form method="post" style="display:inline"
-                action="{{ url_for('admin_statement_moderate', conv_id=conversation.id, tid=s.tid) }}">
+                action="{{ url_for('admin.admin_statement_moderate', conv_id=conversation.id, tid=s.tid) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="mod" value="0">
             <button type="submit" class="btn-small">pending</button>

--- a/v2/templates/base.html
+++ b/v2/templates/base.html
@@ -37,7 +37,7 @@
             <button type="submit" class="header-logout">log out</button>
           </form>
           {% if is_admin %}
-            <a href="{{ url_for('admin') }}" class="header-admin-link">admin</a>
+            <a href="{{ url_for('admin.admin') }}" class="header-admin-link">admin</a>
           {% endif %}
         {% else %}
           <a href="{{ url_for('login') }}" style="color:var(--muted);font-size:13px;text-decoration:none">log in</a>

--- a/v2/templates/forbidden_invite_only.html
+++ b/v2/templates/forbidden_invite_only.html
@@ -18,7 +18,7 @@
   <div style="background:#f0f4ff;border:1px solid #c7d3f5;border-radius:8px;padding:1rem 1.25rem;font-size:14px;color:var(--ink);line-height:1.6;margin-bottom:1.5rem">
     <strong>You can moderate this consultation.</strong>
     To participate as a voter, add yourself to the invite list first:
-    <a href="{{ url_for('admin_conversation_invites', conv_id=conversation.id) }}"
+    <a href="{{ url_for('admin.admin_conversation_invites', conv_id=conversation.id) }}"
        style="color:var(--accent)">Manage invites →</a>
   </div>
   {% endif %}

--- a/v2/templates/home.html
+++ b/v2/templates/home.html
@@ -162,7 +162,7 @@
         </span>
         <span class="conv-card-divider" aria-hidden="true"></span>
         {# → aria-hidden on "Admin →" not needed — the aria-label overrides the text content #}
-        <a href="{{ url_for('admin_conversation_detail', conv_id=c.id) }}"
+        <a href="{{ url_for('admin.admin_conversation_detail', conv_id=c.id) }}"
            class="admin-action-btn"
            aria-label="Open admin panel for {{ c.title }}">Admin →</a>
       </div>

--- a/v2/tests/test_admin.py
+++ b/v2/tests/test_admin.py
@@ -207,3 +207,26 @@ def test_remove_invite(admin_client, conv):
         f'/admin/conversations/{conv.id}/invites/{inv.id}/remove')
     assert resp.status_code == 302
     assert db.session.get(ConversationInvite, inv.id) is None
+
+
+# ── Template-render smoke test (#92 blueprint extraction) ───────────────────────
+# The admin routes moved onto Blueprint('admin'), so every `url_for('admin…')` in the
+# admin templates was requalified to `url_for('admin.admin…')`. The rest of this suite
+# hits admin routes by URL path, which only catches a broken template url_for if that
+# template is GET-rendered — and admin_conversation.html (13 url_for calls),
+# admin_invites.html, and admin_statements.html are NOT otherwise rendered here. This
+# guards them (and future renames) by GET-rendering all three end to end.
+def test_admin_template_pages_render(admin_client, conv):
+    # Pure-DB pages — no backend needed.
+    assert admin_client.get(f'/admin/conversations/{conv.id}').status_code == 200
+    assert admin_client.get(f'/admin/conversations/{conv.id}/invites').status_code == 200
+
+    # Statements page pulls from Polis; stub both clients so it renders offline.
+    from unittest.mock import MagicMock
+    server = MagicMock()
+    server.get_statements.return_value = ([], [], [])
+    with patch('app._polis_server_client', return_value=server), \
+         patch('app.PolisParticipantClient') as ppc:
+        ppc.return_value.get_settings.return_value = {}
+        resp = admin_client.get(f'/admin/conversations/{conv.id}/statements')
+    assert resp.status_code == 200


### PR DESCRIPTION
Blueprint-refactor **step 8** — lifts the **23 `/admin/…` route handlers** out of the 1,300-line `_register_routes` closure onto a module-level `Blueprint('admin')`. Behavior-preserving: a contiguous, closure-independent block moved verbatim (dedented one level), no logic change.

## What changed
- 23 handlers → `admin_bp`; both auth conventions preserved **and kept distinct**: `@admin_required` (global admin, 10 routes) and in-body `_require_mod_for_conv(conv_id)` (per-conversation moderator, 13 routes). `@login_required` intact on all.
- **CSRF stays ON** — `admin_bp` is *not* csrf-exempt (only the proxy blueprint is). Admin POSTs keep their tokens.
- Endpoints are now `admin.<fn>` (Flask qualifies blueprint endpoints, per the #91 precedent); the **60 `url_for('admin…')` references** across `app.py` + 8 templates were requalified to `url_for('admin.admin…')`. Rendered URLs unchanged.
- `_register_routes` cyclomatic complexity **153 → 90**.

## Tests
- **134 passed**, zero assertion changes to existing tests.
- Added `test_admin_template_pages_render`: GET-renders `admin_conversation.html` (13 `url_for`), `admin_invites.html`, `admin_statements.html` — the three admin templates the path-tests don't otherwise render — so a future broken `url_for('admin.…')` in them fails loudly instead of shipping a silent 500.

## Review
Three independent Opus passes: senior (correctness) **SHIP**, security **SHIP**, cross-review adjudicator **AGREE-SHIP** (re-derived the byte-identical-bodies and `csrf._exempt_blueprints == {proxy}` claims; checked shared blind spots — app-level `before/after_request` hooks + context processor still fire for blueprint routes, no rate-limit/`_external`/JS-`url_for`/error-handler/endpoint-name coupling). No blocking findings.

## Relationships
- **Refactor series:** step 8 of the 9-step blueprint refactor (audit/plan #94; steps 1–6 merged via #88/#97, step 7 via #98). Depends on #90 + #91 (both merged).
- **Ship before #93** (step 9, the last) — which extracts the participant/accept/argument/reveal routes.
- **Touches code shared with** open admin issues: #84, #68, #61, #60, #47, #42, #12 — all of which add/restructure admin routes and now build on the blueprint.

Closes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)