### PR TITLE
docs: record blueprint refactor in changelog + roadmap

### DIFF
--- a/v2/log_changelog.md
+++ b/v2/log_changelog.md
@@ -213,3 +213,30 @@ gate_passed = bool(
 - [x] Moderator delete of arguments
 - [x] Hash-aware tab restore (`#tab-arguments` after all argument form redirects)
 - [x] Phrasing settled: **"most important"** (matches Citizens' Assembly practice)
+
+---
+
+## Codebase refactor — blueprint decomposition ✓ (2026-06-02)
+
+Decomposed the ~1,300-line `_register_routes` closure in `app.py` into Flask blueprints,
+per the audit's refactor plan (#94). Steps 1–4 landed earlier (PR #88); steps 5–9 completed
+here. Every step was a **behavior-preserving** relocation — handler bodies verified
+byte-identical (AST), zero test-assertion changes. `_register_routes` cyclomatic complexity
+**177 → 33**.
+
+- **#90 / #89** (PR #97) — lifted 5 non-route helpers to module level; deduped the three
+  statement-text fetch blocks into one `_statement_text_map()`.
+- **#91** (PR #98) — extracted the Particiapi proxy + statement-submit into `proxy_bp`
+  (the `@csrf.exempt` + `_validate_same_origin` compensating control preserved). Also added
+  `synthetic_traffic.py` (a proxy soak/load harness driving a deployed instance through the
+  real Flask stack) and a runbook section documenting staging topology + a 5xx-investigation
+  playbook.
+- **#92** (PR #99) — extracted the ~23 `/admin/…` routes into `admin_bp` (both auth
+  conventions — `@admin_required` vs `_require_mod_for_conv` — kept distinct; CSRF retained).
+- **#93** (PR #100) — extracted the participant accept / conversation / argument / reveal
+  routes into `participant_bp`. Auth / OAuth / index / logout / health / dev-login stay in
+  `_register_routes` (they close over its locals).
+
+Each step shipped alone with a senior + security review (cross-reviewed); #91 was soak-tested
+and #91/#92/#93 staging-verified. Test suite grew 120 → 134 (promoted helper-characterization
+tests + an admin-template smoke test).

--- a/v2/plan_roadmap.md
+++ b/v2/plan_roadmap.md
@@ -35,12 +35,13 @@ retention commitment (decision D-PRIV), pending legal/comms review.
 
 ## 3. Code health
 
-- **Blueprint refactor** — decompose `app.py` into blueprints, steps 5–9:
-  [#90](https://github.com/lgelauff/wiki-polis/issues/90),
-  [#89](https://github.com/lgelauff/wiki-polis/issues/89),
-  [#91](https://github.com/lgelauff/wiki-polis/issues/91),
-  [#92](https://github.com/lgelauff/wiki-polis/issues/92),
-  [#93](https://github.com/lgelauff/wiki-polis/issues/93). (Steps 1–4 landed in PR #88.)
+- **Blueprint refactor** — ✅ **done.** `app.py` decomposed into `proxy_bp` / `admin_bp` /
+  `participant_bp`; `_register_routes` complexity 177→33. Steps 1–4 (PR #88), 5–6 (#97),
+  7 (#98), 8 (#99), 9 (#100); issues #89–93 closed. See
+  [`log_changelog.md`](log_changelog.md).
+- **Soak harness follow-up** — `synthetic_traffic.py` soaks the proxy/vote path; its
+  accept step doesn't yet establish a Participation, so `statements/new` returns 401 and is
+  not exercised. Fix the accept step so statement-submit gets soak coverage too.
 - **Testing strategy / CI** — decision pending (D-TEST); recommendation in
   `.claude/testing-strategy-recommendations.md`. Leaning toward a CI gate on PRs plus
   coverage for the untested risky paths (proxy, reveal nullification, Polis-Postgres


### PR DESCRIPTION
Housekeeping after #97–#100 (blueprint decomposition complete).

- **log_changelog.md** — new build-log entry for the blueprint refactor: proxy/admin/participant blueprints, `_register_routes` 177→33, per-step PRs/reviews, suite 120→134.
- **plan_roadmap.md** — flips the *Blueprint refactor* item to ✅ done; adds a follow-up note that `synthetic_traffic.py`'s accept step doesn't yet cover statement-submit (401).

Docs only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)