### PR TITLE
a11y: fix accessibility audit findings in the participant front-end

### DIFF
--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -372,7 +372,15 @@ header {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .conv-card { transition: none; }
+  /* Neutralise motion app-wide: make transitions/animations effectively
+     instant and disable CSS smooth scrolling. (JS scrollIntoView with
+     behavior:'smooth' ignores this; it is gated separately in the template.) */
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
   .conv-card:active { transform: none; }
   /* shadow change on :active is retained intentionally — not vestibular motion */
 }

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -1358,6 +1358,7 @@ pa-statement:state(no-statement) ~ .vote-choice-row { display: none; }
   align-items: center;
   gap: 6px;
   padding: 2px 0;
+  min-height: 24px; /* WCAG 2.5.8 target size */
   font-family: var(--sans);
 }
 
@@ -1537,6 +1538,12 @@ h3.section-heading {
   line-height: 1;
   padding: 0;
   flex-shrink: 0;
+  /* keep the glyph small but the hit area >= 24px (WCAG 2.5.8) */
+  min-width: 24px;
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 .toast__close:hover { opacity: 1; }
 .toast--out { opacity: 0; transform: translateY(.5rem); }

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -7,17 +7,17 @@
   /* Cluster palette */
   --ink:           #0c0c0e;
   --body:          #3f3f43;
-  --muted:         #71717a;
+  --muted:         #5f5f68;  /* darkened for WCAG AA (4.5:1) on off-white panels */
   --bg:            #fafaf9;
   --surface:       #ffffff;
   --surface2:      #f4f4f3;
   --surface3:      #eeece6;
   --hairline:      #e5e5e6;
   --hairline-soft: #efefef;
-  --agree:         #1f8a5b;
+  --agree:         #15734a;  /* darkened for WCAG AA as text/badges (see --green for the brighter legacy tone) */
   --pass:          #3d6dba;
-  --disagree:      #c44a4a;
-  --spot:          #f59e0b;
+  --disagree:      #b23a3a;  /* darkened for WCAG AA as text/badges */
+  --spot:          #b45309;  /* deepened amber: was #f59e0b (2.15:1 as text); now AA as text and white-on-spot */
   --accent:        #2d2d31;
   /* Legacy aliases used by admin UI */
   --blue:          #3d6dba;

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -55,6 +55,29 @@
   outline-offset: -2px;
 }
 
+/* Skip-to-content link: off-screen until focused, then pinned top-left. */
+.skip-link {
+  position: absolute;
+  top: -48px;
+  left: 8px;
+  z-index: 1000;
+  padding: 8px 14px;
+  background: var(--surface);
+  color: var(--ink);
+  border: 1px solid var(--hairline);
+  border-radius: 6px;
+  font-size: 13px;
+  text-decoration: none;
+  transition: top 0.15s ease;
+}
+.skip-link:focus {
+  top: 8px;
+}
+/* Suppress the focus outline on the jump target itself (it is not a control). */
+#main:focus {
+  outline: none;
+}
+
 /* .conv-card is always an <a> element — this rule relies on that assumption */
 .conv-card:focus-visible {
   outline: 2px solid var(--accent);

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -43,6 +43,18 @@
   outline-offset: 2px;
 }
 
