### PR TITLE
fix(results): make results actually appear — render personal results + enable Polis vis_type (#81)

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -1137,7 +1137,11 @@ def conversation(slug):
 
     results     = None
     polis_stats = None
-    if conv.phase_public_results:
+    # Fetch clustering results for either results phase. Personal results (Phase 3,
+    # logged-in only) and public results (Phase 4, everyone) currently render the same
+    # aggregate data; #81 part 2 will scope personal results to the participant's voted
+    # statements (anti-anchoring).
+    if conv.phase_public_results or conv.phase_personal_results:
         results      = PolisParticipantClient(
             current_app.config['PARTICIAPI_BASE']).get_results(conv.polis_id)
         polis_stats = _polis_server_client().get_polis_stats(conv.polis_id)

--- a/v2/app.py
+++ b/v2/app.py
@@ -780,6 +780,12 @@ def admin_conversation_phases(conv_id):
     # Mirror the results phase onto Polis's vis_type, which gates GET /results/ (off by
     # default — otherwise the Results tab stays empty no matter how many votes are cast).
     # Best-effort: a Polis failure must not lose the phase change we just saved.
+    #
+    # CAVEAT: vis_type is a single all-or-nothing Polis flag — it cannot distinguish
+    # public vs personal results. Enabling it for *personal* results makes the full
+    # aggregate /results/ fetchable by any logged-in participant through the proxy.
+    # Withholding/scoping the aggregate for personal results (the anti-anchoring intent)
+    # must be enforced app-side — tracked as #81 Part 2 — not via vis_type.
     if conv.polis_id:
         results_on = conv.phase_public_results or conv.phase_personal_results
         try:

--- a/v2/app.py
+++ b/v2/app.py
@@ -776,6 +776,18 @@ def admin_conversation_phases(conv_id):
     conv.phase_argument_mapping = bool(request.form.get('phase_argument_mapping'))
     conv.phase_public_results   = bool(request.form.get('phase_public_results'))
     db.session.commit()
+
+    # Mirror the results phase onto Polis's vis_type, which gates GET /results/ (off by
+    # default — otherwise the Results tab stays empty no matter how many votes are cast).
+    # Best-effort: a Polis failure must not lose the phase change we just saved.
+    if conv.polis_id:
+        results_on = conv.phase_public_results or conv.phase_personal_results
+        try:
+            _polis_server_client().set_vis_type(conv.polis_id, 1 if results_on else 0)
+        except PolisServerError as exc:
+            current_app.logger.warning('vis_type update failed for %s: %s', conv.slug, exc)
+            flash('Phases saved, but updating results visibility in Polis failed — '
+                  'results may not appear until you save phases again.', 'error')
     return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
 
 @admin_bp.post('/admin/global-admins/add')

--- a/v2/app.py
+++ b/v2/app.py
@@ -1690,6 +1690,14 @@ def _register_routes(app: Flask) -> None:
                 )
                 db.session.add(participant)
                 db.session.commit()
+            elif participant.mw_username != username or participant.xid != xid:
+                # Reused dev row: keep it consistent with the username we authenticate as.
+                # _current_participant() looks up by mw_username, so a drifted row (e.g. a
+                # pre-existing dev participant from an older username/xid scheme) would make
+                # it return None and 404 participant-gated routes like /accept and /reveal.
+                participant.mw_username = username
+                participant.xid         = xid
+                db.session.commit()
             session['username']  = username
             session['xid']       = xid
             session['emailable'] = False

--- a/v2/polis_admin.py
+++ b/v2/polis_admin.py
@@ -262,6 +262,31 @@ class PolisServerClient:
                 f'{resp.text[:300]}'
             )
 
