### PR TITLE
Security hardening pass: auth, CSRF, config, and privacy

### DIFF
--- a/v2/.env.example
+++ b/v2/.env.example
@@ -14,7 +14,7 @@ DEV_LOGIN_USER=DevUser
 DEV_DATABASE_URL=sqlite:///dev.db
 
 # Set to 1 to show hardcoded dev-user-1/2/3 badges on the home page (fake login, no OAuth).
-# Never set in production.
+# Only active in local debug mode; never set in production.
 DEV_FAKE_LOGIN=
 
 # URLs for the backend services exposed by dev.sh / docker-compose.wiki-polis.local.yaml.

--- a/v2/.env.example
+++ b/v2/.env.example
@@ -24,6 +24,9 @@ POLIS_SERVER_URL=http://127.0.0.1:8003
 # Leave blank for local dev. Production must set a distributed Flask-Limiter backend.
 RATELIMIT_STORAGE_URI=
 
+# Leave blank for local dev. Production must set comma-separated allowed hostnames.
+TRUSTED_HOSTS=
+
 # Direct Postgres connection for admin stats panel.
 POLIS_DATABASE_URL=postgresql://polis:polis@127.0.0.1:5433/polis
 

--- a/v2/.env.example
+++ b/v2/.env.example
@@ -21,6 +21,9 @@ DEV_FAKE_LOGIN=
 PARTICIAPI_BASE_URL=http://127.0.0.1:8002
 POLIS_SERVER_URL=http://127.0.0.1:8003
 
+# Leave blank for local dev. Production must set a distributed Flask-Limiter backend.
+RATELIMIT_STORAGE_URI=
+
 # Direct Postgres connection for admin stats panel.
 POLIS_DATABASE_URL=postgresql://polis:polis@127.0.0.1:5433/polis
 

--- a/v2/app.py
+++ b/v2/app.py
@@ -132,10 +132,16 @@ def _parse_conversation_form() -> dict:
 def _current_participant() -> 'Participant | None':
     if 'participant' in g:
         return g.participant
+    xid = session.get('xid')
+    if xid:
+        g.participant = Participant.query.filter_by(xid=xid).first()
+        return g.participant
     username = session.get('username')
     if not username:
         g.participant = None
         return None
+    # Temporary compatibility for old server-side sessions created before xid
+    # was stored. New sessions resolve by the stable Wikimedia user-id hash.
     g.participant = Participant.query.filter_by(mw_username=username).first()
     return g.participant
 
@@ -1898,7 +1904,9 @@ def _register_routes(app: Flask) -> None:
                     xid=xid,
                 )
                 db.session.add(participant)
-                db.session.commit()
+            else:
+                participant.xid = xid
+            db.session.commit()
             session['username']  = username
             session['xid']       = xid
             session['emailable'] = _is_emailable(username)
@@ -1940,15 +1948,10 @@ def _register_routes(app: Flask) -> None:
                     xid=xid,
                 )
                 db.session.add(participant)
-                db.session.commit()
-            elif participant.mw_username != username or participant.xid != xid:
-                # Reused dev row: keep it consistent with the username we authenticate as.
-                # _current_participant() looks up by mw_username, so a drifted row (e.g. a
-                # pre-existing dev participant from an older username/xid scheme) would make
-                # it return None and 404 participant-gated routes like /accept and /reveal.
+            else:
                 participant.mw_username = username
-                participant.xid         = xid
-                db.session.commit()
+                participant.xid = xid
+            db.session.commit()
             session['username']  = username
             session['xid']       = xid
             session['emailable'] = False
@@ -2113,6 +2116,8 @@ def _register_routes(app: Flask) -> None:
             db.session.add(participant)
         elif participant.mw_username != username:
             participant.mw_username = username
+        if participant.xid != xid:
+            participant.xid = xid
         db.session.commit()
 
         next_url = session.pop('next', None)

--- a/v2/app.py
+++ b/v2/app.py
@@ -6,6 +6,7 @@ import base64
 import click
 import functools
 import hashlib
+import hmac
 import os
 import random
 import re
@@ -44,7 +45,8 @@ _TEXT_ALLOWED_ATTRS = {'a': {'href', 'title'}}
 _POLIS_ID_RE     = re.compile(r'^[A-Za-z0-9]{6,20}$')
 _SLUG_RE         = re.compile(r'^[a-z0-9]+(?:-[a-z0-9]+)*$')
 _PSEUDONYM_RE    = re.compile(r'^[a-z]{2,20}-[a-z]{2,20}$')
-_DISTRIBUTED_RATELIMIT_SCHEMES = ('redis://', 'rediss://', 'memcached://', 'mongodb://')
+_REDIS_RATELIMIT_SCHEMES = ('redis://', 'rediss://')
+_MIN_RATELIMIT_IDENTITY_SECRET_LEN = 32
 
 
 def _read_secret(name: str) -> str:
@@ -60,6 +62,12 @@ def _split_csv(value: str) -> list[str]:
     return [v.strip() for v in (value or '').split(',') if v.strip()]
 
 
+def _truthy(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value or '').strip().lower() in ('1', 'true', 'yes', 'on')
+
+
 ADMIN_USERS = [u.strip() for u in _read_secret('admin-users').split(',') if u.strip()]
 
 _REVEAL_COOLDOWN_DAYS = 30   # days after close before reveal window opens
@@ -70,8 +78,28 @@ _math_recompute_last: dict[int, float] = {}  # conv.id → epoch of last trigger
 
 csrf    = CSRFProtect()
 # No global default — limits applied per endpoint only.
-# On multi-worker deployments configure RATELIMIT_STORAGE_URI=redis://... in env.
-limiter = Limiter(key_func=get_remote_address, default_limits=[])
+# Toolforge provides TOOL_REDIS_URI; production startup validates Redis isolation.
+def _ratelimit_identity_key() -> str:
+    """Return a stable, non-reversible client identity for Flask-Limiter."""
+    trust_proxy_headers = (
+        _truthy(current_app.config.get('TRUST_PROXY_HEADERS'))
+        or bool(os.environ.get('TOOL_TOOLFORGE_API_URL'))
+    )
+    if trust_proxy_headers:
+        access_route = [addr.strip() for addr in request.access_route if addr.strip()]
+        client_identity = access_route[0] if access_route else get_remote_address()
+    else:
+        client_identity = get_remote_address()
+    identity_secret = current_app.config.get('RATELIMIT_IDENTITY_SECRET', '')
+    if not identity_secret:
+        return client_identity
+    digest = hmac.new(str(identity_secret).encode('utf-8'),
+                      client_identity.encode('utf-8'),
+                      hashlib.sha256).hexdigest()
+    return f'ip:{digest}'
+
+
+limiter = Limiter(key_func=_ratelimit_identity_key, default_limits=[])
 
 
 def _short_title(text: str, max_len: int = 80) -> str:
@@ -985,8 +1013,8 @@ def admin_conversation_invites(conv_id):
 @login_required
 def admin_invite_add(conv_id):
     _require_mod_for_conv(conv_id)
-    raw = [l.strip() for l in
-           request.form.get('mw_usernames', '').splitlines() if l.strip()]
+    raw = [line.strip() for line in
+           request.form.get('mw_usernames', '').splitlines() if line.strip()]
     usernames = [u for u in raw if 1 <= len(u) <= 255]
     if not usernames:
         return redirect(url_for('admin.admin_conversation_invites', conv_id=conv_id))
@@ -1768,6 +1796,13 @@ def create_app(test_config: dict | None = None) -> Flask:
     if test_config is not None:
         app.config.update(test_config)
 
+    _trust_proxy_headers = app.config.get('TRUST_PROXY_HEADERS')
+    if _trust_proxy_headers is None:
+        _trust_proxy_headers = _read_secret('trust-proxy-headers')
+    app.config['TRUST_PROXY_HEADERS'] = (
+        _truthy(_trust_proxy_headers) or bool(os.environ.get('TOOL_TOOLFORGE_API_URL'))
+    )
+
     _trusted_hosts = app.config.get('TRUSTED_HOSTS')
     if _trusted_hosts is None:
         _trusted_hosts = _split_csv(_read_secret('trusted-hosts'))
@@ -1783,20 +1818,52 @@ def create_app(test_config: dict | None = None) -> Flask:
 
     _ratelimit_storage_uri = (
         app.config.get('RATELIMIT_STORAGE_URI')
-        or os.environ.get('RATELIMIT_STORAGE_URI', '').strip()
+        or _read_secret('ratelimit-storage-uri')
+        or os.environ.get('TOOL_REDIS_URI', '').strip()
     )
     if _ratelimit_storage_uri:
         if (not app.debug and not app.testing
-                and not _ratelimit_storage_uri.startswith(_DISTRIBUTED_RATELIMIT_SCHEMES)):
+                and not _ratelimit_storage_uri.startswith(_REDIS_RATELIMIT_SCHEMES)):
             raise RuntimeError(
-                'RATELIMIT_STORAGE_URI must use a distributed backend in production '
-                '(for example redis://...).'
+                'RATELIMIT_STORAGE_URI must use a Redis backend in production '
+                '(for example Toolforge TOOL_REDIS_URI or redis://...).'
             )
         app.config['RATELIMIT_STORAGE_URI'] = _ratelimit_storage_uri
     elif not app.debug and not app.testing:
         raise RuntimeError(
-            'RATELIMIT_STORAGE_URI is not set. Configure a distributed Flask-Limiter '
-            'storage backend such as redis://... before starting production.'
+            'RATELIMIT_STORAGE_URI is not set and Toolforge TOOL_REDIS_URI is unavailable. '
+            'Configure Redis-backed Flask-Limiter storage before starting production.'
+        )
+
+    _ratelimit_key_prefix = app.config.get('RATELIMIT_KEY_PREFIX')
+    if _ratelimit_key_prefix is None:
+        _ratelimit_key_prefix = _read_secret('ratelimit-key-prefix')
+    _ratelimit_key_prefix = str(_ratelimit_key_prefix).strip() if _ratelimit_key_prefix else ''
+    if _ratelimit_key_prefix:
+        app.config['RATELIMIT_KEY_PREFIX'] = _ratelimit_key_prefix
+    elif not app.debug and not app.testing:
+        raise RuntimeError(
+            'RATELIMIT_KEY_PREFIX is not set. Configure a unique Toolforge Redis key '
+            'prefix such as wiki-polis:<random>: before starting production.'
+        )
+
+    _ratelimit_identity_secret = app.config.get('RATELIMIT_IDENTITY_SECRET')
+    if _ratelimit_identity_secret is None:
+        _ratelimit_identity_secret = _read_secret('ratelimit-identity-secret')
+    _ratelimit_identity_secret = (
+        str(_ratelimit_identity_secret).strip() if _ratelimit_identity_secret else ''
+    )
+    if _ratelimit_identity_secret:
+        if (not app.debug and not app.testing
+                and len(_ratelimit_identity_secret) < _MIN_RATELIMIT_IDENTITY_SECRET_LEN):
+            raise RuntimeError(
+                'RATELIMIT_IDENTITY_SECRET must be at least 32 characters in production.'
+            )
+        app.config['RATELIMIT_IDENTITY_SECRET'] = _ratelimit_identity_secret
+    elif not app.debug and not app.testing:
+        raise RuntimeError(
+            'RATELIMIT_IDENTITY_SECRET is not set. Configure a random secret so '
+            'rate-limit keys do not expose raw client identities in shared Redis.'
         )
 
     db.init_app(app)

--- a/v2/app.py
+++ b/v2/app.py
@@ -59,28 +59,9 @@ def _read_secret(name: str) -> str:
 ADMIN_USERS = [u.strip() for u in _read_secret('admin-users').split(',') if u.strip()]
 
 _REVEAL_COOLDOWN_DAYS = 30   # days after close before reveal window opens
-_REVEAL_NULLIFY_DAYS  = 30   # days after window opens before nullification (total = cooldown + nullify)
+_REVEAL_WINDOW_DAYS   = 30   # days participants may opt in once the window opens
 _MATH_RECOMPUTE_COOLDOWN = 600  # seconds between auto-triggered recomputes per conversation
 _math_recompute_last: dict[int, float] = {}  # conv.id → epoch of last trigger
-
-
-def _nullify_expired_reveals(conv: 'Conversation') -> None:
-    """Clear public_username / revealed_at for all participations once past internal deadline."""
-    if not conv.closed_at:
-        return
-    # closed_at is stored as naive UTC
-    age = datetime.now(timezone.utc) - conv.closed_at.replace(tzinfo=timezone.utc)
-    if age < timedelta(days=_REVEAL_COOLDOWN_DAYS + _REVEAL_NULLIFY_DAYS):
-        return
-    stale = (Participation.query
-             .filter_by(conversation_id=conv.id)
-             .filter(Participation.public_username.isnot(None))
-             .all())
-    for p in stale:
-        p.public_username = None
-        p.revealed_at     = None
-    if stale:
-        db.session.commit()
 
 
 csrf    = CSRFProtect()
