### PR TITLE
fix(voting): make the "change" button actually change a vote (#69)

### DIFF
--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -560,6 +560,11 @@ pa-conversation:state(loading) { opacity: 0.5; }
 .statement-card--voted .vote-choice-row { display: none !important; }
 .statement-card--voted .stmt-meta-right { visibility: hidden; }
 
+/* Re-vote (#69): while changing a recorded vote, reveal the choice buttons over the
+   voted card (original statement text + badge stay visible for context). Declared after
+   the --voted hide, and !important, so it also beats the no-statement sibling rule. */
+.statement-card--revoting .vote-choice-row { display: flex !important; }
+
 .propose-stmt-display {
   margin: 0;
   font-size: 15px;

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -999,6 +999,11 @@
     // await particiappvotesubmitsuccess before calling enterVoted.
     var stmt    = liveStmt();
     var stmtTxt = stmt ? (stmt.text || '').trim() : '';
+    // Record which statement this vote is for, so "change" (#69) can re-target it. The
+    // particiappvotesubmit event carries only `value` (never statementID), and the
+    // component advances pa-statement on vote — so capture it now, from the same source
+    // submitVote() reads (conv.statement), before the click advances the queue.
+    lastVoteStmtId = (conv.statement && conv.statement.id != null) ? conv.statement.id : null;
     pvb[type].click();
     enterVoted(type, stmtTxt);
   });
@@ -1184,11 +1189,10 @@
   conv.addEventListener('particiappstatementschange', function (e) { updateProgress(e.statements); });
   conv.addEventListener('particiappvotesubmitsuccess', function ()  { updateProgress(conv.client.statements); });
 
-  // Track the last statement ID being voted on (statementID comes from pa-vote-button event).
+  // Statement id of the most recent vote — set at vote time in the click handler above.
+  // (It cannot be read from the particiappvotesubmit event: that event carries only
+  // `value`, never statementID.) Consumed by "change" (#69) and the error handler below.
   var lastVoteStmtId = null;
-  conv.addEventListener('particiappvotesubmit', function (e) {
-    lastVoteStmtId = e.statementID != null ? Number(e.statementID) : null;
-  });
 
   // On vote failure: mark the statement as voted in the web component so it advances,
   // then reset UI. Covers both own-statement 403s and any other transient failures.

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -954,19 +954,62 @@
   }
 
   // ── Vote buttons ──────────────────────────────────────────────────────────────
+  // tid of a recorded vote the participant is currently changing (#69); null = normal vote.
+  var revoteTid = null;
+
   choiceRow.addEventListener('click', function (e) {
     var btn = e.target.closest('.vote-choice');
     if (!btn) return;
-    var type    = btn.dataset.type;
+    var type = btn.dataset.type;
+
+    if (revoteTid != null) {
+      // ── Re-vote: change an already-recorded vote (#69 / D-VOTE). ──
+      // submitVote(value, tid) re-PUTs to Polis (upsert on participant+tid) using the
+      // component's own session + CSRF, and targets the *original* statement — the visible
+      // queue has already advanced past it. It does NOT dispatch particiappvotesubmit, so
+      // lastVoteStmtId is preserved and the same statement can be changed again.
+      var keepText = originalStmtText;
+      var finish = function (ok) {
+        conv.removeEventListener('particiappvotesubmitsuccess', onOk);
+        conv.removeEventListener('particiappvotesubmiterror',  onErr);
+        stmtCard.classList.remove('statement-card--revoting');
+        revoteTid = null;
+        enterVoted(type, keepText);                 // badge now reflects the new vote
+        if (!ok) {
+          convError.hidden = false;
+          convErrorMsg.textContent = 'Could not change your vote. Please try again.';
+        }
+      };
+      var onOk  = function () { finish(true); };
+      var onErr = function () { finish(false); };
+      conv.addEventListener('particiappvotesubmitsuccess', onOk, { once: true });
+      conv.addEventListener('particiappvotesubmiterror',  onErr, { once: true });
+      conv.submitVote(type, revoteTid);
+      return;
+    }
+
+    // ── Normal first vote (optimistic UI). ──
+    // KNOWN LIMITATION: we enter the "voted" state immediately, before the async PUT
+    // resolves. If the connection drops in the sub-second window before the vote lands,
+    // the UI shows "voted" while Polis may not have recorded it (particiappvotesubmiterror
+    // handles detectable failures by marking voted + returning to idle). Acceptable for a
+    // prototype; to harden, await particiappvotesubmitsuccess before calling enterVoted.
     var stmt    = liveStmt();
     var stmtTxt = stmt ? (stmt.text || '').trim() : '';
     pvb[type].click();
     enterVoted(type, stmtTxt);
   });
 
