### PR TITLE
fix(admin): show inline slug format error instead of silent 400

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -749,8 +749,16 @@ def admin_conversation_new():
     slug   = request.form.get('slug', '').strip().lower()
     fields = _parse_conversation_form()
 
-    if not fields['title'] or not _valid_slug(slug):
-        abort(400)
+    if not fields['title']:
+        flash('Title is required.', 'error')
+        return redirect(url_for('admin.admin'))
+    if not _valid_slug(slug):
+        flash(
+            'Invalid slug — use lowercase letters, numbers, and hyphens only, '
+            'no spaces or special characters (e.g. climate-2026).',
+            'error',
+        )
+        return redirect(url_for('admin.admin'))
 
     polis_configured = all(current_app.config.get(k) for k in (
         'POLIS_SERVER_URL', 'POLIS_ADMIN_EMAIL', 'POLIS_ADMIN_PASSWORD'))

--- a/v2/templates/admin.html
+++ b/v2/templates/admin.html
@@ -50,7 +50,8 @@
       <div class="edit-row-fields">
         <label>Slug (URL-safe, immutable)
           <input type="text" name="slug" placeholder="e.g. rfc-2024-adminship" required
-                 pattern="[a-z0-9]+(-[a-z0-9]+)*">
+                 pattern="[a-z0-9]+(-[a-z0-9]+)*"
+                 title="Lowercase letters, numbers, and hyphens only — no spaces or special characters (e.g. climate-2026)">
         </label>
         <label>Title
           <input type="text" name="title" required>

--- a/v2/tests/test_admin.py
+++ b/v2/tests/test_admin.py
@@ -60,8 +60,9 @@ def test_create_conversation_invalid_slug_rejected(admin_client):
         'polis_id': 'abc1234567',
         'title': 'Test',
         'access_policy': 'public',
-    })
-    assert resp.status_code == 400
+    }, follow_redirects=True)
+    assert resp.status_code == 200
+    assert b'lowercase letters' in resp.data.lower() or b'invalid slug' in resp.data.lower()
 
 
 def test_create_conversation_polis_failure_redirects(app, admin_client):


### PR DESCRIPTION
## Summary

- Adds a `title` attribute to the slug input so the browser's native validation tooltip shows the actual format rule instead of the generic "Please match the format requested"
- Replaces the silent `abort(400)` on invalid slug POST with a flash error message that explains the rule inline

Fixes #68

## Test plan

- [ ] Submit the new conversation form with an invalid slug (e.g. `INVALID SLUG!`) — browser tooltip should read "Lowercase letters, numbers, and hyphens only…"
- [ ] POST directly to `/admin/conversations/new` with an invalid slug — should redirect to admin with flash error, not a bare 400
- [ ] Valid slug still creates the conversation normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)