@@ -1202,8 +1183,7 @@ def accept(slug):
     return render_template('accept.html', conversation=conv,
                            emailable=emailable, pseudonyms=pseudonyms,
                            reveal_cooldown=_REVEAL_COOLDOWN_DAYS,
-                           reveal_window_end=_REVEAL_COOLDOWN_DAYS + _REVEAL_NULLIFY_DAYS,
-                           retention_public_days=120)
+                           reveal_window_end=_REVEAL_COOLDOWN_DAYS + _REVEAL_WINDOW_DAYS)
 
 @participant_bp.post('/accept/<slug>')
 @login_required
@@ -1271,11 +1251,6 @@ def conversation(slug):
     if participation is None:
         return redirect(url_for('participant.accept', slug=slug))
 
-    # Lazy nullification: clear identity links past the internal retention deadline.
-    if conv.closed_at:
-        _nullify_expired_reveals(conv)
-        db.session.refresh(participation)
-
     can_mod = _can_moderate(conv, participant)
 
     results     = None
@@ -1307,7 +1282,7 @@ def conversation(slug):
         reveal_opens_at = conv.closed_at + timedelta(days=_REVEAL_COOLDOWN_DAYS)
         if participation.public_username:
             reveal_state = 'revealed'
-        elif age >= timedelta(days=_REVEAL_COOLDOWN_DAYS + _REVEAL_NULLIFY_DAYS):
+        elif age >= timedelta(days=_REVEAL_COOLDOWN_DAYS + _REVEAL_WINDOW_DAYS):
             reveal_state = 'expired'
         elif age >= timedelta(days=_REVEAL_COOLDOWN_DAYS):
             reveal_state = 'open'
@@ -1572,16 +1547,13 @@ def reveal_identity(slug):
     if not conv.closed_at:
         abort(404)
 
-    _nullify_expired_reveals(conv)
-    db.session.refresh(participation)
-
     age = datetime.now(timezone.utc) - conv.closed_at.replace(tzinfo=timezone.utc)
     opens_at = conv.closed_at + timedelta(days=_REVEAL_COOLDOWN_DAYS)
     return render_template('reveal.html',
                            conversation=conv,
                            participation=participation,
                            window_open=age >= timedelta(days=_REVEAL_COOLDOWN_DAYS),
-                           window_closed=age >= timedelta(days=_REVEAL_COOLDOWN_DAYS + _REVEAL_NULLIFY_DAYS),
+                           window_closed=age >= timedelta(days=_REVEAL_COOLDOWN_DAYS + _REVEAL_WINDOW_DAYS),
                            opens_at=opens_at)
 
 @participant_bp.post('/c/<slug>/reveal')
@@ -1603,7 +1575,7 @@ def reveal_identity_post(slug):
     age = datetime.now(timezone.utc) - conv.closed_at.replace(tzinfo=timezone.utc)
     if age < timedelta(days=_REVEAL_COOLDOWN_DAYS):
         abort(400)
-    if age >= timedelta(days=_REVEAL_COOLDOWN_DAYS + _REVEAL_NULLIFY_DAYS):
+    if age >= timedelta(days=_REVEAL_COOLDOWN_DAYS + _REVEAL_WINDOW_DAYS):
         abort(400)
     if participation.public_username is not None:
         abort(400)

--- a/v2/app.py
+++ b/v2/app.py
@@ -687,7 +687,11 @@ def admin_conversation_detail(conv_id):
     conv_roles = (AdminRole.query
                    .filter_by(conversation_id=conv_id)
                    .all())
-    participants      = Participant.query.order_by(Participant.mw_username).all()
+    can_manage_roles  = _is_global_admin()
+    participants      = (
+        Participant.query.order_by(Participant.mw_username).all()
+        if can_manage_roles else []
+    )
     invite_count      = ConversationInvite.query.filter_by(conversation_id=conv_id).count()
     participant_count = Participation.query.filter_by(conversation_id=conv_id).count()
     polis_stats       = _polis_server_client().get_polis_stats(conv.polis_id)
@@ -698,7 +702,8 @@ def admin_conversation_detail(conv_id):
                            invite_count=invite_count,
                            participant_count=participant_count,
                            polis_stats=polis_stats,
-                           admin_roles=ADMIN_ROLES)
+                           admin_roles=ADMIN_ROLES,
+                           can_manage_roles=can_manage_roles)
 
 @admin_bp.post('/admin/conversations/new')
 @login_required

--- a/v2/app.py
+++ b/v2/app.py
@@ -2187,4 +2187,4 @@ def _register_routes(app: Flask) -> None:
 app = create_app()
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(host='127.0.0.1', debug=app.debug)

--- a/v2/app.py
+++ b/v2/app.py
@@ -1906,8 +1906,8 @@ def _register_routes(app: Flask) -> None:
 
     # ── Dev test users (DEV_FAKE_LOGIN=1) ────────────────────────────────────
     # Hardcoded test accounts with negative mw_user_ids so they can never
-    # collide with real Wikimedia accounts. Only active when DEV_FAKE_LOGIN=1
-    # is set in the environment — never enable this on production.
+    # collide with real Wikimedia accounts. Only active for local debug runs;
+    # never register this bypass on Toolforge or other non-debug deployments.
 
     _DEV_TEST_USERS = [
         {'username': 'dev-user-1', 'mw_user_id': -1},
@@ -1915,7 +1915,12 @@ def _register_routes(app: Flask) -> None:
         {'username': 'dev-user-3', 'mw_user_id': -3},
     ]
 
-    _fake_login_enabled = os.environ.get('DEV_FAKE_LOGIN', '').strip() == '1'
+    _fake_login_requested = os.environ.get('DEV_FAKE_LOGIN', '').strip() == '1'
+    _fake_login_enabled = bool(app.debug and _fake_login_requested and not _on_toolforge)
+    if _fake_login_requested and not _fake_login_enabled:
+        app.logger.warning(
+            'DEV_FAKE_LOGIN ignored because fake login is only allowed in local debug mode'
+        )
     app.config['DEV_FAKE_LOGIN'] = _fake_login_enabled
     app.config['DEV_TEST_USERS'] = _DEV_TEST_USERS if _fake_login_enabled else []
 

--- a/v2/app.py
+++ b/v2/app.py
@@ -56,6 +56,10 @@ def _read_secret(name: str) -> str:
     return os.environ.get(name.upper().replace('-', '_'), '')
 
 
+def _split_csv(value: str) -> list[str]:
+    return [v.strip() for v in (value or '').split(',') if v.strip()]
+
+
 ADMIN_USERS = [u.strip() for u in _read_secret('admin-users').split(',') if u.strip()]
 
 _REVEAL_COOLDOWN_DAYS = 30   # days after close before reveal window opens
@@ -1763,6 +1767,19 @@ def create_app(test_config: dict | None = None) -> Flask:
     # SQLALCHEMY_DATABASE_URI, etc. are effective from the first db.init_app call.
     if test_config is not None:
         app.config.update(test_config)