+/* These composer textareas suppress the default outline for a borderless look
+   (border:0/outline:0 below). Restore a clear keyboard focus ring on
+   :focus-visible — higher specificity than the base rules, so it wins on
+   focus while leaving the resting/mouse appearance untouched. Inset offset so
+   the ring is never clipped by the surrounding composer frame. */
+.propose-textarea:focus-visible,
+.v2-composer-textarea:focus-visible,
+.contribute-textarea:focus-visible {
+  outline: 2px solid var(--pass);
+  outline-offset: -2px;
+}
+
 /* .conv-card is always an <a> element — this rule relies on that assumption */
 .conv-card:focus-visible {
   outline: 2px solid var(--accent);

--- a/v2/templates/accept.html
+++ b/v2/templates/accept.html
@@ -95,7 +95,7 @@
       <p class="muted" style="margin-top:.25rem">
         Email notifications unavailable — no confirmed email on your wiki account.
         <a href="https://meta.wikimedia.org/wiki/Special:Preferences#mw-prefsection-personal"
-           target="_blank" rel="noopener">Add one on Meta-Wiki</a> and return to enable this.
+           target="_blank" rel="noopener">Add one on Meta-Wiki<span class="sr-only"> (opens in a new tab)</span></a> and return to enable this.
       </p>
       {% endif %}
 

--- a/v2/templates/base.html
+++ b/v2/templates/base.html
@@ -10,6 +10,7 @@
   {% block head %}{% endblock %}
 </head>
 <body>
+  <a class="skip-link" href="#main">Skip to main content</a>
   <header>
     <div class="header-inner">
       <div style="display:flex;align-items:center;gap:14px">
@@ -46,7 +47,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="main" tabindex="-1">
     {% block content %}{% endblock %}
   </main>
 

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -119,6 +119,12 @@
           <span class="vote-progress-queued" id="vote-progress-queued"></span>
         </div>
 
+        {# ── SR-only live region — announces each new statement to screen
+             readers (the visible <pa-statement> text is not in a live region
+             and focus moves to the vote buttons, so the statement change is
+             otherwise silent). ── #}
+        <p class="sr-only" id="statement-live" role="status" aria-live="polite"></p>
+
         {# ── Statement card — always visible ── #}
         <div class="statement-card" id="statement-card">
           <div class="statement-card-header">
@@ -1001,6 +1007,7 @@
   var votedBadge       = document.getElementById('voted-badge');
   var votedLabel       = document.getElementById('voted-label');
   var votedStmtText    = document.getElementById('voted-stmt-text');
+  var stmtLive         = document.getElementById('statement-live');
   var triad            = document.getElementById('v2-triad');
   var triadLabel       = document.getElementById('v2-triad-label');
   var triadSuggest     = document.getElementById('triad-suggest');
@@ -1042,6 +1049,18 @@
   // ── Helpers ───────────────────────────────────────────────────────────────────
 
   function liveStmt() { return conv.querySelector('pa-statement'); }
+
+  // Announce the currently-displayed statement in the polite live region.
+  // The component advances pa-statement synchronously on vote, so by the time
+  // we re-enter the idle vote view liveStmt() already holds the next statement.
+  function announceStatement() {
+    if (!stmtLive) return;
+    if (isAllDone()) { stmtLive.textContent = ''; return; }
+    var s   = liveStmt();
+    var txt = s ? (s.text || '').trim() : '';
+    if (!txt && conv.statement && conv.statement.text) txt = String(conv.statement.text).trim();
+    if (txt) stmtLive.textContent = 'Statement: ' + txt;
+  }
 
   function getVotedCount() {
     try { return conv.client.participant.votes.size; } catch (e) { return 0; }
@@ -1122,6 +1141,9 @@
     // Restore keyboard focus
     var target = focusTarget || choiceRow.querySelector('.vote-choice');
     if (target) target.focus();
+
+    // Announce the new statement now that the idle vote view is showing.
+    announceStatement();
   }
 
   // ── Mode: voted ───────────────────────────────────────────────────────────────
@@ -1420,6 +1442,10 @@
   // `value`, never statementID.) Consumed by "change" (#69) and the error handler below.
   var lastVoteStmtId = null;
 
+  // Announce the first statement once the client has loaded (subsequent
+  // statements are announced from enterIdle as the queue advances).
+  var initialAnnounced = false;
+
   // On vote failure: mark the statement as voted in the web component so it advances,
   // then reset UI. Covers both own-statement 403s and any other transient failures.
   conv.addEventListener('particiappvotesubmiterror', function () {
@@ -1446,6 +1472,7 @@
     if (e.state === 'loaded' && conv.client) {
       updateProgress(conv.client.statements);
       handleNoStatement();
+      if (!initialAnnounced) { initialAnnounced = true; announceStatement(); }
     }
   });
 }());

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -19,6 +19,8 @@
 
 <div class="container">
 
+  <h1 class="sr-only">{{ conversation.title }}</h1>
+
   {% if conversation.intro_text %}
   <div class="intro-text">
     {{ conversation.intro_text | safe }}

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -294,7 +294,7 @@
           <pa-submit-button id="pvb-submit-newstmt" submitfor="newstmt-input">new-statement</pa-submit-button>
         </span>
 
-        <div id="conv-error" hidden>
+        <div id="conv-error" role="alert" hidden>
           <p class="muted" id="conv-error-msg">Unable to load statements. Please refresh the page.</p>
         </div>
 
@@ -393,6 +393,11 @@
        class="tab-panel arguments-tab{% if tabs|length > 1 and tabs[0] != 'arguments' %} tab-panel--hidden{% endif %}"
        role="tabpanel" aria-labelledby="tab-btn-arguments"
        data-voting="{{ 'true' if arg_voting_open else 'false' }}">
+
+    {# SR-only assertive region — vote-rejection reasons are shown transiently
+       in the visible status strip (and reverted); mirror them here so screen
+       readers hear them once without announcing the instructional baseline. #}
+    <p class="sr-only" id="arg-alert" role="alert"></p>
 
     {% if featured_data | length == 0 %}
     <div class="landing-section">
@@ -752,7 +757,7 @@
           <span class="stmt-dot"></span>
           INFORMED VOTE &middot; {{ loop.index }} of {{ phase6_data | length }}
         </span>
-        <span class="p6-voted-badge" hidden></span>
+        <span class="p6-voted-badge" role="alert" hidden></span>
       </div>
 
       {# Statement text #}
@@ -947,9 +952,9 @@
       if (skip) {
         skip.addEventListener('click', function () {
           skip.hidden = true;
-          badge.textContent = 'Skipped';
           badge.className = 'p6-voted-badge';
           badge.removeAttribute('hidden');
+          badge.textContent = 'Skipped';
           row.querySelectorAll('.btn-p6-vote').forEach(function (b) { b.disabled = true; b.classList.add('p6-voted'); });
           card.classList.add('p6-card--voted');
           markTerminal(card);
@@ -972,9 +977,9 @@
             if (resp.ok) {
               var label = vote === 1 ? 'Agreed' : vote === -1 ? 'Disagreed' : 'Passed';
               var cls   = vote === 1 ? 'agree' : vote === -1 ? 'disagree' : 'pass';
-              badge.textContent = '✓ ' + label;
               badge.className = 'p6-voted-badge p6-voted-badge--' + cls;
               badge.removeAttribute('hidden');
+              badge.textContent = '✓ ' + label;
               row.querySelectorAll('.btn-p6-vote').forEach(function (b) {
                 b.classList.toggle('p6-voted', b.dataset.vote === String(vote));
               });
@@ -986,8 +991,8 @@
               if (skip) skip.hidden = false;
             }
           }).catch(function () {
-            badge.textContent = 'Network error — refresh to check';
             badge.removeAttribute('hidden');
+            badge.textContent = 'Network error — refresh to check';
           });
         });
       });