+    def set_vis_type(self, conversation_id: str, vis_type: int) -> None:
+        """Set the conversation's `vis_type` in Polis.
+
+        Polis gates `GET /api/conversations/<id>/results/` on `vis_type <> 0`
+        (surfaced as `results_available`), and defaults it to 0 — so results are
+        hidden until this is set. We mirror it onto the results-phase toggle: a
+        non-zero value makes the results visualisation available, 0 hides it.
+        """
+        sess, auth_headers = self._login()
+        headers = {**self._HEADERS, **auth_headers}
+        try:
+            resp = sess.put(
+                f'{self._base}/api/v3/conversations',
+                json={'conversation_id': conversation_id, 'vis_type': vis_type},
+                headers=headers,
+                timeout=10,
+            )
+        except requests.RequestException as exc:
+            raise PolisServerError(str(exc)) from exc
+        if not resp.ok:
+            raise PolisServerError(
+                f'Polis vis_type update failed (HTTP {resp.status_code}): '
+                f'{resp.text[:300]}'
+            )
+
     # ── Statements ────────────────────────────────────────────────────────────
 
     def moderate(self, conversation_id: str, tid: int, mod: int) -> None:

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -296,7 +296,7 @@
     <div class="landing-section results-section">
       <h3>Results{% if polis_stats and polis_stats.n_participants %}<span class="muted" style="font-size:13px;font-weight:400;margin-left:.75rem">{{ polis_stats.n_participants }} participant{{ 's' if polis_stats.n_participants != 1 }}</span>{% endif %}</h3>
 
-      {% if conversation.phase_public_results %}
+      {% if conversation.phase_public_results or conversation.phase_personal_results %}
 
         {% if results %}
 
@@ -358,7 +358,7 @@
           <p class="muted">Results will appear here once enough votes have been cast.</p>
         {% endif %}
 
-        {% if polis_public_url %}
+        {% if polis_public_url and conversation.phase_public_results %}
         <p style="margin-top:1rem">
           <a href="{{ polis_public_url }}/{{ conversation.polis_id }}"
              target="_blank" rel="noopener">View full interactive results on Polis →</a>

