### PR TITLE
refactor(app): extract participant/accept/argument/reveal routes into a blueprint (#93)

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -651,6 +651,7 @@ def proxy_particiapi(pa_path):
     return _proxy_to_particiapi(pa_path)
 
 admin_bp = Blueprint('admin', __name__)
+participant_bp = Blueprint('participant', __name__)
 
 # ── Admin ─────────────────────────────────────────────────────────────────
 
@@ -1041,6 +1042,393 @@ def admin_argument_delete(conv_id, arg_id):
     return redirect(url_for('admin.admin_conversation_featured', conv_id=conv_id))
 
 
+# ── Accept ───────────────────────────────────────────────────────────────
+
+@participant_bp.get('/accept/<slug>')
+@login_required
+def accept(slug):
+    conv        = Conversation.query.filter_by(slug=slug).first_or_404()
+    participant = _current_participant()
+    _check_conversation_access(conv, participant)
+    if participant and Participation.query.filter_by(
+            participant_id=participant.id,
+            conversation_id=conv.id).first():
+        return redirect(url_for('participant.conversation', slug=slug))
+    pseudonyms = _generate_pseudonyms(5)
+    emailable  = session.get('emailable', False)
+    return render_template('accept.html', conversation=conv,
+                           emailable=emailable, pseudonyms=pseudonyms,
+                           reveal_cooldown=_REVEAL_COOLDOWN_DAYS,
+                           reveal_window_end=_REVEAL_COOLDOWN_DAYS + _REVEAL_NULLIFY_DAYS,
+                           retention_public_days=120)
+
+@participant_bp.post('/accept/<slug>')
+@login_required
+@limiter.limit('10 per minute')
+def accept_post(slug):
+    conv        = Conversation.query.filter_by(slug=slug).first_or_404()
+    participant = _current_participant()
+    if participant is None:
+        abort(404)
+    _check_conversation_access(conv, participant)
+
+    if Participation.query.filter_by(
+            participant_id=participant.id,
+            conversation_id=conv.id).first():
+        return redirect(url_for('participant.conversation', slug=slug))
+
+    pseudonym = request.form.get('pseudonym', '').strip()
+    emailable = session.get('emailable', False)
+
+    if not _PSEUDONYM_RE.match(pseudonym):
+        abort(400)
+
+    db.session.add(Participation(
+        participant_id=participant.id,
+        conversation_id=conv.id,
+        pseudonym=pseudonym,
+        notify_email=bool(request.form.get('notify_email')) and emailable,
+        notify_talk_page=bool(request.form.get('notify_talk_page')),
+    ))
+    try:
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        pseudonyms = _generate_pseudonyms(5)
+        return render_template('accept.html', conversation=conv,
+                               emailable=emailable, pseudonyms=pseudonyms,
+                               error='That pseudonym was just taken — please choose another.')
+    return redirect(url_for('participant.conversation', slug=slug))
+
+@participant_bp.get('/accept/<slug>/pseudonyms')
+@login_required
+@limiter.limit('30 per minute')
+def accept_pseudonyms(slug):
+    Conversation.query.filter_by(slug=slug).first_or_404()
+    return jsonify({'pseudonyms': _generate_pseudonyms(5)})
+
+# ── Argument helpers ──────────────────────────────────────────────────────
+
+# ── Conversation ─────────────────────────────────────────────────────────
+
+@participant_bp.get('/c/<slug>')
+@login_required
+def conversation(slug):
+    conv        = Conversation.query.filter_by(slug=slug).first_or_404()
+    participant = _current_participant()
+    _check_conversation_access(conv, participant)
+
+    participation = None
+    if participant:
+        participation = Participation.query.filter_by(
+            participant_id=participant.id,
+            conversation_id=conv.id,
+        ).first()
+
+    if participation is None:
+        return redirect(url_for('participant.accept', slug=slug))
+
+    # Lazy nullification: clear identity links past the internal retention deadline.
+    if conv.closed_at:
+        _nullify_expired_reveals(conv)
+        db.session.refresh(participation)
+
+    can_mod = _can_moderate(conv, participant)
+
+    results     = None
+    polis_stats = None
+    if conv.phase_public_results:
+        results      = PolisParticipantClient(
+            current_app.config['PARTICIAPI_BASE']).get_results(conv.polis_id)
+        polis_stats = _polis_server_client().get_polis_stats(conv.polis_id)
+
+    # Reveal window state for closed conversations.
+    reveal_state    = None
+    reveal_opens_at = None
+    if conv.closed_at:
+        age = datetime.now(timezone.utc) - conv.closed_at.replace(tzinfo=timezone.utc)
+        reveal_opens_at = conv.closed_at + timedelta(days=_REVEAL_COOLDOWN_DAYS)
+        if participation.public_username:
+            reveal_state = 'revealed'
+        elif age >= timedelta(days=_REVEAL_COOLDOWN_DAYS + _REVEAL_NULLIFY_DAYS):
+            reveal_state = 'expired'
+        elif age >= timedelta(days=_REVEAL_COOLDOWN_DAYS):
+            reveal_state = 'open'
+        else:
+            reveal_state = 'pending'
+
+    featured_data = []
+    if conv.phase_argument_mapping and participation:
+        featured_data = _build_featured_data(conv, participation, can_mod=can_mod)
+
+    return render_template('conversation.html',
+                           conversation=conv,
+                           participation=participation,
+                           can_moderate=can_mod,
+                           results=results,
+                           polis_stats=polis_stats,
+                           polis_public_url=current_app.config.get('POLIS_PUBLIC_URL', ''),
+                           reveal_state=reveal_state,
+                           reveal_opens_at=reveal_opens_at,
+                           featured_data=featured_data,
+                           new_stmt_unlock_at=conv.argument_vote_data.get('new_stmt_unlock_at', 10) if conv.argument_vote_data else 10,
+                           new_stmt_max=conv.argument_vote_data.get('new_stmt_max', 3) if conv.argument_vote_data else 3,
+                           new_stmt_ids=participation.new_stmt_ids if participation else [])
+
+# ── Arguments ────────────────────────────────────────────────────────────
+
+@participant_bp.post('/c/<slug>/arguments/<int:fs_id>/submit')
+@login_required
+def argument_submit(slug, fs_id):
+    conv, part = _require_arg_participation(slug)
+    FeaturedStatement.query.filter_by(
+        id=fs_id, conversation_id=conv.id).first_or_404()
+    side = request.form.get('side', '').strip()
+    body = nh3.clean(request.form.get('body', '').strip(), tags=frozenset())
+    if side not in ('pro', 'con') or not body or len(body) > 280:
+        abort(400)
+
+    existing = Argument.query.filter_by(
+        proposer_id=part.participant_id,
+        featured_statement_id=fs_id,
+        side=side,
+    ).first()
+    if existing:
+        if request.headers.get('X-Requested-With') == 'fetch':
+            return jsonify({'ok': True, 'id': existing.id, 'body': existing.body})
+        return redirect(url_for('participant.conversation', slug=slug) + '#tab-arguments')
+
+    arg = Argument(
+        featured_statement_id=fs_id,
+        proposer_id=part.participant_id,
+        body=body,
+        side=side,
+    )
+    db.session.add(arg)
+    db.session.flush()   # get arg.id before commit
+
+    # Insert new argument at a random position in this participant's display order.
+    # Create ArgumentSideState now if the participant hasn't visited the page yet.
+    state = ArgumentSideState.query.filter_by(
+        participant_id=part.participant_id,
+        featured_statement_id=fs_id,
+        side=side,
+    ).first()
+    if state is None:
+        state = ArgumentSideState(
+            participant_id=part.participant_id,
+            featured_statement_id=fs_id,
+            side=side,
+            argument_order=[],
+        )
+        db.session.add(state)
+        db.session.flush()
+    order = list(state.argument_order)
+    order.insert(random.randint(0, len(order)), arg.id)
+    state.argument_order = order
+
+    db.session.commit()
+    if request.headers.get('X-Requested-With') == 'fetch':
+        return jsonify({'ok': True, 'id': arg.id, 'body': body})
+    return redirect(url_for('participant.conversation', slug=slug) + '#tab-arguments')
+
+@participant_bp.post('/c/<slug>/arguments/<int:fs_id>/<side>/skip')
+@login_required
+def argument_skip(slug, fs_id, side):
+    conv, part = _require_arg_participation(slug)
+    FeaturedStatement.query.filter_by(
+        id=fs_id, conversation_id=conv.id).first_or_404()
+    if side not in ('pro', 'con'):
+        abort(400)
+
+    state = ArgumentSideState.query.filter_by(
+        participant_id=part.participant_id,
+        featured_statement_id=fs_id,
+        side=side,
+    ).first()
+    if state is None:
+        state = ArgumentSideState(
+            participant_id=part.participant_id,
+            featured_statement_id=fs_id,
+            side=side,
+            skipped=True,
+        )
+        db.session.add(state)
+        db.session.commit()
+    elif not state.skipped:
+        state.skipped = True
+        db.session.commit()
+    if request.headers.get('X-Requested-With') == 'fetch':
+        return jsonify({'ok': True})
+    return redirect(url_for('participant.conversation', slug=slug) + '#tab-arguments')
+
+@participant_bp.post('/c/<slug>/arguments/<int:arg_id>/vote')
+@login_required
+def argument_vote(slug, arg_id):
+    conv, part = _require_arg_participation(slug)
+    arg = Argument.query.filter_by(id=arg_id).first_or_404()
+    fs  = FeaturedStatement.query.filter_by(
+        id=arg.featured_statement_id, conversation_id=conv.id).first_or_404()
+
+    # Gate: participant must have proposed or skipped both sides.
+    pro_state = ArgumentSideState.query.filter_by(
+        participant_id=part.participant_id,
+        featured_statement_id=fs.id, side='pro').first()
+    con_state = ArgumentSideState.query.filter_by(
+        participant_id=part.participant_id,
+        featured_statement_id=fs.id, side='con').first()
+    pro_proposed = Argument.query.filter_by(
+        proposer_id=part.participant_id,
+        featured_statement_id=fs.id, side='pro').first()
+    con_proposed = Argument.query.filter_by(
+        proposer_id=part.participant_id,
+        featured_statement_id=fs.id, side='con').first()
+    pro_gate = bool(pro_proposed or (pro_state and pro_state.skipped))
+    con_gate = bool(con_proposed or (con_state and con_state.skipped))
+    is_ajax = request.headers.get('X-Requested-With') == 'fetch'
+    if not (pro_gate and con_gate):
+        if is_ajax:
+            return jsonify({'ok': False, 'reason': 'gate'}), 403
+        abort(403)
+
+    # K-approval cap: count existing votes for this side.
+    k = conv.argument_vote_data.get('K', 2)
+    side_arg_ids = [a.id for a in
+                    Argument.query.filter_by(
+                        featured_statement_id=fs.id, side=arg.side).all()]
+    existing_votes = ArgumentVote.query.filter(
+        ArgumentVote.participant_id == part.participant_id,
+        ArgumentVote.argument_id.in_(side_arg_ids),
+    ).count()
+    if existing_votes >= k:
+        if is_ajax:
+            return jsonify({'ok': False, 'reason': 'cap'}), 409
+        abort(409)   # cap reached
+
+    # Can't vote on hidden or own argument.
+    if arg.hidden:
+        if is_ajax:
+            return jsonify({'ok': False, 'reason': 'hidden'}), 403
+        abort(403)
+    if arg.proposer_id == part.participant_id:
+        if is_ajax:
+            return jsonify({'ok': False, 'reason': 'own'}), 403
+        abort(403)
+
+    existing = ArgumentVote.query.filter_by(
+        participant_id=part.participant_id, argument_id=arg_id).first()
+    if not existing:
+        db.session.add(ArgumentVote(
+            argument_id=arg_id,
+            participant_id=part.participant_id,
+        ))
+        db.session.commit()
+    if is_ajax:
+        return jsonify({'ok': True})
+    return redirect(url_for('participant.conversation', slug=slug) + '#tab-arguments')
+
+@participant_bp.post('/c/<slug>/arguments/<int:arg_id>/unvote')
+@login_required
+def argument_unvote(slug, arg_id):
+    conv, part = _require_arg_participation(slug)
+    arg = Argument.query.filter_by(id=arg_id).first_or_404()
+    FeaturedStatement.query.filter_by(
+        id=arg.featured_statement_id, conversation_id=conv.id).first_or_404()
+    existing = ArgumentVote.query.filter_by(
+        participant_id=part.participant_id, argument_id=arg_id).first()
+    if existing:
+        db.session.delete(existing)
+        db.session.commit()
+    if request.headers.get('X-Requested-With') == 'fetch':
+        return jsonify({'ok': True})
+    return redirect(url_for('participant.conversation', slug=slug) + '#tab-arguments')
+
+@participant_bp.post('/c/<slug>/arguments/<int:arg_id>/hide')
+@login_required
+def argument_hide(slug, arg_id):
+    conv = Conversation.query.filter_by(slug=slug).first_or_404()
+    if not _can_moderate(conv):
+        abort(403)
+    arg = Argument.query.filter_by(id=arg_id).first_or_404()
+    FeaturedStatement.query.filter_by(
+        id=arg.featured_statement_id, conversation_id=conv.id).first_or_404()
+    arg.hidden = True
+    db.session.commit()
+    return redirect(url_for('participant.conversation', slug=slug) + '#tab-arguments')
+
+@participant_bp.post('/c/<slug>/arguments/<int:arg_id>/unhide')
+@login_required
+def argument_unhide(slug, arg_id):
+    conv = Conversation.query.filter_by(slug=slug).first_or_404()
+    if not _can_moderate(conv):
+        abort(403)
+    arg = Argument.query.filter_by(id=arg_id).first_or_404()
+    FeaturedStatement.query.filter_by(
+        id=arg.featured_statement_id, conversation_id=conv.id).first_or_404()
+    arg.hidden = False
+    db.session.commit()
+    return redirect(url_for('participant.conversation', slug=slug) + '#tab-arguments')
+
+# ── Identity reveal ───────────────────────────────────────────────────────
+
+@participant_bp.get('/c/<slug>/reveal')
+@login_required
+def reveal_identity(slug):
+    conv        = Conversation.query.filter_by(slug=slug).first_or_404()
+    participant = _current_participant()
+    if participant is None:
+        abort(404)
+    participation = Participation.query.filter_by(
+        participant_id=participant.id,
+        conversation_id=conv.id,
+    ).first_or_404()
+    if not conv.closed_at:
+        abort(404)
+
+    _nullify_expired_reveals(conv)
+    db.session.refresh(participation)
+
+    age = datetime.now(timezone.utc) - conv.closed_at.replace(tzinfo=timezone.utc)
+    opens_at = conv.closed_at + timedelta(days=_REVEAL_COOLDOWN_DAYS)
+    return render_template('reveal.html',
+                           conversation=conv,
+                           participation=participation,
+                           window_open=age >= timedelta(days=_REVEAL_COOLDOWN_DAYS),
+                           window_closed=age >= timedelta(days=_REVEAL_COOLDOWN_DAYS + _REVEAL_NULLIFY_DAYS),
+                           opens_at=opens_at)
+
+@participant_bp.post('/c/<slug>/reveal')
+@login_required
+@limiter.limit('5 per minute')
+def reveal_identity_post(slug):
+    conv        = Conversation.query.filter_by(slug=slug).first_or_404()
+    participant = _current_participant()
+    if participant is None:
+        abort(404)
+    participation = Participation.query.filter_by(
+        participant_id=participant.id,
+        conversation_id=conv.id,
+    ).first_or_404()
+
+    if not conv.closed_at:
+        abort(400)
+
+    age = datetime.now(timezone.utc) - conv.closed_at.replace(tzinfo=timezone.utc)
+    if age < timedelta(days=_REVEAL_COOLDOWN_DAYS):
+        abort(400)
+    if age >= timedelta(days=_REVEAL_COOLDOWN_DAYS + _REVEAL_NULLIFY_DAYS):
+        abort(400)
+    if participation.public_username is not None:
+        abort(400)
+    if request.form.get('confirm') != '1':
+        return redirect(url_for('participant.reveal_identity', slug=slug))
+
+    participation.public_username = participant.mw_username
+    participation.revealed_at     = datetime.now(timezone.utc)
+    db.session.commit()
+    return redirect(url_for('participant.conversation', slug=slug))
+
+
 def create_app(test_config: dict | None = None) -> Flask:
     app = Flask(__name__)
 
@@ -1210,6 +1598,7 @@ def create_app(test_config: dict | None = None) -> Flask:
     # blueprint explicitly rather than per-route.
     app.register_blueprint(proxy_bp)
     app.register_blueprint(admin_bp)
+    app.register_blueprint(participant_bp)
     csrf.exempt(proxy_bp)
 
     return app
@@ -1375,392 +1764,6 @@ def _register_routes(app: Flask) -> None:
                                moderating=moderating,
                                pseudonym_map=pseudonym_map,
                                dev_test_users=dev_test_users)