@@ -1877,9 +1882,13 @@
               var prev = txt.textContent;
               txt.textContent = msgs[data.reason];
               strip.classList.add('arg-status-strip--error');
+              // Mirror to the assertive alert region so screen readers hear it.
+              var alertEl = document.getElementById('arg-alert');
+              if (alertEl) alertEl.textContent = msgs[data.reason];
               setTimeout(function () {
                 txt.textContent = prev;
                 strip.classList.remove('arg-status-strip--error');
+                if (alertEl) alertEl.textContent = '';
               }, 3500);
             }
           }).catch(function () {});

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -917,13 +917,19 @@
     var voteUrl   = '{{ url_for("participant.phase6_vote", slug=conversation.slug) }}';
     var doneEl    = document.querySelector('.p6-done');
 
+    // Respect prefers-reduced-motion: a smooth auto-scroll becomes an instant
+    // jump. Read at call time so a mid-session preference change is honoured.
+    function scrollBehavior() {
+      return (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) ? 'auto' : 'smooth';
+    }
+
     function scrollToNext(card) {
       var cards = Array.prototype.slice.call(document.querySelectorAll('.p6-card'));
       var idx   = cards.indexOf(card);
       var next  = cards[idx + 1];
       if (next) {
         setTimeout(function () {
-          next.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          next.scrollIntoView({ behavior: scrollBehavior(), block: 'start' });
         }, 400);
       }
     }
@@ -936,7 +942,7 @@
       if (done.length === all.length && doneEl) {
         doneEl.removeAttribute('hidden');
         setTimeout(function () {
-          doneEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          doneEl.scrollIntoView({ behavior: scrollBehavior(), block: 'start' });
         }, 400);
       }
     }

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -555,7 +555,9 @@
                data-vote-url="{{ url_for('participant.argument_vote', slug=conversation.slug, arg_id=arg.id) }}"
                data-unvote-url="{{ url_for('participant.argument_unvote', slug=conversation.slug, arg_id=arg.id) }}"
                data-csrf="{{ csrf_token() }}">
-            <button class="argument-checkbox" aria-label="Mark as most important"
+            <button class="argument-checkbox"
+                    aria-pressed="{{ 'true' if is_picked else 'false' }}"
+                    aria-label="{{ 'Unmark as most important' if is_picked else 'Mark as most important' }}"
                     tabindex="{{ '0' if pro_can_vote else '-1' }}">
               {% if is_picked %}
               <svg width="10" height="8" viewBox="0 0 10 8" fill="none" aria-hidden="true">
@@ -572,6 +574,7 @@
                           stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                   </svg>
                   <strong class="importance-count">{{ arg.votes | length }}</strong>
+                  <span class="sr-only"> importance votes</span>
                 </span>
                 <span class="argument-by">{{ item.proposer_pseudonyms.get(arg.proposer_id, 'admin') if arg.proposer_id else 'admin' }}</span>
                 {% if is_own %}<span class="argument-yours">YOURS</span>{% endif %}