--- a/v2/tests/test_admin.py
+++ b/v2/tests/test_admin.py
@@ -237,13 +237,20 @@ def test_phases_toggle_mirrors_results_into_polis_vis_type(admin_client, conv):
     phases off flips it back to 0 — otherwise GET /results/ stays empty regardless of votes."""
     from unittest.mock import MagicMock
 
-    # Enabling a results phase → vis_type = 1
+    # Public results on → vis_type = 1
     server = MagicMock()
     with patch('app._polis_server_client', return_value=server):
         r = admin_client.post(f'/admin/conversations/{conv.id}/phases',
                               data={'phase_public_results': 'on'})
     assert r.status_code == 302
     server.set_vis_type.assert_called_once_with('adm1234567', 1)
+
+    # Personal results ALONE also enables it → vis_type = 1 (guards the `or` arm)
+    server_p = MagicMock()
+    with patch('app._polis_server_client', return_value=server_p):
+        admin_client.post(f'/admin/conversations/{conv.id}/phases',
+                          data={'phase_personal_results': 'on'})
+    server_p.set_vis_type.assert_called_once_with('adm1234567', 1)
 
     # No results phase on → vis_type = 0
     server2 = MagicMock()

--- a/v2/tests/test_admin.py
+++ b/v2/tests/test_admin.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from db import AdminRole, Conversation, ConversationInvite, Participation, db
+from db import AdminRole, Conversation, ConversationInvite, db
 from polis_admin import PolisServerError
 
 
@@ -230,3 +230,24 @@ def test_admin_template_pages_render(admin_client, conv):
         ppc.return_value.get_settings.return_value = {}
         resp = admin_client.get(f'/admin/conversations/{conv.id}/statements')
     assert resp.status_code == 200
+
+
+def test_phases_toggle_mirrors_results_into_polis_vis_type(admin_client, conv):
+    """Enabling a results phase must flip Polis `vis_type` on (1); turning both results
+    phases off flips it back to 0 — otherwise GET /results/ stays empty regardless of votes."""
+    from unittest.mock import MagicMock
+
+    # Enabling a results phase → vis_type = 1
+    server = MagicMock()
+    with patch('app._polis_server_client', return_value=server):
+        r = admin_client.post(f'/admin/conversations/{conv.id}/phases',
+                              data={'phase_public_results': 'on'})
+    assert r.status_code == 302
+    server.set_vis_type.assert_called_once_with('adm1234567', 1)
+
+    # No results phase on → vis_type = 0
+    server2 = MagicMock()
+    with patch('app._polis_server_client', return_value=server2):
+        admin_client.post(f'/admin/conversations/{conv.id}/phases',
+                          data={'phase_submission': 'on'})
+    server2.set_vis_type.assert_called_once_with('adm1234567', 0)

--- a/v2/tests/test_conversations.py
+++ b/v2/tests/test_conversations.py
@@ -128,6 +128,35 @@ def test_conversation_with_participation_renders(auth_client, conv, participatio
     assert b'Nothing is available yet' in resp.data
 
 
+def test_personal_results_renders_clustering_data(auth_client, conv, participation,
+                                                  monkeypatch):
+    """#81: with ONLY the Personal results toggle on, the Results tab must render the
+    clustering results — not fall through to the 'not published yet' message. Regression
+    guard for the bug where both the route fetch and the template render were gated on
+    phase_public_results only."""
+    import polis_admin
+    conv.phase_personal_results = True
+    conv.phase_public_results = False
+    db.session.commit()
+
+    fake_results = {
+        'majority': {
+            'agree': [{'statement_text': 'Cats make excellent companions', 'value': 0.82}],
+            'disagree': [],
+        },
+        'groups': [],
+    }
+    monkeypatch.setattr(polis_admin.PolisParticipantClient, 'get_results',
+                        lambda self, cid: fake_results)
+    monkeypatch.setattr(polis_admin.PolisServerClient, 'get_polis_stats',
+                        lambda self, cid: None)
+
+    resp = auth_client.get('/c/test-conv')
+    assert resp.status_code == 200
+    assert b'Cats make excellent companions' in resp.data           # results rendered
+    assert b"Results haven't been published yet" not in resp.data   # not the empty fallback
+
+
 # ── Access control ────────────────────────────────────────────────────────────
 
 def test_invite_only_blocks_uninvited(client, app, participant):

--- a/v2/tests/test_dev_login.py
+++ b/v2/tests/test_dev_login.py
@@ -1,0 +1,71 @@
+"""Tests for the DEV_FAKE_LOGIN staging login (`/dev/login/<username>`).
+
+Regression for the bug where a reused dev Participant (matched by mw_user_id) kept a
+stale mw_username, so `_current_participant()` — which looks up by mw_username — returned
+None and participant-gated routes (/accept, /reveal) 404'd for dev users.
+"""
+import os
+from unittest.mock import patch
+
+import pytest
+from cachelib.file import FileSystemCache
+
+from app import create_app
+from db import Participant, db
+
+
+@pytest.fixture
+def fake_login_app(tmp_path):
+    """App with DEV_FAKE_LOGIN=1 so `/dev/login/<username>` is registered."""
+    session_dir = tmp_path / 'sessions'
+    session_dir.mkdir()
+    env = {'FLASK_DEBUG': '0', 'DEV_LOGIN_USER': '', 'DEV_FAKE_LOGIN': '1'}
+    with patch.dict(os.environ, env, clear=False):
+        a = create_app({
+            'TESTING': True,
+            'SQLALCHEMY_DATABASE_URI': f'sqlite:///{tmp_path}/test.db',
+            'SQLALCHEMY_ENGINE_OPTIONS': {'connect_args': {'check_same_thread': False}},
+            'WTF_CSRF_ENABLED': False,
+            'RATELIMIT_ENABLED': False,
+            'SECRET_KEY': 'test-secret',
+            'SESSION_TYPE': 'cachelib',
+            'SESSION_CACHELIB': FileSystemCache(str(session_dir)),
+            'SESSION_PERMANENT': False,
+        })
+    with a.app_context():
+        db.create_all()
+        yield a
+        db.session.remove()
+
+
+def test_dev_fake_login_creates_participant(fake_login_app):
+    """First login creates the dev Participant with matching mw_username."""
+    r = fake_login_app.test_client().get('/dev/login/dev-user-1')
+    assert r.status_code == 302
+    with fake_login_app.app_context():
+        p = Participant.query.filter_by(mw_user_id=-1).first()
+        assert p is not None
+        assert p.mw_username == 'dev-user-1'
+
+
+def test_dev_fake_login_syncs_drifted_username(fake_login_app):
+    """A reused dev row whose mw_username drifted is corrected on login, so
+    _current_participant() (lookup by mw_username) resolves again."""
+    with fake_login_app.app_context():
+        db.session.add(Participant(mw_user_id=-2, mw_username='stale-name', xid='x' * 64))
+        db.session.commit()
+
+    r = fake_login_app.test_client().get('/dev/login/dev-user-2')
+    assert r.status_code == 302
+
+    with fake_login_app.app_context():
+        # Same row (matched by mw_user_id), now consistent with the authenticated username.
+        rows = Participant.query.filter_by(mw_user_id=-2).all()
+        assert len(rows) == 1
+        assert rows[0].mw_username == 'dev-user-2'
+        # mw_username now matches what _current_participant() looks up by → no more 404.
+        assert Participant.query.filter_by(mw_username='dev-user-2').first() is not None
+
+
+def test_dev_fake_login_unknown_user_404(fake_login_app):
+    assert fake_login_app.test_client().get('/dev/login/not-a-dev-user').status_code == 404


### PR DESCRIPTION
Makes consultation **results actually appear** (fixes #81), plus a dev-login bug found while testing it. Four clearly-separated commits:

| commit | what |
|---|---|
| `70f8980` | **render** personal results when the Phase 3 toggle is on — route fetch + template were gated on `phase_public_results` only, so personal results showed an empty tab |
| `40ac428` | **root cause:** enable Polis `vis_type` when a results phase is toggled — Polis gates `GET /results/` on `vis_type <> 0` (off by default), so results were switched off at the source regardless of votes |
| `4622025` | review nits — personal-results→`vis_type` test case + the binary-`vis_type` exposure caveat |
| `367cd2b` | **dev-login** — sync `mw_username` on a reused dev participant; dev users were getting 404 on `/accept`, which blocked testing this PR |

## Why results never appeared — two layers were both off
1. The route fetched, and the template rendered, results only for `phase_public_results`; `phase_personal_results` showed the tab with nothing in it.
2. Even fixing that, Polis returns `[]` until the conversation's `vis_type <> 0`, which the app never set. `40ac428` ties `vis_type` to the results phase (1 when public **or** personal is on, else 0), best-effort so a Polis failure never loses the saved phase change.

## Verification
- **Unit:** 139 pass; tests cover the personal-results render and the phase→`vis_type` mapping (0 and 1, public and personal arms).
- **End-to-end against real Polis** (local stack, dense data): `set_vis_type` flips `/results/` from empty → real `{groups, majority}` clustering, and the **shape matches our template exactly** — results genuinely render.
- **Reviewed:** senior + security, both **SHIP-WITH-NITS**; nits applied (`4622025`).

## Known follow-up (not a regression) → #81 Part 2
`vis_type` is a single all-or-nothing Polis flag, so enabling it for *personal* results makes the full aggregate `/results/` fetchable by any logged-in participant through the proxy. The anti-anchoring "scope to your own votes" intent must be enforced app-side — tracked as **#81 Part 2**, documented inline at the call site.

Refs #81 (parts 2 — voted-statement scoping — and 3 — Polis viz embed — remain open on the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Staging verification (commit `4622025`)
Confirmed end-to-end on `wiki-polis-dev`: after re-saving **Phases** in admin for a conversation, `set_vis_type` fired against the staging Polis admin API and `results_available` flipped **False → True**; `GET /results/` then returned **real clustering** (2 opinion groups on cats-vs-dogs). So the fix works against real Polis, not just the local stack.

⚠️ **Rollout note:** `set_vis_type` only runs when the **Phases form is saved** (the admin POST). Conversations that *already* had a results phase enabled before this deploys will keep `vis_type=0` until an admin **re-saves Phases** once. After deploying, do a one-time Phases re-save on any conversation that should show results (or treat it as expected that results stay hidden until the next phase save).