-  // ── Change vote ───────────────────────────────────────────────────────────────
+  // ── Change vote (#69) ─────────────────────────────────────────────────────────
+  // Reveal the vote buttons over the voted card and target the just-voted statement —
+  // the live <pa-statement> has already advanced to the next one, so we can't rely on it.
   document.getElementById('change-vote-btn').addEventListener('click', function () {
-    enterIdle(choiceRow.querySelector('.vote-choice'));
+    if (lastVoteStmtId == null) return;          // nothing recorded to change
+    revoteTid = lastVoteStmtId;
+    stmtCard.classList.add('statement-card--revoting');
+    triad.hidden = true;
+    var first = choiceRow.querySelector('.vote-choice');
+    if (first) first.focus();
   });
 
   // ── Triad click guard (aria-disabled) ────────────────────────────────────────

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -975,7 +975,9 @@
         stmtCard.classList.remove('statement-card--revoting');
         revoteTid = null;
         enterVoted(type, keepText);                 // badge now reflects the new vote
-        if (!ok) {
+        if (ok) {
+          convError.hidden = true;                  // clear any stale error from a prior attempt
+        } else {
           convError.hidden = false;
           convErrorMsg.textContent = 'Could not change your vote. Please try again.';
         }
@@ -991,9 +993,10 @@
     // ── Normal first vote (optimistic UI). ──
     // KNOWN LIMITATION: we enter the "voted" state immediately, before the async PUT
     // resolves. If the connection drops in the sub-second window before the vote lands,
-    // the UI shows "voted" while Polis may not have recorded it (particiappvotesubmiterror
-    // handles detectable failures by marking voted + returning to idle). Acceptable for a
-    // prototype; to harden, await particiappvotesubmitsuccess before calling enterVoted.
+    // the UI shows "voted" while Polis may not have recorded it. Detectable failures are
+    // caught by the particiappvotesubmiterror handler, which marks the statement voted in
+    // the client and returns to the idle vote view. Acceptable for a prototype; to harden,
+    // await particiappvotesubmitsuccess before calling enterVoted.
     var stmt    = liveStmt();
     var stmtTxt = stmt ? (stmt.text || '').trim() : '';
     pvb[type].click();
@@ -1190,6 +1193,9 @@
   // On vote failure: mark the statement as voted in the web component so it advances,
   // then reset UI. Covers both own-statement 403s and any other transient failures.
   conv.addEventListener('particiappvotesubmiterror', function () {
+    // During a re-vote (#69) the local once-handler owns recovery (restores the voted
+    // card); skip this first-vote recovery so they don't fight and flash the idle view.
+    if (revoteTid != null) return;
     if (lastVoteStmtId != null) {
       try { conv.client.participant.votes.add(lastVoteStmtId); } catch (e) {}
     }


### PR DESCRIPTION
Closes #69. Per decision **D-VOTE**, the post-vote "change" button should reopen the just-voted statement and resubmit to Polis.

## The bug (two layers)
1. After voting, the Polis web component **advances `pa-statement` to the next statement**, so "change" re-showed controls bound to the *wrong* statement.
2. More fatally, `lastVoteStmtId` (the statement "change" targets) was read from the `particiappvotesubmit` event's `statementID` — but `<pa-vote-button>` dispatches that event with **only `{ value }`, never `statementID`**. So `lastVoteStmtId` was **always null** and the change handler's guard returned every time → change did literally nothing.

This second bug rendered "change" a no-op for *everyone*, and **would not have been caught by the unit tests** (they render the template, not the live web-component event contract) — it surfaced only on staging.

## The fix (frontend only — `conversation.html` + `style.css`)
- Capture the tid at **vote time** from `conv.statement.id` (the same source `submitVote` reads), instead of the empty event field.
- "change" enters a re-vote mode (`statement-card--revoting`) that **reveals the vote buttons over the voted card** (original statement text + badge stay for context).
- Re-vote calls `conv.submitVote(value, tid)` — re-PUTs to Polis (upsert on participant+tid) using the component's own session/CSRF. No server/proxy/DB change.
- Also fixes a latent bug where the first-vote error handler did `votes.add(null)`, and documents the pre-existing optimistic-vote race as a known limitation.

## Verification (staging, live DOM + live Polis DB)
- Clicking "change" flips the card `revoting` false→true and the vote row `none`→`flex` (DOM-confirmed).
- Re-voting **agree → disagree → pass** on one statement wrote **`-1 → 1 → 0`** to `votes_latest_unique`, each overwriting the last (DB-confirmed; note Polis's raw sign: agree=-1).
- 134 unit tests pass (template render).

## Note for reviewers
Commit `9c940e3` (the `lastVoteStmtId` root-cause fix) landed **after** the earlier senior review of `a49639b`/`4e3527b`, so this wants a fresh senior pass on the final state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)