@@ -667,7 +670,9 @@
                data-vote-url="{{ url_for('participant.argument_vote', slug=conversation.slug, arg_id=arg.id) }}"
                data-unvote-url="{{ url_for('participant.argument_unvote', slug=conversation.slug, arg_id=arg.id) }}"
                data-csrf="{{ csrf_token() }}">
-            <button class="argument-checkbox" aria-label="Mark as most important"
+            <button class="argument-checkbox"
+                    aria-pressed="{{ 'true' if is_picked else 'false' }}"
+                    aria-label="{{ 'Unmark as most important' if is_picked else 'Mark as most important' }}"
                     tabindex="{{ '0' if con_can_vote else '-1' }}">
               {% if is_picked %}
               <svg width="10" height="8" viewBox="0 0 10 8" fill="none" aria-hidden="true">
@@ -684,6 +689,7 @@
                           stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                   </svg>
                   <strong class="importance-count">{{ arg.votes | length }}</strong>
+                  <span class="sr-only"> importance votes</span>
                 </span>
                 <span class="argument-by">{{ item.proposer_pseudonyms.get(arg.proposer_id, 'admin') if arg.proposer_id else 'admin' }}</span>
                 {% if is_own %}<span class="argument-yours">YOURS</span>{% endif %}
@@ -1613,7 +1619,7 @@
     div.dataset.unvoteUrl = unvoteUrl;
     div.dataset.csrf = csrf;
     div.innerHTML =
-      '<button class="argument-checkbox" aria-label="Mark as most important" tabindex="-1"></button>' +
+      '<button class="argument-checkbox" aria-pressed="false" aria-label="Mark as most important" tabindex="-1"></button>' +
       '<div class="argument-body">' +
         '<p class="argument-text">' + escapeHtml(body) + '</p>' +
         '<div class="argument-meta">' +
@@ -1622,6 +1628,7 @@
               '<path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>' +
             '</svg>' +
             '<strong class="importance-count">0</strong>' +
+            '<span class="sr-only"> importance votes</span>' +
           '</span>' +
           '<span class="argument-by">' + escapeHtml(pseudonym) + '</span>' +
           '<span class="argument-yours">YOURS</span>' +
@@ -1632,6 +1639,17 @@
 
   function escapeHtml(s) {
     return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+  }
+
+  // Reflect an argument's pick state on its checkbox: the visible checkmark
+  // plus the programmatic toggle state (aria-pressed) and the label a screen
+  // reader announces. Keeps the two in lock-step everywhere the state flips.
+  var PICK_SVG = '<svg width="10" height="8" viewBox="0 0 10 8" fill="none" aria-hidden="true"><path d="M1 4L3.5 6.5L9 1" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+  function setPicked(cb, picked) {
+    if (!cb) return;
+    cb.innerHTML = picked ? PICK_SVG : '';
+    cb.setAttribute('aria-pressed', picked ? 'true' : 'false');
+    cb.setAttribute('aria-label', picked ? 'Unmark as most important' : 'Mark as most important');
   }
 
   // ── Contribute wrapper state machine ─────────────────────────────────────────
@@ -1813,17 +1831,15 @@
       var fsId = getCardFsId(card);
 
       // Optimistic update
+      var cb  = card.querySelector('.argument-checkbox');
+      var cnt = card.querySelector('.importance-count');
       if (isPicked) {
         card.dataset.picked = 'false';
-        var cb = card.querySelector('.argument-checkbox');
-        if (cb) cb.innerHTML = '';
-        var cnt = card.querySelector('.importance-count');
+        setPicked(cb, false);
         if (cnt) cnt.textContent = Math.max(0, parseInt(cnt.textContent, 10) - 1);
       } else {
         card.dataset.picked = 'true';
-        var cb = card.querySelector('.argument-checkbox');
-        if (cb) cb.innerHTML = '<svg width="10" height="8" viewBox="0 0 10 8" fill="none"><path d="M1 4L3.5 6.5L9 1" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>';
-        var cnt = card.querySelector('.importance-count');
+        setPicked(cb, true);
         if (cnt) cnt.textContent = parseInt(cnt.textContent, 10) + 1;
       }
 
@@ -1835,15 +1851,11 @@
           // Revert on error
           if (isPicked) {
             card.dataset.picked = 'true';
-            var cb = card.querySelector('.argument-checkbox');
-            if (cb) cb.innerHTML = '<svg width="10" height="8" viewBox="0 0 10 8" fill="none"><path d="M1 4L3.5 6.5L9 1" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>';
-            var cnt = card.querySelector('.importance-count');
+            setPicked(cb, true);
             if (cnt) cnt.textContent = parseInt(cnt.textContent, 10) + 1;
           } else {
             card.dataset.picked = 'false';
-            var cb = card.querySelector('.argument-checkbox');
-            if (cb) cb.innerHTML = '';
-            var cnt = card.querySelector('.importance-count');
+            setPicked(cb, false);
             if (cnt) cnt.textContent = Math.max(0, parseInt(cnt.textContent, 10) - 1);
           }
           updateLimitReached(fsId, side);

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -78,23 +78,27 @@
   <div class="tab-bar" role="tablist">
     {% if 'vote' in tabs %}
     <button id="tab-btn-vote" class="tab-btn{% if tabs[0] == 'vote' %} tab-btn--active{% endif %}"