-
-    # ── Accept ───────────────────────────────────────────────────────────────
-
-    @app.get('/accept/<slug>')
-    @login_required
-    def accept(slug):
-        conv        = Conversation.query.filter_by(slug=slug).first_or_404()
-        participant = _current_participant()
-        _check_conversation_access(conv, participant)
-        if participant and Participation.query.filter_by(
-                participant_id=participant.id,
-                conversation_id=conv.id).first():
-            return redirect(url_for('conversation', slug=slug))
-        pseudonyms = _generate_pseudonyms(5)
-        emailable  = session.get('emailable', False)
-        return render_template('accept.html', conversation=conv,
-                               emailable=emailable, pseudonyms=pseudonyms,
-                               reveal_cooldown=_REVEAL_COOLDOWN_DAYS,
-                               reveal_window_end=_REVEAL_COOLDOWN_DAYS + _REVEAL_NULLIFY_DAYS,
-                               retention_public_days=120)
-
-    @app.post('/accept/<slug>')
-    @login_required
-    @limiter.limit('10 per minute')
-    def accept_post(slug):
-        conv        = Conversation.query.filter_by(slug=slug).first_or_404()
-        participant = _current_participant()
-        if participant is None:
-            abort(404)
-        _check_conversation_access(conv, participant)
-
-        if Participation.query.filter_by(
-                participant_id=participant.id,
-                conversation_id=conv.id).first():
-            return redirect(url_for('conversation', slug=slug))
-
-        pseudonym = request.form.get('pseudonym', '').strip()
-        emailable = session.get('emailable', False)
-
-        if not _PSEUDONYM_RE.match(pseudonym):
-            abort(400)
-
-        db.session.add(Participation(
-            participant_id=participant.id,
-            conversation_id=conv.id,
-            pseudonym=pseudonym,
-            notify_email=bool(request.form.get('notify_email')) and emailable,
-            notify_talk_page=bool(request.form.get('notify_talk_page')),
-        ))
-        try:
-            db.session.commit()
-        except IntegrityError:
-            db.session.rollback()
-            pseudonyms = _generate_pseudonyms(5)
-            return render_template('accept.html', conversation=conv,
-                                   emailable=emailable, pseudonyms=pseudonyms,
-                                   error='That pseudonym was just taken — please choose another.')
-        return redirect(url_for('conversation', slug=slug))
-
-    @app.get('/accept/<slug>/pseudonyms')
-    @login_required
-    @limiter.limit('30 per minute')
-    def accept_pseudonyms(slug):
-        Conversation.query.filter_by(slug=slug).first_or_404()
-        return jsonify({'pseudonyms': _generate_pseudonyms(5)})
-
-    # ── Argument helpers ──────────────────────────────────────────────────────
-
-    # ── Conversation ─────────────────────────────────────────────────────────
-
-    @app.get('/c/<slug>')
-    @login_required
-    def conversation(slug):
-        conv        = Conversation.query.filter_by(slug=slug).first_or_404()
-        participant = _current_participant()
-        _check_conversation_access(conv, participant)
-
-        participation = None
-        if participant:
-            participation = Participation.query.filter_by(
-                participant_id=participant.id,
-                conversation_id=conv.id,
-            ).first()
-
-        if participation is None:
-            return redirect(url_for('accept', slug=slug))
-
-        # Lazy nullification: clear identity links past the internal retention deadline.
-        if conv.closed_at:
-            _nullify_expired_reveals(conv)
-            db.session.refresh(participation)
-
-        can_mod = _can_moderate(conv, participant)
-
-        results     = None
-        polis_stats = None
-        if conv.phase_public_results:
-            results      = PolisParticipantClient(
-                current_app.config['PARTICIAPI_BASE']).get_results(conv.polis_id)
-            polis_stats = _polis_server_client().get_polis_stats(conv.polis_id)
-
-        # Reveal window state for closed conversations.
-        reveal_state    = None
-        reveal_opens_at = None
-        if conv.closed_at:
-            age = datetime.now(timezone.utc) - conv.closed_at.replace(tzinfo=timezone.utc)
-            reveal_opens_at = conv.closed_at + timedelta(days=_REVEAL_COOLDOWN_DAYS)
-            if participation.public_username:
-                reveal_state = 'revealed'
-            elif age >= timedelta(days=_REVEAL_COOLDOWN_DAYS + _REVEAL_NULLIFY_DAYS):
-                reveal_state = 'expired'
-            elif age >= timedelta(days=_REVEAL_COOLDOWN_DAYS):
-                reveal_state = 'open'
-            else:
-                reveal_state = 'pending'
-
-        featured_data = []
-        if conv.phase_argument_mapping and participation:
-            featured_data = _build_featured_data(conv, participation, can_mod=can_mod)
-
-        return render_template('conversation.html',
-                               conversation=conv,
-                               participation=participation,
-                               can_moderate=can_mod,
-                               results=results,
-                               polis_stats=polis_stats,
-                               polis_public_url=current_app.config.get('POLIS_PUBLIC_URL', ''),
-                               reveal_state=reveal_state,
-                               reveal_opens_at=reveal_opens_at,
-                               featured_data=featured_data,
-                               new_stmt_unlock_at=conv.argument_vote_data.get('new_stmt_unlock_at', 10) if conv.argument_vote_data else 10,
-                               new_stmt_max=conv.argument_vote_data.get('new_stmt_max', 3) if conv.argument_vote_data else 3,
-                               new_stmt_ids=participation.new_stmt_ids if participation else [])
-
-    # ── Arguments ────────────────────────────────────────────────────────────
-
-    @app.post('/c/<slug>/arguments/<int:fs_id>/submit')
-    @login_required
-    def argument_submit(slug, fs_id):
-        conv, part = _require_arg_participation(slug)
-        FeaturedStatement.query.filter_by(
-            id=fs_id, conversation_id=conv.id).first_or_404()
-        side = request.form.get('side', '').strip()
-        body = nh3.clean(request.form.get('body', '').strip(), tags=frozenset())
-        if side not in ('pro', 'con') or not body or len(body) > 280:
-            abort(400)
-
-        existing = Argument.query.filter_by(
-            proposer_id=part.participant_id,
-            featured_statement_id=fs_id,
-            side=side,
-        ).first()
-        if existing:
-            if request.headers.get('X-Requested-With') == 'fetch':
-                return jsonify({'ok': True, 'id': existing.id, 'body': existing.body})
-            return redirect(url_for('conversation', slug=slug) + '#tab-arguments')
-
-        arg = Argument(
-            featured_statement_id=fs_id,
-            proposer_id=part.participant_id,
-            body=body,
-            side=side,
-        )
-        db.session.add(arg)
-        db.session.flush()   # get arg.id before commit
-
-        # Insert new argument at a random position in this participant's display order.
-        # Create ArgumentSideState now if the participant hasn't visited the page yet.
-        state = ArgumentSideState.query.filter_by(
-            participant_id=part.participant_id,
-            featured_statement_id=fs_id,
-            side=side,
-        ).first()
-        if state is None:
-            state = ArgumentSideState(
-                participant_id=part.participant_id,
-                featured_statement_id=fs_id,
-                side=side,
-                argument_order=[],
-            )
-            db.session.add(state)
-            db.session.flush()
-        order = list(state.argument_order)
-        order.insert(random.randint(0, len(order)), arg.id)
-        state.argument_order = order
-
-        db.session.commit()
-        if request.headers.get('X-Requested-With') == 'fetch':
-            return jsonify({'ok': True, 'id': arg.id, 'body': body})
-        return redirect(url_for('conversation', slug=slug) + '#tab-arguments')
-
-    @app.post('/c/<slug>/arguments/<int:fs_id>/<side>/skip')
-    @login_required
-    def argument_skip(slug, fs_id, side):
-        conv, part = _require_arg_participation(slug)
-        FeaturedStatement.query.filter_by(
-            id=fs_id, conversation_id=conv.id).first_or_404()
-        if side not in ('pro', 'con'):
-            abort(400)
-
-        state = ArgumentSideState.query.filter_by(
-            participant_id=part.participant_id,
-            featured_statement_id=fs_id,
-            side=side,
-        ).first()
-        if state is None:
-            state = ArgumentSideState(
-                participant_id=part.participant_id,
-                featured_statement_id=fs_id,
-                side=side,
-                skipped=True,
-            )
-            db.session.add(state)
-            db.session.commit()
-        elif not state.skipped:
-            state.skipped = True
-            db.session.commit()
-        if request.headers.get('X-Requested-With') == 'fetch':
-            return jsonify({'ok': True})
-        return redirect(url_for('conversation', slug=slug) + '#tab-arguments')
-
-    @app.post('/c/<slug>/arguments/<int:arg_id>/vote')
-    @login_required
-    def argument_vote(slug, arg_id):
-        conv, part = _require_arg_participation(slug)
-        arg = Argument.query.filter_by(id=arg_id).first_or_404()
-        fs  = FeaturedStatement.query.filter_by(
-            id=arg.featured_statement_id, conversation_id=conv.id).first_or_404()
-
-        # Gate: participant must have proposed or skipped both sides.
-        pro_state = ArgumentSideState.query.filter_by(
-            participant_id=part.participant_id,
-            featured_statement_id=fs.id, side='pro').first()
-        con_state = ArgumentSideState.query.filter_by(
-            participant_id=part.participant_id,
-            featured_statement_id=fs.id, side='con').first()
-        pro_proposed = Argument.query.filter_by(
-            proposer_id=part.participant_id,
-            featured_statement_id=fs.id, side='pro').first()
-        con_proposed = Argument.query.filter_by(
-            proposer_id=part.participant_id,
-            featured_statement_id=fs.id, side='con').first()
-        pro_gate = bool(pro_proposed or (pro_state and pro_state.skipped))
-        con_gate = bool(con_proposed or (con_state and con_state.skipped))
-        is_ajax = request.headers.get('X-Requested-With') == 'fetch'
-        if not (pro_gate and con_gate):
-            if is_ajax:
-                return jsonify({'ok': False, 'reason': 'gate'}), 403
-            abort(403)
-
-        # K-approval cap: count existing votes for this side.
-        k = conv.argument_vote_data.get('K', 2)
-        side_arg_ids = [a.id for a in
-                        Argument.query.filter_by(
-                            featured_statement_id=fs.id, side=arg.side).all()]
-        existing_votes = ArgumentVote.query.filter(
-            ArgumentVote.participant_id == part.participant_id,
-            ArgumentVote.argument_id.in_(side_arg_ids),
-        ).count()
-        if existing_votes >= k:
-            if is_ajax:
-                return jsonify({'ok': False, 'reason': 'cap'}), 409
-            abort(409)   # cap reached
-
-        # Can't vote on hidden or own argument.
-        if arg.hidden:
-            if is_ajax:
-                return jsonify({'ok': False, 'reason': 'hidden'}), 403
-            abort(403)
-        if arg.proposer_id == part.participant_id:
-            if is_ajax:
-                return jsonify({'ok': False, 'reason': 'own'}), 403
-            abort(403)
-
-        existing = ArgumentVote.query.filter_by(
-            participant_id=part.participant_id, argument_id=arg_id).first()
-        if not existing:
-            db.session.add(ArgumentVote(
-                argument_id=arg_id,
-                participant_id=part.participant_id,
-            ))
-            db.session.commit()
-        if is_ajax:
-            return jsonify({'ok': True})
-        return redirect(url_for('conversation', slug=slug) + '#tab-arguments')
-
-    @app.post('/c/<slug>/arguments/<int:arg_id>/unvote')
-    @login_required
-    def argument_unvote(slug, arg_id):
-        conv, part = _require_arg_participation(slug)
-        arg = Argument.query.filter_by(id=arg_id).first_or_404()
-        FeaturedStatement.query.filter_by(
-            id=arg.featured_statement_id, conversation_id=conv.id).first_or_404()
-        existing = ArgumentVote.query.filter_by(
-            participant_id=part.participant_id, argument_id=arg_id).first()
-        if existing:
-            db.session.delete(existing)
-            db.session.commit()
-        if request.headers.get('X-Requested-With') == 'fetch':
-            return jsonify({'ok': True})
-        return redirect(url_for('conversation', slug=slug) + '#tab-arguments')
-
-    @app.post('/c/<slug>/arguments/<int:arg_id>/hide')
-    @login_required
-    def argument_hide(slug, arg_id):
-        conv = Conversation.query.filter_by(slug=slug).first_or_404()
-        if not _can_moderate(conv):
-            abort(403)
-        arg = Argument.query.filter_by(id=arg_id).first_or_404()
-        FeaturedStatement.query.filter_by(
-            id=arg.featured_statement_id, conversation_id=conv.id).first_or_404()
-        arg.hidden = True
-        db.session.commit()
-        return redirect(url_for('conversation', slug=slug) + '#tab-arguments')
-
-    @app.post('/c/<slug>/arguments/<int:arg_id>/unhide')
-    @login_required
-    def argument_unhide(slug, arg_id):
-        conv = Conversation.query.filter_by(slug=slug).first_or_404()
-        if not _can_moderate(conv):
-            abort(403)
-        arg = Argument.query.filter_by(id=arg_id).first_or_404()
-        FeaturedStatement.query.filter_by(
-            id=arg.featured_statement_id, conversation_id=conv.id).first_or_404()
-        arg.hidden = False
-        db.session.commit()
-        return redirect(url_for('conversation', slug=slug) + '#tab-arguments')
-
-    # ── Identity reveal ───────────────────────────────────────────────────────
-
-    @app.get('/c/<slug>/reveal')
-    @login_required
-    def reveal_identity(slug):
-        conv        = Conversation.query.filter_by(slug=slug).first_or_404()
-        participant = _current_participant()
-        if participant is None:
-            abort(404)
-        participation = Participation.query.filter_by(
-            participant_id=participant.id,
-            conversation_id=conv.id,
-        ).first_or_404()
-        if not conv.closed_at:
-            abort(404)
-
-        _nullify_expired_reveals(conv)
-        db.session.refresh(participation)
-
-        age = datetime.now(timezone.utc) - conv.closed_at.replace(tzinfo=timezone.utc)
-        opens_at = conv.closed_at + timedelta(days=_REVEAL_COOLDOWN_DAYS)
-        return render_template('reveal.html',
-                               conversation=conv,
-                               participation=participation,
-                               window_open=age >= timedelta(days=_REVEAL_COOLDOWN_DAYS),
-                               window_closed=age >= timedelta(days=_REVEAL_COOLDOWN_DAYS + _REVEAL_NULLIFY_DAYS),
-                               opens_at=opens_at)
-
-    @app.post('/c/<slug>/reveal')
-    @login_required
-    @limiter.limit('5 per minute')
-    def reveal_identity_post(slug):
-        conv        = Conversation.query.filter_by(slug=slug).first_or_404()
-        participant = _current_participant()
-        if participant is None:
-            abort(404)
-        participation = Participation.query.filter_by(
-            participant_id=participant.id,
-            conversation_id=conv.id,
-        ).first_or_404()
-
-        if not conv.closed_at:
-            abort(400)
-
-        age = datetime.now(timezone.utc) - conv.closed_at.replace(tzinfo=timezone.utc)
-        if age < timedelta(days=_REVEAL_COOLDOWN_DAYS):
-            abort(400)
-        if age >= timedelta(days=_REVEAL_COOLDOWN_DAYS + _REVEAL_NULLIFY_DAYS):
-            abort(400)
-        if participation.public_username is not None:
-            abort(400)
-        if request.form.get('confirm') != '1':
-            return redirect(url_for('reveal_identity', slug=slug))
-
-        participation.public_username = participant.mw_username
-        participation.revealed_at     = datetime.now(timezone.utc)
-        db.session.commit()
-        return redirect(url_for('conversation', slug=slug))
 
     # ── OAuth ─────────────────────────────────────────────────────────────────
 

