### PR TITLE
fix(#107): propose button after all voted — full UX pass

### DIFF
--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -955,14 +955,16 @@ pa-statement:state(no-statement) ~ .vote-choice-row { display: none; }
 }
 
 /* Hide action labels in pre-vote dimmed state */
-.v2-triad:not(.v2-triad--active) .v2-option-action { visibility: hidden; }
+.v2-triad:not(.v2-triad--active):not(.v2-triad--alldone) .v2-option-action { visibility: hidden; }
 
-/* Active state — set when triad has v2-triad--active */
-.v2-triad--active .v2-option-card:not([aria-disabled="true"]) {
+/* Active and all-done states — set when triad has v2-triad--active or v2-triad--alldone */
+.v2-triad--active .v2-option-card:not([aria-disabled="true"]),
+.v2-triad--alldone .v2-option-card:not([aria-disabled="true"]) {
   opacity: 1;
   cursor: pointer;
 }
-.v2-triad--active .v2-option-card:not([aria-disabled="true"]):hover {
+.v2-triad--active .v2-option-card:not([aria-disabled="true"]):hover,
+.v2-triad--alldone .v2-option-card:not([aria-disabled="true"]):hover {
   border-color: #888; /* fallback for Safari < 15.4 */
   border-color: color-mix(in srgb, var(--ink) 55%, transparent);
 }

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -857,9 +857,10 @@ pa-statement:state(no-statement) ~ .vote-choice-row { display: none; }
   margin: 0;
 }
 
-/* In all-done state, show only the Propose New card */
+/* In all-done state, show only the Propose New card, centred */
 .v2-triad--alldone .v2-option-card { display: none; }
 .v2-triad--alldone #triad-newstmt  { display: flex; }
+.v2-triad--alldone .v2-triad-grid  { justify-content: center; }
 
 .propose-submitted {
   display: flex;

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -273,8 +273,8 @@
 
         {# ── All done message ── #}
         <div id="all-done-msg" class="all-done-msg" hidden>
-          <p class="all-done-label">You've voted on all available statements.</p>
-          <p class="all-done-sub">New statements may appear when others propose them.</p>
+          <p class="all-done-label">For now, you have shared your opinion on all available statements. Please come back later for more!</p>
+          <p class="all-done-sub" id="all-done-propose-hint" hidden>If you can think of any statements that are missing from the current set, this is your chance to submit them.</p>
         </div>
 
         {# ── Hidden pa-* elements for API submission ── #}
@@ -1087,6 +1087,9 @@
     if (triad.classList.contains('v2-triad--active') || triad.classList.contains('v2-triad--alldone')) {
       setAriaDisabled(triadNewstmt, !active);
     }
+
+    var hint = document.getElementById('all-done-propose-hint');
+    if (hint) hint.hidden = !active;
   }
 
   // ── Mode: idle ────────────────────────────────────────────────────────────────
@@ -1340,7 +1343,7 @@
         NEW_STMT_USED++;
         updateNewstmtCard();
         if (newstmtOrigin === 'alldone') {
-          setTimeout(function () { proposeSubmitted.hidden = true; }, 1200);
+          setTimeout(enterAllDone, 1200);
         } else {
           setTimeout(enterIdle, 1200);
         }

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -1091,6 +1091,10 @@
 
   // ── Mode: idle ────────────────────────────────────────────────────────────────
   function enterIdle(focusTarget) {
+    // If the queue is empty, route to the all-done state so the propose
+    // button is correctly enabled (fixes #107 — idle vs all-done inconsistency).
+    if (isAllDone()) { enterAllDone(); return; }
+
     stmtCard.classList.remove('statement-card--voted');
     stmtCard.hidden        = false;
     votedStmtText.hidden   = true;


### PR DESCRIPTION
## Summary

- Enable the propose button when all statements are voted (fixes the original #107 report)
- Show pointer cursor and hover state on the propose card in all-done state
- Re-enter all-done state after a submission so the propose card reappears (instead of going blank)
- Show the propose card disabled (quota reached) rather than hiding it
- Centre the propose card in all-done state
- Update all-done message text; show a hint sentence only when submission quota remains

## Test plan

- [ ] Vote on all statements → all-done state appears with new message text
- [ ] Hint sentence visible when quota remains, hidden when quota exhausted
- [ ] Propose card centred in all-done state
- [ ] Submit a statement → "PROPOSED" confirmation → propose card reappears (enabled or disabled)
- [ ] When quota exhausted → propose card shows disabled, hint hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)