-            role="tab" data-tab="tab-vote"
-            aria-selected="{{ 'true' if tabs[0] == 'vote' else 'false' }}">Vote</button>
+            role="tab" data-tab="tab-vote" aria-controls="tab-vote"
+            aria-selected="{{ 'true' if tabs[0] == 'vote' else 'false' }}"
+            tabindex="{{ '0' if tabs[0] == 'vote' else '-1' }}">Vote</button>
     {% endif %}
     {% if 'results' in tabs %}
     <button id="tab-btn-results" class="tab-btn{% if tabs[0] == 'results' %} tab-btn--active{% endif %}"
-            role="tab" data-tab="tab-results"
-            aria-selected="{{ 'true' if tabs[0] == 'results' else 'false' }}">Results</button>
+            role="tab" data-tab="tab-results" aria-controls="tab-results"
+            aria-selected="{{ 'true' if tabs[0] == 'results' else 'false' }}"
+            tabindex="{{ '0' if tabs[0] == 'results' else '-1' }}">Results</button>
     {% endif %}
     {% if 'arguments' in tabs %}
     <button id="tab-btn-arguments" class="tab-btn{% if tabs[0] == 'arguments' %} tab-btn--active{% endif %}"
-            role="tab" data-tab="tab-arguments"
-            aria-selected="{{ 'true' if tabs[0] == 'arguments' else 'false' }}">Arguments</button>
+            role="tab" data-tab="tab-arguments" aria-controls="tab-arguments"
+            aria-selected="{{ 'true' if tabs[0] == 'arguments' else 'false' }}"
+            tabindex="{{ '0' if tabs[0] == 'arguments' else '-1' }}">Arguments</button>
     {% endif %}
     {% if 'informed-voting' in tabs %}
     <button id="tab-btn-informed-voting" class="tab-btn{% if tabs[0] == 'informed-voting' %} tab-btn--active{% endif %}"
-            role="tab" data-tab="tab-informed-voting"
-            aria-selected="{{ 'true' if tabs[0] == 'informed-voting' else 'false' }}">Informed voting</button>
+            role="tab" data-tab="tab-informed-voting" aria-controls="tab-informed-voting"
+            aria-selected="{{ 'true' if tabs[0] == 'informed-voting' else 'false' }}"
+            tabindex="{{ '0' if tabs[0] == 'informed-voting' else '-1' }}">Informed voting</button>
     {% endif %}
   </div>
   {% endif %}
@@ -116,7 +120,8 @@
             <span id="votes-total">?</span>
           </span>
           <div class="vote-progress-bar-wrap">
-            <div class="vote-progress-bar" id="vote-progress-bar"></div>
+            <div class="vote-progress-bar" id="vote-progress-bar"
+                 role="progressbar" aria-label="Statements voted" aria-valuemin="0"></div>
           </div>
           <span class="vote-progress-queued" id="vote-progress-queued"></span>
         </div>
@@ -872,6 +877,7 @@
       btns.forEach(function (b) {
         b.classList.remove('tab-btn--active');
         b.setAttribute('aria-selected', 'false');
+        b.setAttribute('tabindex', '-1');
       });
       panels.forEach(function (p) {
         p.classList.add('tab-panel--hidden');
@@ -879,6 +885,7 @@
       });
       btn.classList.add('tab-btn--active');
       btn.setAttribute('aria-selected', 'true');
