### PR TITLE
fix(dev-login): dev users 404 on accept — sync mw_username on reuse

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -1686,6 +1686,14 @@ def _register_routes(app: Flask) -> None:
                 )
                 db.session.add(participant)
                 db.session.commit()
+            elif participant.mw_username != username or participant.xid != xid:
+                # Reused dev row: keep it consistent with the username we authenticate as.
+                # _current_participant() looks up by mw_username, so a drifted row (e.g. a
+                # pre-existing dev participant from an older username/xid scheme) would make
+                # it return None and 404 participant-gated routes like /accept and /reveal.
+                participant.mw_username = username
+                participant.xid         = xid
+                db.session.commit()
             session['username']  = username
             session['xid']       = xid
             session['emailable'] = False

--- a/v2/tests/test_dev_login.py
+++ b/v2/tests/test_dev_login.py
@@ -1,0 +1,71 @@
+"""Tests for the DEV_FAKE_LOGIN staging login (`/dev/login/<username>`).
+
+Regression for the bug where a reused dev Participant (matched by mw_user_id) kept a
+stale mw_username, so `_current_participant()` — which looks up by mw_username — returned
+None and participant-gated routes (/accept, /reveal) 404'd for dev users.
+"""
+import os
+from unittest.mock import patch
+
+import pytest
+from cachelib.file import FileSystemCache
+
+from app import create_app
+from db import Participant, db
+
+
+@pytest.fixture
+def fake_login_app(tmp_path):
+    """App with DEV_FAKE_LOGIN=1 so `/dev/login/<username>` is registered."""
+    session_dir = tmp_path / 'sessions'
+    session_dir.mkdir()
+    env = {'FLASK_DEBUG': '0', 'DEV_LOGIN_USER': '', 'DEV_FAKE_LOGIN': '1'}
+    with patch.dict(os.environ, env, clear=False):
+        a = create_app({
+            'TESTING': True,
+            'SQLALCHEMY_DATABASE_URI': f'sqlite:///{tmp_path}/test.db',
+            'SQLALCHEMY_ENGINE_OPTIONS': {'connect_args': {'check_same_thread': False}},
+            'WTF_CSRF_ENABLED': False,
+            'RATELIMIT_ENABLED': False,
+            'SECRET_KEY': 'test-secret',
+            'SESSION_TYPE': 'cachelib',
+            'SESSION_CACHELIB': FileSystemCache(str(session_dir)),
+            'SESSION_PERMANENT': False,
+        })
+    with a.app_context():
+        db.create_all()
+        yield a
+        db.session.remove()
+
+
+def test_dev_fake_login_creates_participant(fake_login_app):
+    """First login creates the dev Participant with matching mw_username."""
+    r = fake_login_app.test_client().get('/dev/login/dev-user-1')
+    assert r.status_code == 302
+    with fake_login_app.app_context():
+        p = Participant.query.filter_by(mw_user_id=-1).first()
+        assert p is not None
+        assert p.mw_username == 'dev-user-1'
+
+
+def test_dev_fake_login_syncs_drifted_username(fake_login_app):
+    """A reused dev row whose mw_username drifted is corrected on login, so
+    _current_participant() (lookup by mw_username) resolves again."""
+    with fake_login_app.app_context():
+        db.session.add(Participant(mw_user_id=-2, mw_username='stale-name', xid='x' * 64))
+        db.session.commit()
+
+    r = fake_login_app.test_client().get('/dev/login/dev-user-2')
+    assert r.status_code == 302
+
+    with fake_login_app.app_context():
+        # Same row (matched by mw_user_id), now consistent with the authenticated username.
+        rows = Participant.query.filter_by(mw_user_id=-2).all()
+        assert len(rows) == 1
+        assert rows[0].mw_username == 'dev-user-2'
+        # mw_username now matches what _current_participant() looks up by → no more 404.
+        assert Participant.query.filter_by(mw_username='dev-user-2').first() is not None
+
+
+def test_dev_fake_login_unknown_user_404(fake_login_app):
+    assert fake_login_app.test_client().get('/dev/login/not-a-dev-user').status_code == 404


### PR DESCRIPTION
## Bug
Logging in as a dev user (`DEV_FAKE_LOGIN`, `/dev/login/<username>`) then accepting a conversation → **404**. Reproduced on staging (dev-user-2 → `POST /accept/demo-categories` → 404).

## Cause
`dev_fake_login` looks up the dev Participant by **`mw_user_id`** (the fixed negative test id) and only sets `mw_username` on first creation. `_current_participant()` looks up by **`mw_username`**. If a reused dev row's `mw_username` had drifted from the current login name (a pre-existing row from an older scheme on staging), `_current_participant()` returns `None` and `accept_post`/`reveal` hit `abort(404)`. The session itself stays valid (proxy votes succeed — `@login_required` only checks `session['username']`), which is why it looked so odd.

## Fix
When reusing the row, update `mw_username`/`xid` to match the authenticated username (one `elif`). Self-heals drifted rows on next login; real OAuth users are unaffected.

## Tests
New `tests/test_dev_login.py`: create-on-first-login, **drift-sync** (the regression), unknown-user 404. Full suite **137 passed**.

## Note
Fixes the live staging dev users on next login after redeploy — which also unblocks the dev-user participation flow (accept → vote → results) we were using to exercise #105.