--- a/v2/templates/accept.html
+++ b/v2/templates/accept.html
@@ -37,7 +37,7 @@
   </p>
 
   <form method="post"
-        action="{{ url_for('accept_post', slug=conversation.slug) }}"
+        action="{{ url_for('participant.accept_post', slug=conversation.slug) }}"
         id="accept-form"
         aria-labelledby="accept-title"
         aria-describedby="accept-privacy-summary-copy{% if error %} accept-error{% endif %}">
@@ -232,7 +232,7 @@
     container.setAttribute('aria-busy', 'true');
     if (statusEl) statusEl.textContent = 'Generating new pseudonym options.';
     btn.textContent = '↻ loading…';
-    fetch('{{ url_for("accept_pseudonyms", slug=conversation.slug) }}')
+    fetch('{{ url_for("participant.accept_pseudonyms", slug=conversation.slug) }}')
       .then(function (r) { return r.json(); })
       .then(function (data) {
         buildOptions(data.pseudonyms);

--- a/v2/templates/admin.html
+++ b/v2/templates/admin.html
@@ -21,7 +21,7 @@
     <tbody>
       {% for c in conversations %}
       <tr>
-        <td><a href="{{ url_for('conversation', slug=c.slug) }}">{{ c.title }}</a></td>
+        <td><a href="{{ url_for('participant.conversation', slug=c.slug) }}">{{ c.title }}</a></td>
         <td><code>{{ c.slug }}</code></td>
         <td>{{ c.access_policy }}</td>
         <td>

--- a/v2/templates/admin_invites.html
+++ b/v2/templates/admin_invites.html
@@ -4,7 +4,7 @@
 <div class="container">
 
   <h2>
-    Invites — <a href="{{ url_for('conversation', slug=conversation.slug) }}">{{ conversation.title }}</a>
+    Invites — <a href="{{ url_for('participant.conversation', slug=conversation.slug) }}">{{ conversation.title }}</a>
   </h2>
   <p class="muted" style="margin-bottom: 1.25rem;">
     Access policy: <strong>{{ conversation.access_policy }}</strong>

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -38,7 +38,7 @@
     {% elif reveal_state == 'open' %}
     <p style="margin-top:.75rem;font-size:13px">
       The identity reveal window is open.
-      <a href="{{ url_for('reveal_identity', slug=conversation.slug) }}">Optionally link your username →</a>
+      <a href="{{ url_for('participant.reveal_identity', slug=conversation.slug) }}">Optionally link your username →</a>
     </p>
 
     {% elif reveal_state == 'pending' %}
@@ -490,8 +490,8 @@
                data-state="{{ 'submitted' if item.pro_proposed else ('skipped' if item.pro_gate else 'idle') }}"
                data-side="pro"
                data-fs="{{ fs.id }}"
-               data-submit-url="{{ url_for('argument_submit', slug=conversation.slug, fs_id=fs.id) }}"
-               data-skip-url="{{ url_for('argument_skip', slug=conversation.slug, fs_id=fs.id, side='pro') }}"
+               data-submit-url="{{ url_for('participant.argument_submit', slug=conversation.slug, fs_id=fs.id) }}"
+               data-skip-url="{{ url_for('participant.argument_skip', slug=conversation.slug, fs_id=fs.id, side='pro') }}"
                data-csrf="{{ csrf_token() }}"
                data-k="{{ item.k }}"
                data-my-pseudonym="{{ participation.pseudonym }}">
@@ -540,8 +540,8 @@
                data-can-vote="{{ 'true' if pro_can_vote else 'false' }}"
                data-limit-reached="{{ 'true' if pro_limit_reached else 'false' }}"
                data-hidden="{{ 'true' if arg.hidden else 'false' }}"
-               data-vote-url="{{ url_for('argument_vote', slug=conversation.slug, arg_id=arg.id) }}"
-               data-unvote-url="{{ url_for('argument_unvote', slug=conversation.slug, arg_id=arg.id) }}"
+               data-vote-url="{{ url_for('participant.argument_vote', slug=conversation.slug, arg_id=arg.id) }}"
+               data-unvote-url="{{ url_for('participant.argument_unvote', slug=conversation.slug, arg_id=arg.id) }}"
                data-csrf="{{ csrf_token() }}">
             <button class="argument-checkbox" aria-label="Mark as most important"
                     tabindex="{{ '0' if pro_can_vote else '-1' }}">
@@ -567,12 +567,12 @@
                 {% if can_moderate %}
                 <span style="display:inline-flex;gap:4px;margin-left:auto">
                   {% if arg.hidden %}
-                  <form method="post" action="{{ url_for('argument_unhide', slug=conversation.slug, arg_id=arg.id) }}" style="display:inline">
+                  <form method="post" action="{{ url_for('participant.argument_unhide', slug=conversation.slug, arg_id=arg.id) }}" style="display:inline">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button type="submit" class="btn-small">unhide</button>
                   </form>
                   {% else %}
-                  <form method="post" action="{{ url_for('argument_hide', slug=conversation.slug, arg_id=arg.id) }}" style="display:inline">
+                  <form method="post" action="{{ url_for('participant.argument_hide', slug=conversation.slug, arg_id=arg.id) }}" style="display:inline">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button type="submit" class="btn-small btn-warn">hide</button>
                   </form>
@@ -602,8 +602,8 @@
                data-state="{{ 'submitted' if item.con_proposed else ('skipped' if item.con_gate else 'idle') }}"
                data-side="con"
                data-fs="{{ fs.id }}"
-               data-submit-url="{{ url_for('argument_submit', slug=conversation.slug, fs_id=fs.id) }}"
-               data-skip-url="{{ url_for('argument_skip', slug=conversation.slug, fs_id=fs.id, side='con') }}"
+               data-submit-url="{{ url_for('participant.argument_submit', slug=conversation.slug, fs_id=fs.id) }}"
+               data-skip-url="{{ url_for('participant.argument_skip', slug=conversation.slug, fs_id=fs.id, side='con') }}"
                data-csrf="{{ csrf_token() }}"
                data-k="{{ item.k }}"
                data-my-pseudonym="{{ participation.pseudonym }}">
@@ -652,8 +652,8 @@
                data-can-vote="{{ 'true' if con_can_vote else 'false' }}"
                data-limit-reached="{{ 'true' if con_limit_reached else 'false' }}"
                data-hidden="{{ 'true' if arg.hidden else 'false' }}"
-               data-vote-url="{{ url_for('argument_vote', slug=conversation.slug, arg_id=arg.id) }}"
-               data-unvote-url="{{ url_for('argument_unvote', slug=conversation.slug, arg_id=arg.id) }}"
+               data-vote-url="{{ url_for('participant.argument_vote', slug=conversation.slug, arg_id=arg.id) }}"
+               data-unvote-url="{{ url_for('participant.argument_unvote', slug=conversation.slug, arg_id=arg.id) }}"
                data-csrf="{{ csrf_token() }}">
             <button class="argument-checkbox" aria-label="Mark as most important"
                     tabindex="{{ '0' if con_can_vote else '-1' }}">
@@ -679,12 +679,12 @@
                 {% if can_moderate %}
                 <span style="display:inline-flex;gap:4px;margin-left:auto">
                   {% if arg.hidden %}
-                  <form method="post" action="{{ url_for('argument_unhide', slug=conversation.slug, arg_id=arg.id) }}" style="display:inline">
+                  <form method="post" action="{{ url_for('participant.argument_unhide', slug=conversation.slug, arg_id=arg.id) }}" style="display:inline">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button type="submit" class="btn-small">unhide</button>
                   </form>
                   {% else %}
-                  <form method="post" action="{{ url_for('argument_hide', slug=conversation.slug, arg_id=arg.id) }}" style="display:inline">
+                  <form method="post" action="{{ url_for('participant.argument_hide', slug=conversation.slug, arg_id=arg.id) }}" style="display:inline">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button type="submit" class="btn-small btn-warn">hide</button>
                   </form>

--- a/v2/templates/home.html
+++ b/v2/templates/home.html
@@ -47,7 +47,7 @@
         <span class="home-section-count" aria-hidden="true">{{ public_conversations | length }} total</span>
       </div>
       {% for c in public_conversations %}
-      <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
+      <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card"
          aria-label="{{ c.title }} — join consultation">
         <div class="conv-card-left">
           <span class="conv-dot conv-dot--available" aria-hidden="true"></span>
@@ -71,7 +71,7 @@
       </div>
       {% for c in active_joined %}
       {% set part = pseudonym_map.get(c.id) %}
-      <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
+      <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card"
          aria-label="{{ c.title }}{% if part %} — {{ part.pseudonym }}{% endif %} — {{ 'temporarily paused' if c.paused else 'voting open' }} — continue">
         <div class="conv-card-left">
           <span class="conv-dot conv-dot--active" aria-hidden="true"></span>
@@ -100,7 +100,7 @@
         <span class="home-section-count" aria-hidden="true">{{ available | length }} consultation{{ 's' if available | length != 1 }}</span>
       </div>
       {% for c in available %}
-      <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
+      <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card"
          aria-label="{{ c.title }} — join consultation">
         <div class="conv-card-left">
           <span class="conv-dot conv-dot--available" aria-hidden="true"></span>
@@ -124,7 +124,7 @@
       </div>
       {% for c in archived_joined %}
       {% set part = pseudonym_map.get(c.id) %}
-      <a href="{{ url_for('conversation', slug=c.slug) }}" class="conv-card"
+      <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card"
          aria-label="{{ c.title }}{% if part %} — {{ part.pseudonym }}{% endif %} — closed{% if c.closed_at %} {{ c.closed_at.strftime('%B %Y') }}{% endif %}">
         <div class="conv-card-left">
           <span class="conv-dot conv-dot--closed" aria-hidden="true"></span>
@@ -156,7 +156,7 @@
       <div class="conv-card conv-card--split">
         <span class="conv-card-left">
           <span class="conv-dot {{ 'conv-dot--active' if c.active else 'conv-dot--closed' }}" aria-hidden="true"></span>
-          <a href="{{ url_for('conversation', slug=c.slug) }}"
+          <a href="{{ url_for('participant.conversation', slug=c.slug) }}"
              class="conv-card-title">{{ c.title }}</a>
           {% if not c.active %}<span class="conv-card-badge">closed</span>{% endif %}
         </span>

--- a/v2/templates/reveal.html
+++ b/v2/templates/reveal.html
@@ -14,7 +14,7 @@
 <div class="container" style="max-width:660px">
 
   <p style="margin-bottom:1.25rem">
-    <a href="{{ url_for('conversation', slug=conversation.slug) }}"
+    <a href="{{ url_for('participant.conversation', slug=conversation.slug) }}"
        style="font-size:13px;color:var(--muted);text-decoration:none">← {{ conversation.title }}</a>
   </p>
 
@@ -129,7 +129,7 @@
     </div>
   </div>
 
-  <form method="post" action="{{ url_for('reveal_identity_post', slug=conversation.slug) }}" style="margin-top:22px">
+  <form method="post" action="{{ url_for('participant.reveal_identity_post', slug=conversation.slug) }}" style="margin-top:22px">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <label class="checkbox-label" style="margin-bottom:16px">
       <input type="checkbox" name="confirm" value="1" required>
@@ -139,7 +139,7 @@
     </label>
     <div style="display:flex;align-items:center;gap:16px">
       <button type="submit" class="participate-btn" style="background:var(--ink)">Yes, link my identity</button>
-      <a href="{{ url_for('conversation', slug=conversation.slug) }}"
+      <a href="{{ url_for('participant.conversation', slug=conversation.slug) }}"
          style="color:var(--muted);font-size:13px;text-decoration:none">Cancel</a>
     </div>
   </form>


### PR DESCRIPTION
Blueprint-refactor **step 9 — the final step.** Lifts the **12 participant-facing handlers** (`accept`, `accept_post`, `accept_pseudonyms`, `conversation`, the six `argument_*` routes, `reveal_identity`, `reveal_identity_post`) out of the `_register_routes` closure onto a module-level `Blueprint('participant')`, mirroring the merged `proxy_bp` (#91) and `admin_bp` (#92). The auth/OAuth/index/logout/health/dev-login routes stay in `_register_routes` (they close over `_dev_login_user`/`_on_toolforge`).

This completes the decomposition the audit (#94) laid out: `_register_routes` went **177 → 33** across steps 5–9.

## What changed
- 12 handlers → `participant_bp`; bodies moved **verbatim** (dedent only). Endpoints now `participant.<fn>`; the **38 `url_for('<fn>'…)` references** across `app.py` + 7 templates were requalified to `participant.<fn>`.
- `@login_required` on all 12; `@limiter.limit` preserved exactly (accept_post 10/min, pseudonyms 30/min, reveal 5/min). **Not** csrf-exempt — participant POSTs keep CSRF.
- `_register_routes` complexity **90 → 33**.

## Verification — verbatim move, triple-checked
Three independent methods each concluded **all 12 handler bodies are byte-identical** to `main`, modulo dedent / `@app`→`@participant_bp` / the `url_for` prefix:
1. AST body-dump comparison (positions stripped, `participant.` normalized).
2. Senior reviewer's dedent+strip textual diff.
3. Security reviewer's normalized body diff.

- **134 passed**, zero assertion changes (`test_arguments` 32, `test_conversations` 15, `test_reveal` 13 all green).
- `url_for` sweep complete: zero bare survivors in `app.py`/templates/tests; no `participant.participant.` double-qualification; non-participant refs (`login`/`index`/`dev_login`, `admin.*`) correctly untouched.
- `ruff` clean (one pre-existing E741 unchanged).

## Review
Senior (correctness) **SHIP**, security **SHIP**, cross-review **AGREE-SHIP** — the high-risk handlers were spot-checked intact: `argument_vote` (pro/con gate, K-cap 409, own/hidden 403), `accept_post` (Participation create + IntegrityError rollback), and `reveal_identity_post` (owner-only, window guards, `public_username`/`revealed_at` write). No security guard weakened, dropped, or reordered.

## Relationships
- **Refactor series:** the **last** of the 9 steps (audit/plan #94; steps 1–4 #88, 5–6 #97, 7 #98, 8 #99). Depends on #90 + #92 (merged).
- **Touches code shared with** the participant/argument/reveal issues that now build on this blueprint: #82, #81, #80, #79, #77, #71, #70, #69, #64, #11.

Closes #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)