+      btn.setAttribute('tabindex', '0');
       var target = document.getElementById(btn.dataset.tab);
       if (target) {
         target.classList.remove('tab-panel--hidden');
@@ -1414,6 +1421,9 @@
     progressRow.style.display = '';
     votesDone.textContent  = done;
     votesTotal.textContent = total;
+    progressBar.setAttribute('aria-valuenow', done);
+    progressBar.setAttribute('aria-valuemax', total);
+    progressBar.setAttribute('aria-valuetext', done + ' of ' + total + ' statements voted');
     var current = conv.statement;
     progressBar.innerHTML = '';
     for (var i = 0; i < total; i++) {

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -121,7 +121,7 @@
           </span>
           <div class="vote-progress-bar-wrap">
             <div class="vote-progress-bar" id="vote-progress-bar"
-                 role="progressbar" aria-label="Statements voted" aria-valuemin="0"></div>
+                 role="progressbar" aria-label="Statements voted" aria-valuemin="0" aria-valuenow="0"></div>
           </div>
           <span class="vote-progress-queued" id="vote-progress-queued"></span>
         </div>
@@ -1901,12 +1901,23 @@
               txt.textContent = msgs[data.reason];
               strip.classList.add('arg-status-strip--error');
               // Mirror to the assertive alert region so screen readers hear it.
+              // Blank first, then set on the next frame, so a repeated identical
+              // reason still mutates the node and is re-announced. Track the clear
+              // timer per element so back-to-back messages don't blank each other early.
               var alertEl = document.getElementById('arg-alert');
-              if (alertEl) alertEl.textContent = msgs[data.reason];
+              if (alertEl) {
+                if (alertEl._clearTimer) clearTimeout(alertEl._clearTimer);
+                alertEl.textContent = '';
+                window.requestAnimationFrame(function () {
+                  alertEl.textContent = msgs[data.reason];
+                });
+                alertEl._clearTimer = setTimeout(function () {
+                  alertEl.textContent = '';
+                }, 3500);
+              }
               setTimeout(function () {
                 txt.textContent = prev;
                 strip.classList.remove('arg-status-strip--error');
-                if (alertEl) alertEl.textContent = '';
               }, 3500);
             }
           }).catch(function () {});

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -230,12 +230,13 @@
         <div id="composer-suggest" class="v2-composer" hidden>
           <div class="v2-composer-header">
             <div>
-              <div class="v2-composer-title">Suggest different wording</div>
-              <div class="v2-composer-helper">Stays close to the same idea — just a clearer or fairer phrasing.</div>
+              <div class="v2-composer-title" id="composer-suggest-title">Suggest different wording</div>
+              <div class="v2-composer-helper" id="composer-suggest-helper">Stays close to the same idea — just a clearer or fairer phrasing.</div>
             </div>
             <span class="propose-charcount"><span id="suggest-len">0</span> / 280</span>
           </div>
           <textarea id="suggest-input" class="v2-composer-textarea" maxlength="280"
+                    aria-labelledby="composer-suggest-title" aria-describedby="composer-suggest-helper"
                     placeholder="Re-confirmation every five years would balance accountability against admin burnout…"></textarea>
           <div class="v2-composer-footer">
             <span class="v2-composer-hint">Goes into the pool with the original</span>
@@ -250,12 +251,13 @@
         <div id="composer-newstmt" class="v2-composer" hidden>
           <div class="v2-composer-header">
             <div>
-              <div class="v2-composer-title">Propose a new statement</div>
-              <div class="v2-composer-helper">A different angle entirely. One claim, one sentence. Goes to moderation, then into the same pool.</div>
+              <div class="v2-composer-title" id="composer-newstmt-title">Propose a new statement</div>
+              <div class="v2-composer-helper" id="composer-newstmt-helper">A different angle entirely. One claim, one sentence. Goes to moderation, then into the same pool.</div>
             </div>
             <span class="propose-charcount"><span id="newstmt-len">0</span> / 280</span>
           </div>
           <textarea id="newstmt-input" class="v2-composer-textarea" maxlength="280"
+                    aria-labelledby="composer-newstmt-title" aria-describedby="composer-newstmt-helper"
                     placeholder="A new angle on the topic…"></textarea>
           <div class="v2-composer-footer">
             <span class="v2-composer-hint">A separate statement — others will vote on it too</span>
@@ -515,10 +517,11 @@
             <div class="contribute-composer">
               <div class="contribute-composer-header">
                 <span class="contribute-glyph filled">+</span>
-                <span class="contribute-composer-label">Your for-argument · one sentence, one claim</span>
+                <span class="contribute-composer-label" id="contribute-label-{{ fs.id }}-pro">Your for-argument · one sentence, one claim</span>
                 <span class="contribute-charcount"><span class="cc-len">0</span> / 280</span>
               </div>
               <textarea class="contribute-textarea" maxlength="280" rows="3"
+                        aria-labelledby="contribute-label-{{ fs.id }}-pro"
                         placeholder="Add a short for-argument (one sentence, max 280 characters)…"></textarea>
               <div class="contribute-actions">
                 <button type="button" class="btn-secondary contribute-skip-btn">Nothing to add</button>
@@ -630,10 +633,11 @@
             <div class="contribute-composer">
               <div class="contribute-composer-header">
                 <span class="contribute-glyph filled">−</span>
-                <span class="contribute-composer-label">Your against-argument · one sentence, one claim</span>
+                <span class="contribute-composer-label" id="contribute-label-{{ fs.id }}-con">Your against-argument · one sentence, one claim</span>
                 <span class="contribute-charcount"><span class="cc-len">0</span> / 280</span>
               </div>
               <textarea class="contribute-textarea" maxlength="280" rows="3"