+
+    _trusted_hosts = app.config.get('TRUSTED_HOSTS')
+    if _trusted_hosts is None:
+        _trusted_hosts = _split_csv(_read_secret('trusted-hosts'))
+    elif isinstance(_trusted_hosts, str):
+        _trusted_hosts = _split_csv(_trusted_hosts)
+    if _trusted_hosts:
+        app.config['TRUSTED_HOSTS'] = _trusted_hosts
+    elif not app.debug and not app.testing:
+        raise RuntimeError(
+            'TRUSTED_HOSTS is not set. Configure comma-separated allowed hostnames '
+            'such as wiki-polis.toolforge.org before starting production.'
+        )
 
     _ratelimit_storage_uri = (
         app.config.get('RATELIMIT_STORAGE_URI')

--- a/v2/app.py
+++ b/v2/app.py
@@ -24,10 +24,11 @@ from flask_migrate import Migrate
 from flask_session import Session
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
-from flask_wtf.csrf import CSRFProtect
+from flask_wtf.csrf import CSRFProtect, validate_csrf
 from sqlalchemy import text as _sa_text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
+from wtforms.validators import ValidationError
 
 from db import (ACCESS_POLICIES, ADMIN_ROLES, AdminRole, Argument, ArgumentSideState,
                 ArgumentVote, Conversation, ConversationInvite, FeaturedStatement,
@@ -278,10 +279,26 @@ def _validate_same_origin():
     if sec_fetch:
         if sec_fetch != 'same-origin':
             abort(403)
-    else:
-        origin = request.headers.get('Origin')
-        if origin and urlparse(origin).netloc != urlparse(request.host_url).netloc:
+        return
+    origin = request.headers.get('Origin')
+    if origin:
+        if urlparse(origin).netloc != urlparse(request.host_url).netloc:
             abort(403)
+        return
+    abort(403)
+
+
+def _validate_fetch_csrf():
+    """Validate Flask-WTF CSRF for JSON/fetch routes on the exempt proxy blueprint."""
+    if not current_app.config.get('WTF_CSRF_ENABLED', True):
+        return
+    token = (request.headers.get('X-CSRFToken')
+             or request.headers.get('X-CSRF-Token')
+             or request.form.get('csrf_token'))
+    try:
+        validate_csrf(token)
+    except ValidationError:
+        abort(400)
 
 
 def _proxy_to_particiapi(pa_path: str):
@@ -579,7 +596,9 @@ proxy_bp = Blueprint('proxy', __name__)
 def conversation_statement_new(slug):
     """Submit an entirely new statement; enforces per-participant quota and
     records the Polis statement ID for novelty tracking."""
-    # Origin validation (same compensating control as the proxy).
+    # This route lives on the CSRF-exempt proxy blueprint for historical reasons,
+    # so validate Flask-WTF's token manually before same-origin checks.
+    _validate_fetch_csrf()
     _validate_same_origin()
 
     conv = Conversation.query.filter_by(slug=slug).first_or_404()

--- a/v2/app.py
+++ b/v2/app.py
@@ -44,6 +44,7 @@ _TEXT_ALLOWED_ATTRS = {'a': {'href', 'title'}}
 _POLIS_ID_RE     = re.compile(r'^[A-Za-z0-9]{6,20}$')
 _SLUG_RE         = re.compile(r'^[a-z0-9]+(?:-[a-z0-9]+)*$')
 _PSEUDONYM_RE    = re.compile(r'^[a-z]{2,20}-[a-z]{2,20}$')
+_DISTRIBUTED_RATELIMIT_SCHEMES = ('redis://', 'rediss://', 'memcached://', 'mongodb://')
 
 
 def _read_secret(name: str) -> str:
@@ -1791,17 +1792,29 @@ def create_app(test_config: dict | None = None) -> Flask:
     if test_config is not None:
         app.config.update(test_config)
 
+    _ratelimit_storage_uri = (
+        app.config.get('RATELIMIT_STORAGE_URI')
+        or os.environ.get('RATELIMIT_STORAGE_URI', '').strip()
+    )
+    if _ratelimit_storage_uri:
+        if (not app.debug and not app.testing
+                and not _ratelimit_storage_uri.startswith(_DISTRIBUTED_RATELIMIT_SCHEMES)):
+            raise RuntimeError(
+                'RATELIMIT_STORAGE_URI must use a distributed backend in production '
+                '(for example redis://...).'
+            )
+        app.config['RATELIMIT_STORAGE_URI'] = _ratelimit_storage_uri
+    elif not app.debug and not app.testing:
+        raise RuntimeError(
+            'RATELIMIT_STORAGE_URI is not set. Configure a distributed Flask-Limiter '
+            'storage backend such as redis://... before starting production.'
+        )
+
     db.init_app(app)
     Migrate(app, db)
     Session(app)
     csrf.init_app(app)
     limiter.init_app(app)
-
-    if not app.debug and not os.environ.get('RATELIMIT_STORAGE_URI'):
-        app.logger.warning(
-            'RATELIMIT_STORAGE_URI not set — rate limits are per-worker and '
-            'ineffective on multi-replica deployments. Set RATELIMIT_STORAGE_URI=redis://...'
-        )
 
     @app.cli.command('init-db')
     def init_db_cmd():

--- a/v2/docs/plan_doc-improvement.md
+++ b/v2/docs/plan_doc-improvement.md
@@ -259,8 +259,8 @@ decisions-first · scope.**
   identity-reveal timeline, pseudonym uniqueness, xid-is-not-anonymous caveat, and
   operator data retention all need a public, plain-language commitment.
 - **Audience:** participants (public), with an internal annex for maintainers.
-- **Decisions:** retention commitment **settled (D-PRIV): 180 days** (internal
-  nullification target stays at day 60). Still to draft within N2 and bring back for
+- **Decisions:** retention commitment **settled (D-PRIV): 180 days** (internal-link
+  removal target is sooner). Still to draft within N2 and bring back for
   review: what is logged, who can see raw identity links, lawful basis /
   Wikimedia-aligned framing.
 - **Scope:** M. Drives real participant-facing copy + the accept-page text. Highest
@@ -325,8 +325,8 @@ decisions-first · scope.**
 - **Why:** bigger than a write-up. 107 tests exist but with real structural problems
   the audit surfaced (a whole module uncollectable §3a, drift §3b — fixed in PR #88 —
   and genuinely untested high-risk paths §5: the Polis-Postgres raw SQL, the proxy
-  cookie-rename / 403→200 rewrite, the quota row-lock race, time-based reveal
-  nullification). Documenting "how to run the tests" on top of that would paper over
+  cookie-rename / 403→200 rewrite, the quota row-lock race, time-based reveal-window
+  behavior). Documenting "how to run the tests" on top of that would paper over
   the real question: **how do we want to test this going forward?** So N9 is two
   things — a **test-strategy rethink** (a decision, D-TEST below) and *then* the
   CONTRIBUTING/testing guide that documents the agreed approach (run flow, what to
@@ -370,7 +370,7 @@ decisions-first · scope.**
 | ~~**D-V1**~~ ✅ | **Resolved:** remove the `v1/` archive from the repository. v2 is live; v3 possible later but not a doc concern now. | (unblocked) | maintainer |
 | ~~**C4**~~ ✅ | **Resolved:** split next_steps into a forward roadmap (N7) + a historical record / changelog (N8) so outdated work can't accidentally drive future decisions. | (unblocked) | maintainer |
 | ~~**D-VOTE**~~ ✅ | **Resolved:** (1) "change vote" **reopens the statement and resubmits** the new vote to Polis (fixes #69); (2) after a **proposal submission**, auto-advance to the next statement after a brief pause — make that pause **a bit longer** than a default; (3) after a **plain vote**, keep the **explicit "Move on"** click. (Implementation note: #69 needs a code change, not just docs.) | (unblocked) | product |
-| ~~**D-PRIV**~~ ✅ | **Resolved (clarified).** A participant's voluntary public reveal of their username↔pseudonym is **permanent and irreversible — never nullified.** Separately, the **internal** account↔pseudonym link (held by platform managers, for technical/dedup purposes) is removed within **180 days** of close (internal target sooner). ⚠️ `spec_functional-design.md` and the current code still *nullify reveals* — both need reconciling to this model (spec edit + a code change to `_nullify_expired_reveals`). N2 drafts toward it; not publishable until legal/comms review. | N2, functional_design, code | maintainer + review |
+| ~~**D-PRIV**~~ ✅ | **Resolved (clarified).** A participant's voluntary public reveal of their username↔pseudonym is **permanent and irreversible — never nullified.** Separately, the **internal** account↔pseudonym link (held by platform managers, for technical/dedup purposes) is removed within **180 days** of close (internal target sooner). Code and spec now keep voluntary public reveals permanent; internal-link removal remains separate follow-up work. N2 drafts toward the public privacy statement; not publishable until legal/comms review. | N2, internal-link removal | maintainer + review |
 | ~~**D-AUDIT**~~ ✅ | **Resolved:** merge PR #94 to keep the audits in version control, but treat them as a **point-in-time record** — archive or delete once obsolete. Durable findings must be folded into `spec_architecture.md` / the data-model reference so their value survives the audits' eventual removal. | (unblocked) | maintainer |
 | ~~**D-STORE**~~ ✅ | **Resolved: intended design.** The two read paths are **routes to the same store, not separate stores** — admins read Polis Postgres directly (moderation buckets + vote counts the participant API doesn't expose); participants get the live Particiapi-HTTP view of the same data. Documented in `spec_architecture.md`; the inconsistent client shapes are a minor cleanup, not a redesign. | (unblocked) | maintainer |
 | ~~**D-MON**~~ ✅ | **Resolved (split):** monitoring/log-aggregation (#49) is **deferred** — runbook keeps a monitoring TODO until the production VPS is provisioned; document `/health` and its reachability-only limitation in the meantime. **Staging is permanent** — document `wiki-polis-dev` as a standing environment incl. prod-vs-staging differences (dev-login, separate DB). | deployment, N5 | maintainer |

--- a/v2/docs/route_authorization_matrix.md
+++ b/v2/docs/route_authorization_matrix.md
@@ -1,0 +1,87 @@
+# Route authorization matrix
+
+This matrix describes the production routes served by `v2/app.py`. It is a
+security reference for reviews and route changes; update it when routes move
+between blueprints or authorization policy changes.
+
+## Public routes
+
+| Routes | Methods | Authorization |
+|---|---|---|
+| `/` | GET | Public. Shows public active conversations when logged out; shows participant-specific dashboard when logged in. |
+| `/login` | GET | Public, rate-limited. Starts Wikimedia OAuth or local dev login when explicitly configured. |
+| `/oauth-callback` | GET | Public, rate-limited. Requires matching OAuth state and PKCE verifier from the browser session. |
+| `/health` | GET | Public, limiter-exempt. Returns DB and Particiapi reachability only. |
+| `/static/*` | GET | Public static assets. |
+
+## Participant routes
+
+| Routes | Methods | Authorization |
+|---|---|---|
+| `/accept/<slug>` | GET, POST | `login_required`; invite-only conversations require an invite, existing participation, or moderator access. POST is rate-limited and creates one participation. |
+| `/accept/<slug>/pseudonyms` | GET | `login_required`, rate-limited. Conversation must exist. |
+| `/c/<slug>` | GET | `login_required`; invite-only access check; redirects non-participants to the accept flow. |
+| `/c/<slug>/reveal` | GET, POST | `login_required`; current participant must have joined the closed conversation. POST is rate-limited, requires confirmation, and is only accepted during the reveal window. |
+| `/logout` | POST | `login_required`; clears the Flask session. |
+
+## Participant argument routes
+
+| Routes | Methods | Authorization |
+|---|---|---|
+| `/c/<slug>/arguments/<fs_id>/submit` | POST | `login_required`; `_require_arg_participation()` requires active, unpaused, argument phase enabled, and current participant membership. |
+| `/c/<slug>/arguments/<fs_id>/<side>/skip` | POST | Same as submit; side must be `pro` or `con`. |
+| `/c/<slug>/arguments/<arg_id>/vote` | POST | Same as submit; also enforces side gates, vote cap, not hidden, and not own argument. |
+| `/c/<slug>/arguments/<arg_id>/unvote` | POST | Same as submit; argument must belong to a featured statement in the same conversation. |
+| `/c/<slug>/arguments/<arg_id>/hide` | POST | `login_required`; current participant must be able to moderate the conversation. |
+| `/c/<slug>/arguments/<arg_id>/unhide` | POST | Same as hide. |
+
+## Global-admin routes
+
+| Routes | Methods | Authorization |
+|---|---|---|
+| `/admin` | GET | `login_required` and `admin_required`. |
+| `/admin/conversations/new` | POST | `login_required` and `admin_required`. |
+| `/admin/conversations/<conv_id>/edit` | POST | `login_required` and `admin_required`. |
+| `/admin/conversations/<conv_id>/pause` | POST | `login_required` and `admin_required`. |
+| `/admin/conversations/<conv_id>/close` | POST | `login_required` and `admin_required`. |
+| `/admin/conversations/<conv_id>/phases` | POST | `login_required` and `admin_required`. |
+| `/admin/global-admins/add` | POST | `login_required` and `admin_required`. |
+| `/admin/global-admins/<participant_id>/remove` | POST | `login_required` and `admin_required`. |
+| `/admin/roles/add` | POST | `login_required` and `admin_required`. |
+| `/admin/roles/<role_id>/remove` | POST | `login_required` and `admin_required`. |
+
+## Conversation moderator routes
+
+These routes allow either a global admin or a participant with an `AdminRole` for
+the specific conversation. The shared authorization helper is
+`_require_mod_for_conv(conv_id)`.
+
+| Routes | Methods | Authorization |
+|---|---|---|
+| `/admin/conversations/<conv_id>` | GET | Conversation moderator or global admin. Global role controls are rendered only for global admins. |
+| `/admin/conversations/<conv_id>/invites` | GET | Conversation moderator or global admin. |
+| `/admin/conversations/<conv_id>/invites/add` | POST | Conversation moderator or global admin. |
+| `/admin/conversations/<conv_id>/invites/<invite_id>/remove` | POST | Conversation moderator or global admin. |
+| `/admin/conversations/<conv_id>/statements` | GET | Conversation moderator or global admin. |
+| `/admin/conversations/<conv_id>/statements/<tid>/moderate` | POST | Conversation moderator or global admin. |
+| `/admin/conversations/<conv_id>/statements/seed` | POST | Conversation moderator or global admin. |
+| `/admin/conversations/<conv_id>/strict-moderation` | POST | Conversation moderator or global admin. |
+| `/admin/conversations/<conv_id>/featured` | GET | Conversation moderator or global admin. |
+| `/admin/conversations/<conv_id>/featured/confirm` | POST | Conversation moderator or global admin. |
+| `/admin/conversations/<conv_id>/featured/add` | POST | Conversation moderator or global admin. |
+| `/admin/conversations/<conv_id>/featured/<fs_id>/remove` | POST | Conversation moderator or global admin. |
+| `/admin/conversations/<conv_id>/arguments/<arg_id>/delete` | POST | Conversation moderator or global admin. |
+
+## Particiapi bridge
+
+| Routes | Methods | Authorization |
+|---|---|---|
+| `/proxy/particiapi/<path>` | GET, POST, PUT | `login_required`. Path must stay under `api/` and reject `..` segments. Unsafe methods require same-origin browser provenance headers. |
+| `/c/<slug>/statements/new` | POST | `login_required`. Manually validates Flask-WTF CSRF because it lives on the CSRF-exempt proxy blueprint, then requires same-origin browser provenance headers, active/unpaused submission phase, current participation, and per-participant quota. |
+
+## Local-debug-only routes
+
+| Routes | Methods | Authorization |
+|---|---|---|
+| `/dev-login` | GET | Registered only when Flask debug mode is on, `DEV_LOGIN_USER` is set, and the app is not on Toolforge. |
+| `/dev/login/<username>` | GET | Registered only when Flask debug mode is on, `DEV_FAKE_LOGIN=1`, and the app is not on Toolforge. |

--- a/v2/guide_deployment.md
+++ b/v2/guide_deployment.md
@@ -313,13 +313,14 @@ toolforge envvars create POLIS_SERVER_URL
 toolforge envvars create POLIS_ADMIN_EMAIL
 toolforge envvars create POLIS_ADMIN_PASSWORD
 toolforge envvars create POLIS_DATABASE_URL
+toolforge envvars create RATELIMIT_KEY_PREFIX
+toolforge envvars create RATELIMIT_IDENTITY_SECRET
 ```
 
 Non-secret values can be passed as arguments:
 
 ```bash
 toolforge envvars create OAUTH_REDIRECT_URI 'https://wiki-polis.toolforge.org/oauth-callback'
-toolforge envvars create RATELIMIT_STORAGE_URI 'redis://<rate-limit-host>:6379/0'
 toolforge envvars create TRUSTED_HOSTS 'wiki-polis.toolforge.org'
 ```
 
@@ -333,8 +334,11 @@ Values to enter at the prompts:
 - `POLIS_ADMIN_EMAIL` — email of the Polis system account (see Polis system account step below)
 - `POLIS_ADMIN_PASSWORD` — password of the Polis system account
 - `POLIS_DATABASE_URL` — `postgresql://wiki_polis_ro:<password>@<vps-private-ip>:5432/polis` — use the password set when creating the `wiki_polis_ro` role (see Security hardening step above); do not use the `polis` superuser here
-- `RATELIMIT_STORAGE_URI` — distributed Flask-Limiter storage, for example `redis://<rate-limit-host>:6379/0`; production startup fails if this is missing or set to a local backend
+- `RATELIMIT_KEY_PREFIX` — unique Redis key namespace for this deployment; generate a random value such as `wiki-polis:prod:<random>:` for production and a different one for staging
+- `RATELIMIT_IDENTITY_SECRET` — strong random HMAC key used to hash client identities before Flask-Limiter writes Redis keys
 - `TRUSTED_HOSTS` — comma-separated allowed request hostnames, for example `wiki-polis.toolforge.org`; add explicit staging hostnames on staging deployments
+
+Toolforge exposes shared Redis through the global `TOOL_REDIS_URI` environment variable, so production does not normally need a `RATELIMIT_STORAGE_URI` envvar. If running the Flask frontend directly on a Wikimedia VPS or overriding Toolforge Redis, set `RATELIMIT_STORAGE_URI` to a Redis URL such as `redis://<vps-private-ip>:6379/0`; production startup rejects local limiter backends such as `memory://`. Toolforge proxy headers are trusted automatically. On a Wikimedia VPS, set `TRUST_PROXY_HEADERS=1` only when the Flask app is behind a reverse proxy that overwrites incoming forwarding headers.
 
 > `toolforge envvars list` shows names only, not values. Keep a local record.
 
@@ -542,7 +546,11 @@ export SECRET_KEY=$(toolforge envvars show SECRET_KEY | tail -1 | awk '{print $N
 | `POLIS_ADMIN_EMAIL` | yes | Email of the Polis system account (created once on VPS) |
 | `POLIS_ADMIN_PASSWORD` | yes | Password of the Polis system account |
 | `POLIS_DATABASE_URL` | no | Direct Postgres connection for admin stats panel; leave blank to disable |
-| `RATELIMIT_STORAGE_URI` | yes (prod) | Distributed Flask-Limiter backend, for example `redis://<host>:6379/0` |
+| `TOOL_REDIS_URI` | provided by Toolforge | Shared Toolforge Redis URL; used automatically for Flask-Limiter when `RATELIMIT_STORAGE_URI` is unset |
+| `RATELIMIT_STORAGE_URI` | VPS/override only | Explicit Redis backend, for example `redis://<host>:6379/0`; production rejects non-Redis limiter storage |
+| `RATELIMIT_KEY_PREFIX` | yes (prod) | Unique random Redis key namespace for this deployment, for example `wiki-polis:prod:<random>:` |
+| `RATELIMIT_IDENTITY_SECRET` | yes (prod) | Random HMAC secret used to avoid storing raw client identities in shared Redis keys |
+| `TRUST_PROXY_HEADERS` | VPS reverse proxy only | Set to `1` only when a Wikimedia VPS reverse proxy overwrites forwarding headers; Toolforge is detected automatically |
 | `TRUSTED_HOSTS` | yes (prod) | Comma-separated allowed request hostnames, for example `wiki-polis.toolforge.org` |
 | `DEV_LOGIN_USER` | dev only | Bypasses OAuth in local dev; never set in production |
 | `DEV_FAKE_LOGIN` | dev only | Set to `1` to show hardcoded test-user badges on the home page; never set in production |

--- a/v2/guide_deployment.md
+++ b/v2/guide_deployment.md
@@ -319,7 +319,7 @@ Non-secret values can be passed as arguments:
 
 ```bash
 toolforge envvars create OAUTH_REDIRECT_URI 'https://wiki-polis.toolforge.org/oauth-callback'
-toolforge envvars create POLIS_PUBLIC_URL 'https://wiki-polis.toolforge.org'
+toolforge envvars create RATELIMIT_STORAGE_URI 'redis://<rate-limit-host>:6379/0'
 ```
 
 Values to enter at the prompts:
@@ -332,6 +332,7 @@ Values to enter at the prompts:
 - `POLIS_ADMIN_EMAIL` — email of the Polis system account (see Polis system account step below)
 - `POLIS_ADMIN_PASSWORD` — password of the Polis system account
 - `POLIS_DATABASE_URL` — `postgresql://wiki_polis_ro:<password>@<vps-private-ip>:5432/polis` — use the password set when creating the `wiki_polis_ro` role (see Security hardening step above); do not use the `polis` superuser here
+- `RATELIMIT_STORAGE_URI` — distributed Flask-Limiter storage, for example `redis://<rate-limit-host>:6379/0`; production startup fails if this is missing or set to a local backend
 
 > `toolforge envvars list` shows names only, not values. Keep a local record.
 
@@ -539,6 +540,7 @@ export SECRET_KEY=$(toolforge envvars show SECRET_KEY | tail -1 | awk '{print $N
 | `POLIS_ADMIN_EMAIL` | yes | Email of the Polis system account (created once on VPS) |
 | `POLIS_ADMIN_PASSWORD` | yes | Password of the Polis system account |
 | `POLIS_DATABASE_URL` | no | Direct Postgres connection for admin stats panel; leave blank to disable |
+| `RATELIMIT_STORAGE_URI` | yes (prod) | Distributed Flask-Limiter backend, for example `redis://<host>:6379/0` |
 | `DEV_LOGIN_USER` | dev only | Bypasses OAuth in local dev; never set in production |
 | `DEV_FAKE_LOGIN` | dev only | Set to `1` to show hardcoded test-user badges on the home page; never set in production |
 | `FLASK_DEBUG` | dev only | Enables debug mode; never set in production |

--- a/v2/guide_deployment.md
+++ b/v2/guide_deployment.md
@@ -320,6 +320,7 @@ Non-secret values can be passed as arguments:
 ```bash
 toolforge envvars create OAUTH_REDIRECT_URI 'https://wiki-polis.toolforge.org/oauth-callback'
 toolforge envvars create RATELIMIT_STORAGE_URI 'redis://<rate-limit-host>:6379/0'
+toolforge envvars create TRUSTED_HOSTS 'wiki-polis.toolforge.org'
 ```
 
 Values to enter at the prompts:
@@ -333,6 +334,7 @@ Values to enter at the prompts:
 - `POLIS_ADMIN_PASSWORD` — password of the Polis system account
 - `POLIS_DATABASE_URL` — `postgresql://wiki_polis_ro:<password>@<vps-private-ip>:5432/polis` — use the password set when creating the `wiki_polis_ro` role (see Security hardening step above); do not use the `polis` superuser here
 - `RATELIMIT_STORAGE_URI` — distributed Flask-Limiter storage, for example `redis://<rate-limit-host>:6379/0`; production startup fails if this is missing or set to a local backend
+- `TRUSTED_HOSTS` — comma-separated allowed request hostnames, for example `wiki-polis.toolforge.org`; add explicit staging hostnames on staging deployments
 
 > `toolforge envvars list` shows names only, not values. Keep a local record.
 
@@ -541,6 +543,7 @@ export SECRET_KEY=$(toolforge envvars show SECRET_KEY | tail -1 | awk '{print $N
 | `POLIS_ADMIN_PASSWORD` | yes | Password of the Polis system account |
 | `POLIS_DATABASE_URL` | no | Direct Postgres connection for admin stats panel; leave blank to disable |
 | `RATELIMIT_STORAGE_URI` | yes (prod) | Distributed Flask-Limiter backend, for example `redis://<host>:6379/0` |
+| `TRUSTED_HOSTS` | yes (prod) | Comma-separated allowed request hostnames, for example `wiki-polis.toolforge.org` |
 | `DEV_LOGIN_USER` | dev only | Bypasses OAuth in local dev; never set in production |
 | `DEV_FAKE_LOGIN` | dev only | Set to `1` to show hardcoded test-user badges on the home page; never set in production |
 | `FLASK_DEBUG` | dev only | Enables debug mode; never set in production |

--- a/v2/guide_local-dev.md
+++ b/v2/guide_local-dev.md
@@ -204,14 +204,9 @@ Three generic test accounts let you switch between user identities without going
 DEV_FAKE_LOGIN=1
 ```
 
-**Toolforge dev tool** — on the bastion:
-```bash
-toolforge envvars create DEV_FAKE_LOGIN 1
-```
+Restart Flask, then visit the home page. An amber badge strip appears below the login button with three accounts: `dev-user-1`, `dev-user-2`, `dev-user-3`. Clicking a badge logs you in immediately — the `Participant` record is created on first use. Use the accounts to simulate multiple participants interacting in the same consultation.
 
-Restart Flask (or the webservice), then visit the home page. An amber badge strip appears below the login button with three accounts: `dev-user-1`, `dev-user-2`, `dev-user-3`. Clicking a badge logs you in immediately — the `Participant` record is created on first use. Use the accounts to simulate multiple participants interacting in the same consultation.
-
-These accounts use negative `mw_user_id` values so they never collide with real Wikimedia accounts. Do not set `DEV_FAKE_LOGIN=1` in production.
+These accounts use negative `mw_user_id` values so they never collide with real Wikimedia accounts. The route only registers when Flask is running in local debug mode and not on Toolforge, even if `DEV_FAKE_LOGIN=1` is present.
 
 ## Stopping The Stack
 

--- a/v2/guide_runbook.md
+++ b/v2/guide_runbook.md
@@ -231,8 +231,8 @@ is expected.
 `toolforge envvars delete <NAME>` then `toolforge envvars create <NAME>` (use the
 interactive prompt; never pass a secret as a CLI argument). Restart the webservice
 afterward. Candidates to rotate on a schedule or on suspected compromise: `SECRET_KEY`,
-`OAUTH_CLIENT_SECRET`, `POLIS_ADMIN_PASSWORD`, and the `wiki_polis_ro` Postgres
-password. *(pending — rotation cadence)*
+`OAUTH_CLIENT_SECRET`, `RATELIMIT_IDENTITY_SECRET`, `POLIS_ADMIN_PASSWORD`, and the
+`wiki_polis_ro` Postgres password. *(pending — rotation cadence)*
 
 ## Responding to an outage
 

--- a/v2/guide_runbook.md
+++ b/v2/guide_runbook.md
@@ -209,13 +209,11 @@ flag (or `docker ps`, which always shows the truth — staging containers are
     docker-compose -p wiki-polis-staging logs --since 30m <service>
     # or export COMPOSE_PROJECT_NAME=wiki-polis-staging
 
-**Logging in to staging (headless or browser).** `DEV_FAKE_LOGIN=1` is set on the
-`wiki-polis-dev` tool, enabling `GET /dev/login/<username>` for three fixed identities —
-`dev-user-1`, `dev-user-2`, `dev-user-3` (distinct xids, negative user-ids that cannot
-collide with real accounts). This is how `synthetic_traffic.py` and headless tests
-authenticate. **This path is OFF on production** (`/dev/login/...` → 404 there) — never
-set `DEV_FAKE_LOGIN` on the `wiki-polis` tool. (The single-user `/dev-login` variant is
-local-only; it never registers on Toolforge.)
+**Logging in to staging (headless or browser).** Toolforge deployments do not register
+the fake-login routes, even on a dev tool. Browser checks should use Wikimedia OAuth.
+Headless checks such as `synthetic_traffic.py` must pass `--session-cookie` from an
+authenticated staging browser session. Both `/dev/login/<username>` and the single-user
+`/dev-login` variant are local-debug-only paths.
 
 **Deploying to staging.** `become wiki-polis-dev`, then
 `bash ~/wiki-polis/deploy.sh <branch>` (add `--migrate` only for schema changes). Confirm

--- a/v2/log_changelog.md
+++ b/v2/log_changelog.md
@@ -72,8 +72,8 @@ Security, code quality, and computational social science reviews conducted (2026
 - [x] `link_based` access policy removed from code and UI
 - [x] Opt-in identity reveal: `Participation.public_username` + `revealed_at` columns (migration applied)
 - [x] `Conversation.closed_at` set on permanent close; drives reveal timeline
-- [x] Reveal routes (`GET/POST /c/<slug>/reveal`) with cooldown gate, nullification gate, irreversible-warning form
-- [x] Lazy nullification in conversation view: clears identity links at `cooldown + window` days post-close
+- [x] Reveal routes (`GET/POST /c/<slug>/reveal`) with cooldown gate, opt-in window gate, irreversible-warning form
+- [x] Voluntary public reveals are permanent; app no longer nullifies `public_username` / `revealed_at` after the opt-in window
 - [x] Minimum-N warning on results (< 25 participants): shown above public results, does not hide results
 - [x] Consent copy on accept page updated to reflect platform-wide pseudonym uniqueness and operator data retention
 - [ ] **TODO: open GitHub issue** — audit consistency of pseudonymity / vote privacy messaging across all user-facing surfaces (accept page, conversation view, results page, reveal flow). Ensure the platform's promises (votes are private, pseudonym is per-platform, identity reveal is opt-in post-close) are communicated clearly and consistently everywhere a participant might wonder.

--- a/v2/plan_roadmap.md
+++ b/v2/plan_roadmap.md
@@ -44,7 +44,7 @@ retention commitment (decision D-PRIV), pending legal/comms review.
   not exercised. Fix the accept step so statement-submit gets soak coverage too.
 - **Testing strategy / CI** — decision pending (D-TEST); recommendation in
   `.claude/testing-strategy-recommendations.md`. Leaning toward a CI gate on PRs plus
-  coverage for the untested risky paths (proxy, reveal nullification, Polis-Postgres
+  coverage for the untested risky paths (proxy, reveal-window timing, Polis-Postgres
   SQL, statement-quota race).
 - **Pre-launch hardening review** (from the archived `plan.md`) — confirm whether these
   are still open and fix if so: `argument_unvote` cross-conversation join, restricting
@@ -73,11 +73,10 @@ retention commitment (decision D-PRIV), pending legal/comms review.
   selection screen ([#82](https://github.com/lgelauff/wiki-polis/issues/82)); show the
   reveal-window end date on closed conversations
   ([#70](https://github.com/lgelauff/wiki-polis/issues/70)).
-- **Identity reveal must be permanent (not nullified).** Per D-PRIV (clarified), a
-  voluntary reveal is permanent; only the *internal* account↔pseudonym link is removed
-  (≤180 days). The current code nullifies revealed links at the retention window —
-  change `_nullify_expired_reveals` to stop touching reveals. *(pending — reconcile
-  `spec_functional-design.md` to the model first)*
+- **Internal-link removal still needed.** Per D-PRIV (clarified), a voluntary reveal is
+  permanent and is no longer nullified by the app. The remaining work is a separate
+  data-minimisation mechanism that removes the *internal* account↔pseudonym link for
+  non-revealed participations by the 180-day commitment.
 - **xid is reversible — weak anonymisation.** `xid = sha256(mw_user_id)` and MW user IDs
   are sequential, so the xid can be brute-forced back to an account. Removing the
   internal link at the retention window does **not** anonymise the Polis vote data,

--- a/v2/pub_privacy.md
+++ b/v2/pub_privacy.md
@@ -69,9 +69,8 @@ you never choose this, no such public connection is ever made.
 
 > `pending` — confirm this model before publishing. As written, a voluntary reveal is
 > *permanent* and the 180-day limit applies only to the *internal* account↔pseudonym
-> link. This differs from both `spec_functional-design.md` and the current code, which
-> *nullify* revealed links at the retention window. The spec, decision D-PRIV's wording,
-> and the code must be reconciled to one model first.
+> link. The app no longer nullifies voluntary public reveals; a separate internal-link
+> removal workflow is still needed for the 180-day data-minimisation commitment.
 
 ## Your choices
 

--- a/v2/pyproject.toml
+++ b/v2/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "flask-session>=0.8",
     "flask-wtf>=1.2",           # CSRF protection
     "flask-limiter>=3.5",       # Rate limiting
+    "redis>=5.0",               # Distributed Flask-Limiter storage
 
     # Database
     "flask-migrate>=4.0",

--- a/v2/ref_data-model.md
+++ b/v2/ref_data-model.md
@@ -48,9 +48,8 @@ bool=F · `notify_talk_page` bool=F · `public_username` (nullable) · `revealed
 (nullable) · `new_stmt_ids` JSON=[].
 - **Constraints:** unique `(participant_id, conversation_id)`; unique `pseudonym`
   (platform-wide, never reused/deleted); check `pseudonym = LOWER(pseudonym)`.
-- `public_username` / `revealed_at` record the opt-in reveal. **⚠ `(pending — D-PRIV)`:**
-  the code currently nullifies them ~60 days after close; per the clarified D-PRIV
-  decision a reveal is **permanent** — this nullification must change.
+- `public_username` / `revealed_at` record the opt-in reveal. Per D-PRIV, a reveal is
+  **permanent** and is not nullified by the app.
 - `new_stmt_ids` = Polis statement IDs of new statements this participant submitted;
   quota used = `len(new_stmt_ids)`, slots consumed at submit time and never returned.
 
@@ -112,7 +111,9 @@ proposer_id)`, `argument_votes(argument_id, participant_id)`,
   (lowercase) but the column default and all readers use `{'K': 2}`. *(pending — fix the comment.)*
 - **`ArgumentVote.value` / ranking.** Documented for a ranking method that isn't built;
   only kApproval (row-presence) is implemented. *(pending — implement or remove.)*
-- **Reveal nullification vs D-PRIV.** See `participations` above. *(pending — D-PRIV.)*
+- **Internal-link removal after retention.** Voluntary reveals are permanent; a separate
+  workflow is still needed to remove internal account↔pseudonym links for non-revealed
+  participations by the retention commitment.
 
 > The proposal's `phase6_*` fields (from [`prop_phase-model.md`](prop_phase-model.md)) are
 > **not** in `db.py` — they exist only in the proposal.

--- a/v2/spec_functional-design.md
+++ b/v2/spec_functional-design.md
@@ -257,7 +257,7 @@ Cross-conversation tracking via pseudonym is structurally impossible — each co
 Two separate things run after a conversation closes: a participant's *voluntary, permanent* reveal, and the *removal* of the internal account↔pseudonym link the platform holds.
 
 - **Cooldown** (`REVEAL_COOLDOWN_DAYS`, currently 30) — days after close before the reveal window opens. Gives time for any post-close review before participants attach their name.
-- **Internal-link retention** — the internal account↔pseudonym link is removed by at most **180 days** after close (the public commitment; the internal target is sooner). Removal applies to participants who did **not** reveal; once it happens, no further reveals are possible.
+- **Internal-link retention** — the internal account↔pseudonym link is removed by at most **180 days** after close (the public commitment; the internal target is sooner). Removal applies to participants who did **not** reveal; once it happens, no further reveals are possible. This internal-link removal is a separate data-minimisation workflow and is not the same as removing a voluntary public reveal.
 
 | Day (current defaults) | Event |
 |---|---|
@@ -268,7 +268,7 @@ Two separate things run after a conversation closes: a participant's *voluntary,
 
 A reveal is **permanent**: once a username is attached to a pseudonym it stays, and is never nullified. Removal at the retention deadline affects only the *internal* link of participants who did not reveal; the pseudonym itself remains (for export compatibility), but its connection to a Wikimedia account is dropped.
 
-*(pending — the current code nullifies revealed links at the retention window via `_nullify_expired_reveals`; that must change to match this model. See decision D-PRIV.)*
+The app no longer nullifies `public_username` / `revealed_at` after the reveal window. A separate internal-link removal workflow is still needed to implement the 180-day data-minimisation commitment for participants who did not reveal.
 
 **Privacy policy commitment:** the public guarantee for removing the internal link is **180 days** after close; the internal target is sooner. Voluntary reveals are permanent and sit outside this clock.
 

--- a/v2/synthetic_traffic.py
+++ b/v2/synthetic_traffic.py
@@ -36,8 +36,8 @@ Health invariants (any violation = recorded failure, non-zero exit)
 
 Prerequisites
 -------------
-  * The target must have DEV_FAKE_LOGIN=1 (local: in .env; staging: a Toolforge
-    envvar on the wiki-polis-dev tool). NEVER enable DEV_FAKE_LOGIN on production.
+  * Local targets may use DEV_FAKE_LOGIN=1 from v2/.env. Toolforge targets never
+    register fake-login routes; pass --session-cookie from an authenticated browser.
   * A votable conversation slug (default "test" — free to mutate on staging).
   * The vote/results actions need only login, so they soak the proxy on any deployed
     instance. Auto-discovery (slug→id) and the `submit` action additionally need a
@@ -50,10 +50,10 @@ Usage
   # Local smoke (one of each action, then stop)
   python synthetic_traffic.py --dry-run
 
-  # Staging soak: 3 identities, 10 minutes, ~2 req/s each
+  # Staging soak: authenticated browser session, 10 minutes, ~2 req/s
   python synthetic_traffic.py \
       --base-url https://wiki-polis-dev.toolforge.org \
-      --slug test --workers 3 --duration 600 --rate 2
+      --slug test --session-cookie '<cookie>' --duration 600 --rate 2
 
   # Bypass slug→id discovery (e.g. invite-only conv) by passing the Polis id
   python synthetic_traffic.py --conversation-id 9r7fkvxyjb ...
@@ -61,9 +61,9 @@ Usage
 Exit codes: 0 = clean; 1 = ran but a health invariant was violated; 2 = could not
 authenticate (dev fake-login disabled / no valid --session-cookie) so nothing was sent.
 
-If the dev fake-login path is ever disabled for security (DEV_FAKE_LOGIN turned off, or
-the route removed), the tool detects that in a preflight probe and exits 2 with
-instructions to restore access — rather than firing traffic that all bounces to /login.
+If the dev fake-login path is unavailable and no --session-cookie was supplied, the tool
+detects that in a preflight probe and exits 2 rather than firing traffic that all
+bounces to /login.
 """
 import argparse
 import os
@@ -381,9 +381,8 @@ def main(argv=None):
             f"  The login path needed to drive {args.base_url} is not available. This is\n"
             f"  expected if dev fake-login was disabled for security. To run the soak,\n"
             f"  restore access one of these ways:\n"
-            f"    • non-production target: enable fake-login — DEV_FAKE_LOGIN=1 (local .env,\n"
-            f"      or `toolforge envvars create DEV_FAKE_LOGIN 1` on wiki-polis-dev). Never on prod.\n"
-            f"    • any target: pass --session-cookie \"<cookie from an authenticated browser>\".\n",
+            f"    • local target: enable fake-login with DEV_FAKE_LOGIN=1 in v2/.env.\n"
+            f"    • Toolforge or any target: pass --session-cookie \"<cookie from an authenticated browser>\".\n",
             file=sys.stderr)
         return 2
 

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -258,6 +258,8 @@
     </form>
   </div>
 
+  {% endif %}{# is_admin #}
+
   <!-- ── Moderators ─────────────────────────────────────── -->
   <h3 class="section-heading">Moderators</h3>
 
@@ -276,6 +278,7 @@
         <td>{{ role.participant.mw_username }}</td>
         <td>{{ role.role }}</td>
         <td>
+          {% if can_manage_roles %}
           <form method="post"
                 action="{{ url_for('admin.admin_role_remove', role_id=role.id) }}"
                 style="display:inline">
@@ -284,6 +287,7 @@
                    value="{{ url_for('admin.admin_conversation_detail', conv_id=conversation.id) }}">
             <button type="submit" class="btn-small btn-danger">remove</button>
           </form>
+          {% endif %}
         </td>
       </tr>
       {% endfor %}
@@ -293,6 +297,7 @@
   <p class="muted" style="margin-bottom:1rem;font-size:14px">No moderators assigned.</p>
   {% endif %}
 
+  {% if can_manage_roles %}
   <div class="edit-form">
     <h3>Add moderator</h3>
     <form method="post" action="{{ url_for('admin.admin_role_add') }}">
@@ -320,8 +325,7 @@
       <button type="submit">Add</button>
     </form>
   </div>
-
-  {% endif %}{# is_admin #}
+  {% endif %}
 
 </div>
 

--- a/v2/templates/base.html
+++ b/v2/templates/base.html
@@ -68,10 +68,16 @@
       var el = document.createElement('div');
       el.className = 'toast toast--' + category;
       el.setAttribute('role', 'alert');
-      el.innerHTML =
-        '<span class="toast__msg">' + message + '</span>' +
-        '<button class="toast__close" aria-label="Dismiss">&times;</button>';
-      el.querySelector('.toast__close').addEventListener('click', function () { dismiss(el); });
+      var msg = document.createElement('span');
+      msg.className = 'toast__msg';
+      msg.textContent = message;
+      var close = document.createElement('button');
+      close.className = 'toast__close';
+      close.setAttribute('aria-label', 'Dismiss');
+      close.textContent = '\u00d7';
+      el.appendChild(msg);
+      el.appendChild(close);
+      close.addEventListener('click', function () { dismiss(el); });
       container.appendChild(el);
       console.error('[wiki-polis] ' + category + ': ' + message);
       var t = setTimeout(function () { dismiss(el); }, DURATIONS[category] || 6000);

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -1235,9 +1235,14 @@
     var text = newstmtInput.value.trim();
     if (!text) return;
     newstmtSubmit.disabled = true;
+    var csrfToken = '{{ csrf_token() }}';
     fetch('{{ url_for("proxy.conversation_statement_new", slug=conversation.slug) }}', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'fetch' },
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'fetch',
+        'X-CSRFToken': csrfToken
+      },
       body: JSON.stringify({ text: text }),
     }).then(function (resp) {
       if (resp.ok) {

--- a/v2/templates/reveal.html
+++ b/v2/templates/reveal.html
@@ -39,8 +39,7 @@
     </div>
   </div>
   <p class="muted" style="margin-top:14px">
-    This link is permanent. It will be retained for up to 60–180 days after this consultation
-    closed, then removed by the platform.
+    This public link is permanent and is not removed by the platform.
   </p>
 
   {% elif window_closed %}
@@ -105,12 +104,8 @@
       </li>
       <li>You cannot undo this or re-anonymise your participation.</li>
       <li>
-        The link will be retained for up to 60–180 days after this consultation closed,
-        then removed by the platform.
-      </li>
-      <li>
-        Admins retain visibility of identity links for the duration of the retention
-        period to investigate potential process violations.
+        Separate internal identity links may be retained for moderation and process
+        review according to the platform retention policy.
       </li>
     </ul>
   </div>

--- a/v2/tests/conftest.py
+++ b/v2/tests/conftest.py
@@ -84,7 +84,8 @@ def conversation(app):
 # ── Session helpers ───────────────────────────────────────────────────────────
 
 def login(client, username: str, emailable: bool = True) -> None:
-    xid = hashlib.sha256(username.encode()).hexdigest()
+    participant = Participant.query.filter_by(mw_username=username).first()
+    xid = participant.xid if participant else hashlib.sha256(username.encode()).hexdigest()
     with client.session_transaction() as sess:
         sess['username'] = username
         sess['xid'] = xid

--- a/v2/tests/conftest.py
+++ b/v2/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from cachelib.file import FileSystemCache
 
 from app import create_app
-from db import Conversation, Participant, Participation, db
+from db import Conversation, Participant, db
 
 
 @pytest.fixture
@@ -20,7 +20,16 @@ def app(tmp_path):
     session_dir = tmp_path / 'sessions'
     session_dir.mkdir()
 
-    env_overrides = {'FLASK_DEBUG': '0', 'DEV_LOGIN_USER': ''}
+    env_overrides = {
+        'FLASK_DEBUG': '0',
+        'DEV_LOGIN_USER': '',
+        'RATELIMIT_STORAGE_URI': '',
+        'RATELIMIT_KEY_PREFIX': '',
+        'RATELIMIT_IDENTITY_SECRET': '',
+        'TRUST_PROXY_HEADERS': '',
+        'TOOL_TOOLFORGE_API_URL': '',
+        'TOOL_REDIS_URI': '',
+    }
     with patch.dict(os.environ, env_overrides, clear=False):
         a = create_app({
             'TESTING': True,

--- a/v2/tests/test_admin.py
+++ b/v2/tests/test_admin.py
@@ -3,8 +3,9 @@ from unittest.mock import patch
 
 import pytest
 
-from db import AdminRole, Conversation, ConversationInvite, db
+from db import AdminRole, Conversation, ConversationInvite, Participant, db
 from polis_admin import PolisServerError
+from tests.conftest import login
 
 
 @pytest.fixture
@@ -183,6 +184,23 @@ def test_remove_role(admin_client, admin_participant, conv, participant):
     resp = admin_client.post(f'/admin/roles/{role.id}/remove')
     assert resp.status_code == 302
     assert db.session.get(AdminRole, role.id) is None
+
+
+def test_scoped_moderator_cannot_see_global_role_controls(client, conv, participant):
+    other = Participant(mw_user_id=33333, mw_username='otheruser', xid='t' * 64)
+    db.session.add(other)
+    db.session.add(AdminRole(participant_id=participant.id,
+                             conversation_id=conv.id, role='moderator'))
+    db.session.commit()
+    login(client, 'testuser')
+
+    resp = client.get(f'/admin/conversations/{conv.id}')
+
+    assert resp.status_code == 200
+    assert b'testuser' in resp.data
+    assert b'otheruser' not in resp.data
+    assert b'Add moderator' not in resp.data
+    assert b'class="btn-small btn-danger">remove</button>' not in resp.data
 
 
 # ── Invites ───────────────────────────────────────────────────────────────────

--- a/v2/tests/test_admin.py
+++ b/v2/tests/test_admin.py
@@ -33,7 +33,12 @@ def test_admin_index_accessible_to_global_admin(admin_client):
 
 # ── Conversation CRUD ─────────────────────────────────────────────────────────
 
-def test_create_conversation(admin_client):
+def test_create_conversation(app, admin_client):
+    app.config.update({
+        'POLIS_SERVER_URL': 'http://polis.test',
+        'POLIS_ADMIN_EMAIL': 'admin@example.org',
+        'POLIS_ADMIN_PASSWORD': 'test-password',
+    })
     with patch('app.PolisServerClient.create_conversation',
                return_value='newpolis12'):
         resp = admin_client.post('/admin/conversations/new', data={
@@ -59,8 +64,13 @@ def test_create_conversation_invalid_slug_rejected(admin_client):
     assert resp.status_code == 400
 
 
-def test_create_conversation_polis_failure_redirects(admin_client):
+def test_create_conversation_polis_failure_redirects(app, admin_client):
     """Polis server error on creation → redirect to admin with flash, no conv written."""
+    app.config.update({
+        'POLIS_SERVER_URL': 'http://polis.test',
+        'POLIS_ADMIN_EMAIL': 'admin@example.org',
+        'POLIS_ADMIN_PASSWORD': 'test-password',
+    })
     with patch('app.PolisServerClient.create_conversation',
                side_effect=PolisServerError('test error')):
         resp = admin_client.post('/admin/conversations/new', data={

--- a/v2/tests/test_auth.py
+++ b/v2/tests/test_auth.py
@@ -5,8 +5,6 @@ from flask import session
 
 from db import Participant, db
 
-from tests.conftest import login
-
 
 def test_login_without_oauth_returns_503(client):
     resp = client.get('/login')

--- a/v2/tests/test_auth.py
+++ b/v2/tests/test_auth.py
@@ -1,7 +1,9 @@
 """Tests for login, OAuth callback, and logout flows."""
 from unittest.mock import MagicMock, patch
 
-from db import Participant
+from flask import session
+
+from db import Participant, db
 
 from tests.conftest import login
 
@@ -88,6 +90,30 @@ def test_oauth_callback_updates_username_if_changed(client, app, participant):
     from db import db
     db.session.refresh(participant)
     assert participant.mw_username == 'RenamedUser'
+
+
+def test_current_participant_resolves_stale_username_by_xid(app, participant):
+    """A renamed user keeps the same stable xid, so old session username is ignored."""
+    from app import _current_participant
+
+    old_username = participant.mw_username
+    participant.mw_username = 'RenamedUser'
+    db.session.commit()
+
+    with app.test_request_context('/'):
+        session['username'] = old_username
+        session['xid'] = participant.xid
+        assert _current_participant().id == participant.id
+
+
+def test_current_participant_rejects_invalid_xid_even_if_username_matches(app, participant):
+    """Once a session has xid, username is not accepted as a fallback identity key."""
+    from app import _current_participant
+
+    with app.test_request_context('/'):
+        session['username'] = participant.mw_username
+        session['xid'] = 'not-the-participant-xid'
+        assert _current_participant() is None
 
 
 def test_logout_clears_session(auth_client):

--- a/v2/tests/test_dev_login.py
+++ b/v2/tests/test_dev_login.py
@@ -1,9 +1,10 @@
-"""Tests for the DEV_FAKE_LOGIN staging login (`/dev/login/<username>`).
+"""Tests for the DEV_FAKE_LOGIN local-debug login (`/dev/login/<username>`).
 
 Regression for the bug where a reused dev Participant (matched by mw_user_id) kept a
-stale mw_username, so `_current_participant()` — which looks up by mw_username — returned
-None and participant-gated routes (/accept, /reveal) 404'd for dev users.
+stale mw_username/xid, so the authenticated local-debug session no longer matched the
+participant row used by participant-gated routes (/accept, /reveal).
 """
+import hashlib
 import os
 from unittest.mock import patch
 
@@ -16,10 +17,15 @@ from db import Participant, db
 
 @pytest.fixture
 def fake_login_app(tmp_path):
-    """App with DEV_FAKE_LOGIN=1 so `/dev/login/<username>` is registered."""
+    """Local-debug app with DEV_FAKE_LOGIN=1 so `/dev/login/<username>` is registered."""
     session_dir = tmp_path / 'sessions'
     session_dir.mkdir()
-    env = {'FLASK_DEBUG': '0', 'DEV_LOGIN_USER': '', 'DEV_FAKE_LOGIN': '1'}
+    env = {
+        'FLASK_DEBUG': '1',
+        'DEV_LOGIN_USER': '',
+        'DEV_FAKE_LOGIN': '1',
+        'TOOL_TOOLFORGE_API_URL': '',
+    }
     with patch.dict(os.environ, env, clear=False):
         a = create_app({
             'TESTING': True,
@@ -39,18 +45,18 @@ def fake_login_app(tmp_path):
 
 
 def test_dev_fake_login_creates_participant(fake_login_app):
-    """First login creates the dev Participant with matching mw_username."""
+    """First login creates the dev Participant with matching username and xid."""
     r = fake_login_app.test_client().get('/dev/login/dev-user-1')
     assert r.status_code == 302
     with fake_login_app.app_context():
         p = Participant.query.filter_by(mw_user_id=-1).first()
         assert p is not None
         assert p.mw_username == 'dev-user-1'
+        assert p.xid == hashlib.sha256(b'dev-fake-dev-user-1').hexdigest()
 
 
 def test_dev_fake_login_syncs_drifted_username(fake_login_app):
-    """A reused dev row whose mw_username drifted is corrected on login, so
-    _current_participant() (lookup by mw_username) resolves again."""
+    """A reused dev row whose username/xid drifted is corrected on login."""
     with fake_login_app.app_context():
         db.session.add(Participant(mw_user_id=-2, mw_username='stale-name', xid='x' * 64))
         db.session.commit()
@@ -63,7 +69,8 @@ def test_dev_fake_login_syncs_drifted_username(fake_login_app):
         rows = Participant.query.filter_by(mw_user_id=-2).all()
         assert len(rows) == 1
         assert rows[0].mw_username == 'dev-user-2'
-        # mw_username now matches what _current_participant() looks up by → no more 404.
+        assert rows[0].xid == hashlib.sha256(b'dev-fake-dev-user-2').hexdigest()
+        # The row now matches both legacy username checks and stable xid session lookup.
         assert Participant.query.filter_by(mw_username='dev-user-2').first() is not None
 
 

--- a/v2/tests/test_helpers_argument.py
+++ b/v2/tests/test_helpers_argument.py
@@ -189,6 +189,7 @@ def test_require_arg_participation_gate_branches(app, participant, conv, part):
     # Active + in the argument phase + participating → returns the pair.
     with app.test_request_context():
         session['username'] = participant.mw_username
+        session['xid'] = participant.xid
         got_conv, got_part = _require_arg_participation(conv.slug)
         assert got_conv.id == conv.id
         assert got_part.participant_id == participant.id
@@ -198,6 +199,7 @@ def test_require_arg_participation_gate_branches(app, participant, conv, part):
     db.session.commit()
     with app.test_request_context():
         session['username'] = participant.mw_username
+        session['xid'] = participant.xid
         with pytest.raises(Forbidden):
             _require_arg_participation(conv.slug)
 
@@ -207,6 +209,7 @@ def test_require_arg_participation_gate_branches(app, participant, conv, part):
     db.session.commit()
     with app.test_request_context():
         session['username'] = participant.mw_username
+        session['xid'] = participant.xid
         with pytest.raises(Forbidden):
             _require_arg_participation(conv.slug)
 

--- a/v2/tests/test_proxy_blueprint.py
+++ b/v2/tests/test_proxy_blueprint.py
@@ -3,22 +3,23 @@
 These cover the security-critical behaviours the main suite does NOT exercise. The
 shared `app` fixture runs with `WTF_CSRF_ENABLED=False`, so it cannot catch a broken
 `csrf.exempt(proxy_bp)` — yet CSRF exemption (with same-origin as the compensating
-control) is the whole security posture of these two routes. The extraction onto a
-blueprint must keep all of this byte-identical to the prior inline routes:
+control) is the core proxy security posture. These tests lock the expected boundary:
 
-- CSRF exemption is active on the blueprint;
-- the same-origin check still gates state-changing requests;
+- CSRF exemption is active on the blueprint, with manual CSRF on the
+  first-party statement-submit route;
+- the same-origin check still gates state-changing requests and fails closed
+  when browser provenance headers are missing;
 - the pa_session <-> session cookie rename is preserved in both directions;
 - the 403->200 rewrite on /results/ that keeps the web component usable.
 """
-import tempfile
+import re
 from unittest.mock import MagicMock, patch
 
 import pytest
 from cachelib.file import FileSystemCache
 
 from app import create_app
-from db import Conversation, Participation, db
+from db import Conversation, Participant, Participation, db
 
 
 def _fake_upstream(status_code=200, content=b'{}', cookies=None,
@@ -35,7 +36,7 @@ def _fake_upstream(status_code=200, content=b'{}', cookies=None,
 # ── CSRF exemption — needs a CSRF-ENABLED app (the shared fixture disables it) ────
 
 @pytest.fixture
-def csrf_client(tmp_path):
+def csrf_enabled_app(tmp_path):
     session_dir = tmp_path / 'sessions'
     session_dir.mkdir()
     app = create_app({
@@ -49,8 +50,13 @@ def csrf_client(tmp_path):
     })
     with app.app_context():
         db.create_all()
-        yield app.test_client()
+        yield app
         db.session.remove()
+
+
+@pytest.fixture
+def csrf_client(csrf_enabled_app):
+    return csrf_enabled_app.test_client()
 
 
 @pytest.mark.parametrize('path', ['/proxy/particiapi/api/foo',
@@ -113,6 +119,11 @@ def test_proxy_post_blocks_cross_origin(auth_client):
     assert resp.status_code == 403
 
 
+def test_proxy_post_blocks_missing_provenance_headers(auth_client):
+    resp = auth_client.post('/proxy/particiapi/api/foo', json={})
+    assert resp.status_code == 403
+
+
 def test_proxy_post_allows_same_origin(auth_client):
     up = _fake_upstream()
     with patch('app.requests.request', return_value=up):
@@ -166,6 +177,11 @@ def test_statement_new_blocks_cross_origin(auth_client):
     assert resp.status_code == 403
 
 
+def test_statement_new_blocks_missing_provenance_headers(auth_client):
+    resp = auth_client.post('/c/any/statements/new', json={'text': 'hi'})
+    assert resp.status_code == 403
+
+
 def test_statement_new_happy_path_records_polis_id(auth_client, participant):
     conv = Conversation(slug='sub', polis_id='subxxxxxxx', title='Sub', active=True,
                         access_policy='public', phase_submission=True,
@@ -192,3 +208,65 @@ def test_statement_new_happy_path_records_polis_id(auth_client, participant):
     assert 555 in (part.new_stmt_ids or [])  # Polis id recorded for novelty tracking
     assert any(c.startswith('pa_session=NEWPA')
                for c in resp.headers.getlist('Set-Cookie'))
+
+
+def test_statement_new_requires_manual_csrf_when_csrf_enabled(csrf_enabled_app):
+    client = csrf_enabled_app.test_client()
+    p = Participant(mw_user_id=10101, mw_username='csrfuser', xid='c' * 64)
+    conv = Conversation(slug='csrf-sub', polis_id='csrfxxxxxx', title='CSRF',
+                        active=True, access_policy='public', phase_submission=True)
+    db.session.add_all([p, conv])
+    db.session.commit()
+    db.session.add(Participation(participant_id=p.id,
+                                 conversation_id=conv.id,
+                                 pseudonym='csrf-user'))
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess['username'] = p.mw_username
+        sess['xid'] = p.xid
+
+    with patch('app.requests.post') as post:
+        resp = client.post('/c/csrf-sub/statements/new',
+                           headers={'Sec-Fetch-Site': 'same-origin'},
+                           json={'text': 'Needs a token'})
+
+    assert resp.status_code == 400
+    post.assert_not_called()
+
+
+def test_statement_new_accepts_valid_manual_csrf_when_csrf_enabled(csrf_enabled_app):
+    client = csrf_enabled_app.test_client()
+    p = Participant(mw_user_id=20202, mw_username='csrfok', xid='d' * 64)
+    conv = Conversation(slug='csrf-ok', polis_id='csrfokxxxx', title='CSRF OK',
+                        active=True, access_policy='public', phase_submission=True,
+                        argument_vote_data={'new_stmt_max': 3})
+    db.session.add_all([p, conv])
+    db.session.commit()
+    db.session.add(Participation(participant_id=p.id,
+                                 conversation_id=conv.id,
+                                 pseudonym='csrf-ok'))
+    db.session.commit()
+    with client.session_transaction() as sess:
+        sess['username'] = p.mw_username
+        sess['xid'] = p.xid
+
+    page = client.get('/c/csrf-ok')
+    token_match = re.search(rb"var csrfToken = '([^']+)'", page.data)
+    assert token_match is not None
+    csrf_token = token_match.group(1).decode()
+
+    sess_resp = _fake_upstream(cookies={'session': 'NEWPA'})
+    sess_resp.ok = True
+    sess_resp.json = lambda: {'csrf_token': 'TOK'}
+    stmt_resp = _fake_upstream(status_code=201, content=b'{"id":556}')
+    stmt_resp.json = lambda: {'id': 556}
+
+    with patch('app.requests.post', side_effect=[sess_resp, stmt_resp]):
+        resp = client.post('/c/csrf-ok/statements/new',
+                           headers={
+                               'Sec-Fetch-Site': 'same-origin',
+                               'X-CSRFToken': csrf_token,
+                           },
+                           json={'text': 'A token-backed idea'})
+
+    assert resp.status_code == 201

--- a/v2/tests/test_reveal.py
+++ b/v2/tests/test_reveal.py
@@ -133,12 +133,10 @@ def test_reveal_post_already_revealed_rejected(auth_client, app, participant):
     assert resp.status_code == 400
 
 
-# ── Nullification ─────────────────────────────────────────────────────────────
+# ── Reveal permanence ─────────────────────────────────────────────────────────
 
-def test_nullify_expired_reveals_clears_public_username(app):
-    """_nullify_expired_reveals removes identity data past the 60-day deadline."""
-    from app import _nullify_expired_reveals
-
+def test_revealed_identity_remains_after_window(auth_client, app):
+    """Voluntary public reveals remain visible after the opt-in window closes."""
     conv = _closed_conv(app, 'old-conv', 65, 'old1234567')
     p = Participant(mw_user_id=77777, mw_username='revealeduser', xid='r' * 64)
     db.session.add(p)
@@ -150,18 +148,21 @@ def test_nullify_expired_reveals_clears_public_username(app):
     )
     db.session.add(part)
     db.session.commit()
+    with auth_client.session_transaction() as sess:
+        sess['username'] = p.mw_username
+        sess['xid'] = p.xid
 
-    _nullify_expired_reveals(conv)
+    resp = auth_client.get('/c/old-conv')
     db.session.refresh(part)
-    assert part.public_username is None
-    assert part.revealed_at is None
+    assert resp.status_code == 200
+    assert b'linked your identity' in resp.data.lower()
+    assert part.public_username == 'revealeduser'
+    assert part.revealed_at is not None
 
 
-def test_nullify_does_not_clear_before_deadline(app):
-    """_nullify_expired_reveals is a no-op when the deadline hasn't passed."""
-    from app import _nullify_expired_reveals
-
-    conv = _closed_conv(app, 'recent-conv', 45, 'rec1234567')
+def test_reveal_page_keeps_existing_reveal_after_window(auth_client, app):
+    """The reveal detail page still shows an already-public reveal after day 60."""
+    conv = _closed_conv(app, 'recent-conv', 65, 'rec1234567')
     p = Participant(mw_user_id=66666, mw_username='recentuser', xid='s' * 64)
     db.session.add(p)
     db.session.commit()
@@ -172,7 +173,12 @@ def test_nullify_does_not_clear_before_deadline(app):
     )
     db.session.add(part)
     db.session.commit()
+    with auth_client.session_transaction() as sess:
+        sess['username'] = p.mw_username
+        sess['xid'] = p.xid
 
-    _nullify_expired_reveals(conv)
+    resp = auth_client.get('/c/recent-conv/reveal')
     db.session.refresh(part)
+    assert resp.status_code == 200
+    assert b'identity linked' in resp.data.lower()
     assert part.public_username == 'recentuser'

--- a/v2/tests/test_reveal.py
+++ b/v2/tests/test_reveal.py
@@ -1,8 +1,6 @@
 """Tests for the identity reveal window: state transitions and POST validation."""
 from datetime import datetime, timedelta, timezone
 
-import pytest
-
 from db import Conversation, Participant, Participation, db
 
 

--- a/v2/tests/test_security.py
+++ b/v2/tests/test_security.py
@@ -1,4 +1,6 @@
 """Tests for security headers, redirect safety, and dev DB isolation."""
+import hashlib
+import hmac
 import os
 from pathlib import Path
 from unittest.mock import patch
@@ -177,7 +179,11 @@ def test_fake_login_ignored_when_not_debug(tmp_path):
 
 def test_production_requires_ratelimit_storage_uri(tmp_path):
     """Production must not silently fall back to per-worker limiter storage."""
-    with patch.dict(os.environ, {'FLASK_DEBUG': '0', 'RATELIMIT_STORAGE_URI': ''}, clear=False):
+    with patch.dict(os.environ, {
+        'FLASK_DEBUG': '0',
+        'RATELIMIT_STORAGE_URI': '',
+        'TOOL_REDIS_URI': '',
+    }, clear=False):
         from app import create_app
         with pytest.raises(RuntimeError, match='RATELIMIT_STORAGE_URI is not set'):
             create_app({
@@ -189,10 +195,10 @@ def test_production_requires_ratelimit_storage_uri(tmp_path):
 
 
 def test_production_rejects_local_ratelimit_storage_uri(tmp_path):
-    """Production limiter storage must be distributed, not a local memory backend."""
+    """Production limiter storage must use Redis, not a local memory backend."""
     with patch.dict(os.environ, {'FLASK_DEBUG': '0'}, clear=False):
         from app import create_app
-        with pytest.raises(RuntimeError, match='distributed backend'):
+        with pytest.raises(RuntimeError, match='Redis backend'):
             create_app({
                 'TESTING': False,
                 'SQLALCHEMY_DATABASE_URI': f'sqlite:///{tmp_path}/prod-local-rate.db',
@@ -202,11 +208,118 @@ def test_production_rejects_local_ratelimit_storage_uri(tmp_path):
             })
 
 
+def test_production_uses_toolforge_redis_uri(tmp_path):
+    """Toolforge's global Redis URI is the production default."""
+    session_dir = tmp_path / 'sessions-toolforge-redis'
+    session_dir.mkdir()
+    toolforge_redis = 'redis://redis.svc.tools.eqiad1.wikimedia.cloud:6379'
+    with patch.dict(os.environ, {
+        'FLASK_DEBUG': '0',
+        'RATELIMIT_STORAGE_URI': '',
+        'TOOL_TOOLFORGE_API_URL': 'https://api.svc.tools.eqiad1.wikimedia.cloud',
+        'TOOL_REDIS_URI': toolforge_redis,
+    }, clear=False):
+        from app import create_app
+        a = create_app({
+            'TESTING': False,
+            'SQLALCHEMY_DATABASE_URI': f'sqlite:///{tmp_path}/prod-toolforge-redis.db',
+            'SECRET_KEY': 'test-secret',
+            'RATELIMIT_KEY_PREFIX': 'wiki-polis-test:prefix:',
+            'RATELIMIT_IDENTITY_SECRET': 'x' * 32,
+            'TRUSTED_HOSTS': ['wiki-polis.test'],
+            'SESSION_TYPE': 'cachelib',
+            'SESSION_CACHELIB': FileSystemCache(str(session_dir)),
+        })
+    assert a.config['RATELIMIT_STORAGE_URI'] == toolforge_redis
+    assert a.config['TRUST_PROXY_HEADERS'] is True
+
+
+def test_production_requires_ratelimit_key_prefix(tmp_path):
+    """Shared Toolforge Redis keys must be namespaced per deployment."""
+    with patch.dict(os.environ, {
+        'FLASK_DEBUG': '0',
+        'RATELIMIT_KEY_PREFIX': '',
+        'RATELIMIT_IDENTITY_SECRET': 'x' * 32,
+    }, clear=False):
+        from app import create_app
+        with pytest.raises(RuntimeError, match='RATELIMIT_KEY_PREFIX is not set'):
+            create_app({
+                'TESTING': False,
+                'SQLALCHEMY_DATABASE_URI': f'sqlite:///{tmp_path}/prod-missing-prefix.db',
+                'SECRET_KEY': 'test-secret',
+                'RATELIMIT_STORAGE_URI': 'redis://localhost:6379/0',
+                'TRUSTED_HOSTS': ['wiki-polis.test'],
+            })
+
+
+def test_production_requires_ratelimit_identity_secret(tmp_path):
+    """Production limiter keys must not expose raw client identity values."""
+    with patch.dict(os.environ, {
+        'FLASK_DEBUG': '0',
+        'RATELIMIT_IDENTITY_SECRET': '',
+    }, clear=False):
+        from app import create_app
+        with pytest.raises(RuntimeError, match='RATELIMIT_IDENTITY_SECRET is not set'):
+            create_app({
+                'TESTING': False,
+                'SQLALCHEMY_DATABASE_URI': f'sqlite:///{tmp_path}/prod-missing-identity.db',
+                'SECRET_KEY': 'test-secret',
+                'RATELIMIT_STORAGE_URI': 'redis://localhost:6379/0',
+                'RATELIMIT_KEY_PREFIX': 'wiki-polis-test:prefix:',
+                'TRUSTED_HOSTS': ['wiki-polis.test'],
+            })
+
+
+def test_ratelimit_identity_key_hashes_forwarded_client_identity(app):
+    """The limiter stores HMAC output, not the raw forwarded client address."""
+    from app import _ratelimit_identity_key
+    secret = 'x' * 32
+    app.config['RATELIMIT_IDENTITY_SECRET'] = secret
+    app.config['TRUST_PROXY_HEADERS'] = True
+    with app.test_request_context('/', headers={
+        'X-Forwarded-For': '203.0.113.10, 10.0.0.1',
+    }):
+        expected = 'ip:' + hmac.new(
+            secret.encode('utf-8'),
+            b'203.0.113.10',
+            hashlib.sha256,
+        ).hexdigest()
+        actual = _ratelimit_identity_key()
+
+    assert actual == expected
+    assert '203.0.113.10' not in actual
+
+
+def test_ratelimit_identity_key_ignores_untrusted_forwarded_client(app):
+    """Direct VPS requests cannot spoof rate-limit identity through X-Forwarded-For."""
+    from app import _ratelimit_identity_key
+    secret = 'x' * 32
+    app.config['RATELIMIT_IDENTITY_SECRET'] = secret
+    app.config['TRUST_PROXY_HEADERS'] = False
+    with app.test_request_context('/', headers={
+        'X-Forwarded-For': '203.0.113.10',
+    }, environ_base={'REMOTE_ADDR': '198.51.100.20'}):
+        expected = 'ip:' + hmac.new(
+            secret.encode('utf-8'),
+            b'198.51.100.20',
+            hashlib.sha256,
+        ).hexdigest()
+        actual = _ratelimit_identity_key()
+
+    assert actual == expected
+    assert '203.0.113.10' not in actual
+    assert '198.51.100.20' not in actual
+
+
 def test_test_config_may_disable_distributed_ratelimit_storage(tmp_path):
     """Tests keep the lightweight in-memory limiter unless they opt into storage."""
     session_dir = tmp_path / 'sessions-rate-test'
     session_dir.mkdir()
-    with patch.dict(os.environ, {'FLASK_DEBUG': '0', 'RATELIMIT_STORAGE_URI': ''}, clear=False):
+    with patch.dict(os.environ, {
+        'FLASK_DEBUG': '0',
+        'RATELIMIT_STORAGE_URI': '',
+        'TOOL_REDIS_URI': '',
+    }, clear=False):
         from app import create_app
         a = create_app({
             'TESTING': True,

--- a/v2/tests/test_security.py
+++ b/v2/tests/test_security.py
@@ -132,6 +132,47 @@ def test_fake_login_ignored_when_not_debug(tmp_path):
     assert a.test_client().get('/dev/login/dev-user-1').status_code == 404
 
 
+def test_production_requires_ratelimit_storage_uri(tmp_path):
+    """Production must not silently fall back to per-worker limiter storage."""
+    with patch.dict(os.environ, {'FLASK_DEBUG': '0', 'RATELIMIT_STORAGE_URI': ''}, clear=False):
+        from app import create_app
+        with pytest.raises(RuntimeError, match='RATELIMIT_STORAGE_URI is not set'):
+            create_app({
+                'TESTING': False,
+                'SQLALCHEMY_DATABASE_URI': f'sqlite:///{tmp_path}/prod-missing-rate.db',
+                'SECRET_KEY': 'test-secret',
+            })
+
+
+def test_production_rejects_local_ratelimit_storage_uri(tmp_path):
+    """Production limiter storage must be distributed, not a local memory backend."""
+    with patch.dict(os.environ, {'FLASK_DEBUG': '0'}, clear=False):
+        from app import create_app
+        with pytest.raises(RuntimeError, match='distributed backend'):
+            create_app({
+                'TESTING': False,
+                'SQLALCHEMY_DATABASE_URI': f'sqlite:///{tmp_path}/prod-local-rate.db',
+                'SECRET_KEY': 'test-secret',
+                'RATELIMIT_STORAGE_URI': 'memory://',
+            })
+
+
+def test_test_config_may_disable_distributed_ratelimit_storage(tmp_path):
+    """Tests keep the lightweight in-memory limiter unless they opt into storage."""
+    session_dir = tmp_path / 'sessions-rate-test'
+    session_dir.mkdir()
+    with patch.dict(os.environ, {'FLASK_DEBUG': '0', 'RATELIMIT_STORAGE_URI': ''}, clear=False):
+        from app import create_app
+        a = create_app({
+            'TESTING': True,
+            'SQLALCHEMY_DATABASE_URI': f'sqlite:///{tmp_path}/test-rate.db',
+            'SECRET_KEY': 'test-secret',
+            'SESSION_TYPE': 'cachelib',
+            'SESSION_CACHELIB': FileSystemCache(str(session_dir)),
+        })
+    assert 'RATELIMIT_STORAGE_URI' not in a.config
+
+
 def test_proxy_delete_method_not_allowed(auth_client):
     """DELETE is not in the allowed proxy methods."""
     resp = auth_client.delete('/proxy/particiapi/api/conversations/')

--- a/v2/tests/test_security.py
+++ b/v2/tests/test_security.py
@@ -41,6 +41,40 @@ def test_safe_redirect_allows_relative_paths(app):
         assert _safe_redirect('/accept/foo', '/') == '/accept/foo'
 
 
+def test_trusted_hosts_rejects_unexpected_host(tmp_path):
+    """Flask rejects requests whose Host header is outside TRUSTED_HOSTS."""
+    session_dir = tmp_path / 'sessions-trusted-hosts'
+    session_dir.mkdir()
+    from app import create_app
+    a = create_app({
+        'TESTING': True,
+        'SQLALCHEMY_DATABASE_URI': f'sqlite:///{tmp_path}/trusted-hosts.db',
+        'SECRET_KEY': 'test-secret',
+        'SESSION_TYPE': 'cachelib',
+        'SESSION_CACHELIB': FileSystemCache(str(session_dir)),
+        'TRUSTED_HOSTS': ['wiki-polis.test'],
+    })
+    with a.app_context():
+        db.create_all()
+    client = a.test_client()
+
+    assert client.get('/', headers={'Host': 'wiki-polis.test'}).status_code == 200
+    assert client.get('/', headers={'Host': 'evil.test'}).status_code == 400
+
+
+def test_production_requires_trusted_hosts(tmp_path):
+    """Production must declare the expected hostnames before startup."""
+    with patch.dict(os.environ, {'FLASK_DEBUG': '0', 'TRUSTED_HOSTS': ''}, clear=False):
+        from app import create_app
+        with pytest.raises(RuntimeError, match='TRUSTED_HOSTS is not set'):
+            create_app({
+                'TESTING': False,
+                'SQLALCHEMY_DATABASE_URI': f'sqlite:///{tmp_path}/prod-missing-hosts.db',
+                'SECRET_KEY': 'test-secret',
+                'RATELIMIT_STORAGE_URI': 'redis://localhost:6379/0',
+            })
+
+
 def test_admin_role_redirect_to_cannot_escape(app, admin_client, admin_participant, participant):
     """redirect_to field in role forms is sanitised through _safe_redirect."""
     conv = Conversation(slug='sec-conv', polis_id='sec1234567',
@@ -141,6 +175,7 @@ def test_production_requires_ratelimit_storage_uri(tmp_path):
                 'TESTING': False,
                 'SQLALCHEMY_DATABASE_URI': f'sqlite:///{tmp_path}/prod-missing-rate.db',
                 'SECRET_KEY': 'test-secret',
+                'TRUSTED_HOSTS': ['wiki-polis.test'],
             })
 
 
@@ -154,6 +189,7 @@ def test_production_rejects_local_ratelimit_storage_uri(tmp_path):
                 'SQLALCHEMY_DATABASE_URI': f'sqlite:///{tmp_path}/prod-local-rate.db',
                 'SECRET_KEY': 'test-secret',
                 'RATELIMIT_STORAGE_URI': 'memory://',
+                'TRUSTED_HOSTS': ['wiki-polis.test'],
             })
 
 

--- a/v2/tests/test_security.py
+++ b/v2/tests/test_security.py
@@ -2,6 +2,9 @@
 import os
 from unittest.mock import patch
 
+from cachelib.file import FileSystemCache
+import pytest
+
 from db import Conversation, db
 
 
@@ -63,7 +66,6 @@ def test_dev_db_isolation_refuses_non_sqlite(tmp_path):
         # Make sure we don't collide with real secrets
         'SECRET_KEY': 'test',
     }
-    import pytest
     with patch.dict(os.environ, env, clear=False):
         from app import create_app
         with pytest.raises(RuntimeError, match='sqlite'):
@@ -83,6 +85,51 @@ def test_dev_db_isolation_skipped_without_dev_login_user(tmp_path):
             'SESSION_FILE_DIR': str(tmp_path),
         })
         assert a is not None
+
+
+def test_fake_login_ignored_on_toolforge(tmp_path):
+    """DEV_FAKE_LOGIN must not register auth-bypass routes on Toolforge."""
+    session_dir = tmp_path / 'sessions-toolforge'
+    session_dir.mkdir()
+    env = {
+        'DEV_FAKE_LOGIN': '1',
+        'FLASK_DEBUG': '1',
+        'TOOL_TOOLFORGE_API_URL': 'https://api.svc.tools.eqiad1.wikimedia.cloud',
+        'SECRET_KEY': 'test',
+    }
+    with patch.dict(os.environ, env, clear=False):
+        from app import create_app
+        a = create_app({
+            'TESTING': True,
+            'SQLALCHEMY_DATABASE_URI': f'sqlite:///{tmp_path}/fake-toolforge.db',
+            'SESSION_TYPE': 'cachelib',
+            'SESSION_CACHELIB': FileSystemCache(str(session_dir)),
+        })
+    assert a.config['DEV_FAKE_LOGIN'] is False
+    assert a.config['DEV_TEST_USERS'] == []
+    assert a.test_client().get('/dev/login/dev-user-1').status_code == 404
+
+
+def test_fake_login_ignored_when_not_debug(tmp_path):
+    """DEV_FAKE_LOGIN must not register auth-bypass routes in production mode."""
+    session_dir = tmp_path / 'sessions-prod'
+    session_dir.mkdir()
+    env = {
+        'DEV_FAKE_LOGIN': '1',
+        'FLASK_DEBUG': '0',
+        'TOOL_TOOLFORGE_API_URL': '',
+        'SECRET_KEY': 'test',
+    }
+    with patch.dict(os.environ, env, clear=False):
+        from app import create_app
+        a = create_app({
+            'TESTING': True,
+            'SQLALCHEMY_DATABASE_URI': f'sqlite:///{tmp_path}/fake-prod.db',
+            'SESSION_TYPE': 'cachelib',
+            'SESSION_CACHELIB': FileSystemCache(str(session_dir)),
+        })
+    assert a.config['DEV_FAKE_LOGIN'] is False
+    assert a.test_client().get('/dev/login/dev-user-1').status_code == 404
 
 
 def test_proxy_delete_method_not_allowed(auth_client):

--- a/v2/tests/test_security.py
+++ b/v2/tests/test_security.py
@@ -1,5 +1,6 @@
 """Tests for security headers, redirect safety, and dev DB isolation."""
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 from cachelib.file import FileSystemCache
@@ -17,6 +18,14 @@ def test_security_headers_on_every_response(client):
     csp = resp.headers.get('Content-Security-Policy', '')
     assert "default-src 'self'" in csp
     assert "frame-ancestors 'none'" in csp
+
+
+def test_flash_toasts_do_not_inject_messages_with_innerhtml():
+    base_template = Path(__file__).resolve().parents[1] / 'templates' / 'base.html'
+    source = base_template.read_text()
+
+    assert 'el.innerHTML' not in source
+    assert 'msg.textContent = message' in source
 
 
 def test_safe_redirect_blocks_absolute_external(app):

--- a/v2/uv.lock
+++ b/v2/uv.lock
@@ -17,6 +17,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "blinker"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -693,6 +702,18 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -807,6 +828,7 @@ dependencies = [
     { name = "psycopg2-binary" },
     { name = "pymysql" },
     { name = "python-dotenv" },
+    { name = "redis" },
     { name = "requests" },
     { name = "sqlalchemy" },
 ]
@@ -831,6 +853,7 @@ requires-dist = [
     { name = "psycopg2-binary", specifier = ">=2.9" },
     { name = "pymysql", specifier = ">=1.1" },
     { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "redis", specifier = ">=5.0" },
     { name = "requests", specifier = ">=2.31" },
     { name = "sqlalchemy", specifier = ">=2.0" },
 ]


### PR DESCRIPTION
## Summary
- Gate local fake-login routes to debug and non-Toolforge environments.
- Resolve participant sessions by stable `xid` before mutable Wikimedia username.
- Reduce scoped moderator data exposure in conversation admin pages.
- Harden the CSRF-exempt Particiapi bridge with fail-closed browser provenance checks and manual CSRF validation for first-party statement submission.
- Require production `RATELIMIT_STORAGE_URI` and `TRUSTED_HOSTS` config.
- Align voluntary reveal behavior with the documented privacy model: opt-in public reveals remain permanent.
- Remove the hard-coded debug runner and render flash toasts without `innerHTML`.
- Add a durable route authorization matrix.

## Commit structure
This PR is intentionally split into 10 reviewable commits:
1. `security: gate fake login to local debug only`
2. `security: resolve participant sessions by stable xid`
3. `security: hide global role controls from scoped moderators`
4. `security: harden csrf-exempt particiapi bridge`
5. `security: require distributed rate-limit storage in production`
6. `privacy: reconcile voluntary reveal retention model`
7. `security: configure trusted hosts`
8. `security: remove debug direct app runner`
9. `security: render flash toasts without innerHTML`
10. `docs: add route authorization matrix`

## Deployment notes
- Production startup now fails unless `RATELIMIT_STORAGE_URI` is configured with a distributed backend such as Redis.
- Production startup now fails unless `TRUSTED_HOSTS` is configured with the allowed hostnames.
- Local tests and local debug mode can continue to use lightweight in-memory limiter behavior.

## Verification
- `git diff --check origin/main..HEAD`
- `POLIS_SERVER_URL=http://127.0.0.1:8003 POLIS_ADMIN_EMAIL=test@example.org POLIS_ADMIN_PASSWORD=test .venv/bin/python -m pytest` -> 149 passed
- `pip-audit` -> no known vulnerabilities found; local `wiki-polis` package skipped because it is not on PyPI
- `bandit` over repo-owned Python files -> no high findings after removing `app.run(debug=True)`
- `detect-secrets` scoped scan -> only placeholders and dev/test values flagged
- Production-like route inventory loaded with `TRUSTED_HOSTS` and `RATELIMIT_STORAGE_URI`; no dev-login routes registered