+                        aria-labelledby="contribute-label-{{ fs.id }}-con"
                         placeholder="Add a short against-argument (one sentence, max 280 characters)…"></textarea>
               <div class="contribute-actions">
                 <button type="button" class="btn-secondary contribute-skip-btn">Nothing to add</button>

--- a/v2/templates/home.html
+++ b/v2/templates/home.html
@@ -12,7 +12,7 @@
 {% if not username %}
 
   <div class="landing-section">
-    <h2 style="font-size:26px;font-weight:600;letter-spacing:-0.02em;line-height:1.15;margin-bottom:12px">Where the community actually stands.</h2>
+    <h1 style="font-size:26px;font-weight:600;letter-spacing:-0.02em;line-height:1.15;margin-bottom:12px">Where the community actually stands.</h1>
     <p style="font-size:15px;line-height:1.6;color:var(--body);max-width:520px">
       Vote on short statements, watch opinion clusters emerge.
       No threads, no replies — just signal.
@@ -61,6 +61,8 @@
   {% endif %}
 
 {% else %}
+
+  <h1 class="sr-only">Your consultations</h1>
 
   {% if active_joined %}
   <section aria-label="Active consultations">

--- a/v2/templates/home.html
+++ b/v2/templates/home.html
@@ -6,7 +6,7 @@
   <div style="margin-bottom:1.25rem;padding:10px 14px;border:1px solid var(--hairline);border-radius:8px;background:var(--surface);font-size:13px;color:var(--muted);line-height:1.6">
     Prototype in active development — things may change.
     <a href="https://github.com/lgelauff/wiki-polis/issues/new"
-       target="_blank" rel="noopener" style="color:var(--pass)">Open an issue</a> if you find a bug.
+       target="_blank" rel="noopener" style="color:var(--pass)">Open an issue<span class="sr-only"> (opens in a new tab)</span></a> if you find a bug.
   </div>
 
 {% if not username %}

--- a/v2/templates/reveal.html
+++ b/v2/templates/reveal.html
@@ -31,7 +31,7 @@
         <div class="reveal-identity-label">pseudonym</div>
         <div class="reveal-identity-value">{{ participation.pseudonym }}</div>
       </div>
-      <div class="reveal-identity-sep">↔</div>
+      <div class="reveal-identity-sep" aria-hidden="true">↔</div>
       <div class="reveal-identity-col">
         <div class="reveal-identity-label">wikimedia username</div>
         <div class="reveal-identity-value">{{ participation.public_username }}</div>
@@ -116,7 +116,7 @@
         <div class="reveal-identity-label">pseudonym</div>
         <div class="reveal-identity-value">{{ participation.pseudonym }}</div>
       </div>
-      <div class="reveal-identity-sep">↔</div>
+      <div class="reveal-identity-sep" aria-hidden="true">↔</div>
       <div class="reveal-identity-col">
         <div class="reveal-identity-label">wikimedia username</div>
         <div class="reveal-identity-value">{{ username }}</div>

--- a/v2/tests/test_a11y_markup.py
+++ b/v2/tests/test_a11y_markup.py
@@ -1,0 +1,113 @@
+"""Rendered-markup regression guards for the accessibility work in PR #150.
+
+These assert that the a11y affordances are actually present in the served HTML,
+so a future template edit that drops an aria hook or breaks the
+tab `aria-controls` -> panel `id` coupling fails CI instead of silently
+regressing (the rest of the suite only proves templates still render).
+"""
+import re
+
+import pytest
+
+from db import Conversation, Participation, db
+
+
+@pytest.fixture
+def conv(app):
+    c = Conversation(
+        slug='test-conv', polis_id='abc1234567',
+        title='Test Conversation', active=True, access_policy='public',
+    )
+    db.session.add(c)
+    db.session.commit()
+    return c
+
+
+@pytest.fixture
+def participation(app, participant, conv):
+    p = Participation(
+        participant_id=participant.id,
+        conversation_id=conv.id,
+        pseudonym='happy-fox',
+    )
+    db.session.add(p)
+    db.session.commit()
+    return p
+
+
+# ── Global landmarks (base.html) ───────────────────────────────────────────────
+
+def test_skip_link_and_main_landmark(client, conv):
+    """Every page exposes a skip link targeting a focusable main landmark (2.4.1)."""
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert b'class="skip-link" href="#main"' in resp.data
+    assert b'<main id="main" tabindex="-1">' in resp.data
+
+
+# ── Page headings (1.3.1 / 2.4.6) ──────────────────────────────────────────────
+
+def test_home_has_h1_logged_out(client, conv):
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert b'<h1' in resp.data
+
+
+def test_home_has_h1_logged_in(auth_client, conv):
+    resp = auth_client.get('/')
+    assert resp.status_code == 200
+    assert b'<h1' in resp.data
+
+
+def test_conversation_has_h1_with_title(auth_client, conv, participation):
+    conv.phase_submission = True
+    db.session.commit()
+    resp = auth_client.get('/c/test-conv')
+    assert resp.status_code == 200
+    assert re.search(rb'<h1[^>]*>\s*Test Conversation\s*</h1>', resp.data)
+
+
+# ── Name/role/value affordances (4.1.2 / 1.3.1) ────────────────────────────────
+
+def test_composer_textareas_have_accessible_names(auth_client, conv, participation):
+    conv.phase_submission = True
+    db.session.commit()
+    resp = auth_client.get('/c/test-conv')
+    assert resp.status_code == 200
+    assert b'aria-labelledby="composer-suggest-title"' in resp.data
+    assert b'aria-labelledby="composer-newstmt-title"' in resp.data
+
+
+def test_progressbar_has_static_valuenow(auth_client, conv, participation):
+    """The vote progressbar must carry aria-valuenow before JS runs (m2)."""
+    conv.phase_submission = True
+    db.session.commit()
+    resp = auth_client.get('/c/test-conv')
+    assert resp.status_code == 200
+    bar = re.search(rb'role="progressbar"[^>]*>', resp.data)
+    assert bar, 'progressbar not rendered'
+    assert b'aria-valuenow=' in bar.group(0)
+
+
+# ── The high-value coupling guard ──────────────────────────────────────────────
+
+def test_tab_aria_controls_match_panel_ids(auth_client, conv, participation):
+    """Each tab's aria-controls must point at a rendered panel id.
+
+    A future panel-id rename would otherwise leave activate() selecting nothing
+    while still flipping aria-selected — a silent break the render-only suite
+    would never catch.
+    """
+    conv.phase_submission = True          # -> 'vote' tab
+    conv.phase_argument_mapping = True     # -> 'arguments' tab (no Polis network)
+    db.session.commit()
+    resp = auth_client.get('/c/test-conv')
+    assert resp.status_code == 200
+    html = resp.data.decode()
+
+    # Pull aria-controls only off elements that are role="tab".
+    tab_controls = re.findall(r'role="tab"[^>]*aria-controls="([^"]+)"', html)
+    assert len(tab_controls) >= 2, f'expected a multi-tab tablist, got {tab_controls}'
+    for panel_id in tab_controls:
+        assert f'id="{panel_id}"' in html, \
+            f'tab aria-controls="{panel_id}" has no matching panel id'


### PR DESCRIPTION
Full WCAG 2.1/2.2 AA audit of the participant-facing front (`base`, `home`, `conversation`, `accept`, `reveal`, `style.css`). This PR fixes every finding. One commit per finding for easy review; no behaviour or visual layout changes beyond the colour-contrast adjustments.

## What's fixed

**Serious**
- **Statement announcement** — the next statement now reads out to screen readers (sr-only `aria-live` region; focus flow unchanged). *4.1.3*
- **Argument toggles** — "most important" buttons now expose `aria-pressed` + a state-dependent label. *4.1.2*

**Moderate**
- **Composer labels** — the four contribution textareas get accessible names via `aria-labelledby`. *1.3.1 / 3.3.2 / 4.1.2*
- **Error/confirmation alerts** — `#conv-error`, the Phase-6 vote badge, and argument-vote rejections are now announced. *4.1.3*
- **Colour contrast** — darkened `--muted`, `--agree`, `--disagree`, `--spot` to clear 4.5:1 on the surfaces they render on. *1.4.3*
- **Focus ring** — restored a visible keyboard focus indicator on the composer textareas. *2.4.7 / 2.4.11*
- **Reduced motion** — `prefers-reduced-motion` now neutralises all transitions/animations and the JS smooth-scroll. *2.3.3 / 2.2.2*
- **Page headings** — `home` and `conversation` now have an `<h1>`. *1.3.1 / 2.4.6*

**Minor**
- Skip-to-content link *(2.4.1)*; tablist `aria-controls` + roving tabindex and a `role="progressbar"` vote bar *(4.1.2 / 1.3.1)*; decorative `↔` hidden; "(opens in a new tab)" cues on external links *(3.2.5)*; ≥24px hit area on the toast-close and reroll buttons *(2.5.8)*.

## Not in this PR
`intro_text` / `outro_text` render organizer HTML with `|safe`, which can break heading order or add unlabelled controls. That's a content-governance/validation concern rather than a code bug — flagged for a follow-up.

## Testing
- Full suite green (`238 passed`).
- Ran the app locally against the dev stack; verified the served markup.
- **Needs a manual pass** (not unit-testable): screen-reader + keyboard run for the live-region announcements, toggle state, focus rings, and skip link; and a visual check of the deepened `--spot` amber.