### PR TITLE
docs/fix: argument state machine + featured-statement guards

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -1105,12 +1105,12 @@ def admin_statement_moderate(conv_id, tid):
     mod  = request.form.get('mod', type=int)
     if mod not in (-1, 0, 1):
         abort(400)
-    if mod in (-1, 0):
+    if mod == -1:
         is_featured = FeaturedStatement.query.filter_by(
             conversation_id=conv_id, polis_statement_id=tid).first() is not None
         if is_featured and conv.phase_argument_mapping:
             featured_count = FeaturedStatement.query.filter_by(
-                conversation_id=conv_id).count()
+                conversation_id=conv_id).with_for_update().count()
             if featured_count <= 1:
                 flash(
                     'Cannot hide the last featured statement while argument mapping is active. Disable the argument mapping phase first.',
@@ -1355,7 +1355,7 @@ def admin_featured_remove(conv_id, fs_id):
     fs = FeaturedStatement.query.filter_by(
         id=fs_id, conversation_id=conv_id).first_or_404()
     if conv.phase_argument_mapping:
-        remaining = FeaturedStatement.query.filter_by(conversation_id=conv_id).count()
+        remaining = FeaturedStatement.query.filter_by(conversation_id=conv_id).with_for_update().count()
         if remaining <= 1:
             flash('Cannot remove the last featured statement while argument mapping is active. Disable the argument mapping phase first.', 'error')
             return redirect(url_for('admin.admin_conversation_featured', conv_id=conv_id))

--- a/v2/app.py
+++ b/v2/app.py
@@ -828,6 +828,14 @@ def admin_conversation_close(conv_id):
 @admin_required
 def admin_conversation_phases(conv_id):
     conv = Conversation.query.get_or_404(conv_id)
+    enabling_arg_mapping = (bool(request.form.get('phase_argument_mapping'))
+                            and not conv.phase_argument_mapping)
+    if enabling_arg_mapping:
+        featured_count = FeaturedStatement.query.filter_by(conversation_id=conv_id).count()
+        if featured_count == 0:
+            flash('Cannot enable argument mapping — add at least one featured statement first.', 'error')
+            return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
+
     conv.phase_submission       = bool(request.form.get('phase_submission'))
     conv.phase_personal_results = bool(request.form.get('phase_personal_results'))
     conv.phase_argument_mapping = bool(request.form.get('phase_argument_mapping'))

--- a/v2/app.py
+++ b/v2/app.py
@@ -1113,7 +1113,7 @@ def admin_statement_moderate(conv_id, tid):
     mod  = request.form.get('mod', type=int)
     if mod not in (-1, 0, 1):
         abort(400)
-    if mod == -1:
+    if mod in (-1, 0):
         is_featured = FeaturedStatement.query.filter_by(
             conversation_id=conv_id, polis_statement_id=tid).first() is not None
         if is_featured and conv.phase_argument_mapping:
@@ -1125,7 +1125,7 @@ def admin_statement_moderate(conv_id, tid):
                 conversation_id=conv_id).count()
             if featured_count <= 1:
                 flash(
-                    'Cannot hide the last featured statement while argument mapping is active. Disable the argument mapping phase first.',
+                    'Cannot hide or move the last featured statement to pending while argument mapping is active. Disable the argument mapping phase first.',
                     'error'
                 )
                 return redirect(url_for('admin.admin_conversation_statements', conv_id=conv_id))

--- a/v2/app.py
+++ b/v2/app.py
@@ -1109,8 +1109,12 @@ def admin_statement_moderate(conv_id, tid):
         is_featured = FeaturedStatement.query.filter_by(
             conversation_id=conv_id, polis_statement_id=tid).first() is not None
         if is_featured and conv.phase_argument_mapping:
+            # Best-effort check: the mutation here is a Polis API call, not a
+            # DB write, so FOR UPDATE would be released before the call anyway.
+            # The strong DB-level invariant is enforced by admin_featured_remove,
+            # which does lock correctly before db.session.commit().
             featured_count = FeaturedStatement.query.filter_by(
-                conversation_id=conv_id).with_for_update().count()
+                conversation_id=conv_id).count()
             if featured_count <= 1:
                 flash(
                     'Cannot hide the last featured statement while argument mapping is active. Disable the argument mapping phase first.',

--- a/v2/spec_functional-design.md
+++ b/v2/spec_functional-design.md
@@ -186,6 +186,77 @@ There are no replies to arguments. No threading. Arguments are sorted by usefuln
 
 Moderators can hide arguments that are off-topic, abusive, or redundant.
 
+### State machine — current implementation
+
+The argument phase has two independent per-side state machines (one for pro, one for con) that gate access to a shared voting layer.
+
+#### Per-side contribute states
+
+Each side (pro, con) tracks the participant's contribution independently.
+
+**States:**
+
+- **idle** — no action taken; contribute affordance visible. No DB record.
+- **composing** — textarea open. Client-only; no DB state. Navigating away returns to `idle`.
+- **submitted** — participant submitted an argument for this side. `Argument` row exists for this participant + featured statement + side.
+- **skipped** — participant declined to contribute. `ArgumentSideState.skipped = True`.
+
+**Transitions:**
+
+| From | Event | To |
+|---|---|---|
+| `idle` | click affordance | `composing` |
+| `composing` | cancel / close | `idle` |
+| `composing` | submit (valid body, ≤ 280 chars) | `submitted` |
+| `idle` | click "Nothing to add" | `skipped` |
+| `composing` | click "Nothing to add" | `skipped` |
+| `skipped` | click "change my mind" | `idle` (client-only — see note) |
+
+> **Bug:** "change my mind" resets the UI to `idle` client-side but there is no server route to clear `ArgumentSideState.skipped`. On page reload, the server re-renders the skipped state from the DB, undoing the client reset.
+
+#### Cross-side gate
+
+Voting only opens once the participant has reached a terminal state (`submitted` or `skipped`) on **both** sides.
+
+| Pro state | Con state | Gate |
+|---|---|---|
+| `idle` or `composing` | any | `one-side-open` — voting locked |
+| `submitted` or `skipped` | `idle` or `composing` | `one-side-open` — voting locked |
+| `submitted` or `skipped` | `submitted` or `skipped` | `both-gated` — voting unlocks (if enough arguments exist) |
+
+Voting also requires the argument pool on each side to exceed K (the configured importance-vote quota, default 2) before that side's checkboxes activate.
+
+#### Argument voting states
+
+Once `both-gated`, each argument card on each side is in one of three states. The state is driven by the live count of votes the participant has cast on that side relative to K.
+
+**States (per argument card, per side):**
+
+- **vote-eligible** — card can be voted on (not own, not hidden, count < K)
+- **vote-picked** — participant has voted for this argument; `ArgumentVote` row exists
+- **vote-cap-reached** — participant has cast K votes on this side; card is eligible but blocked
+
+**Transitions:**
+
+| From | Event | To | Side-effect on other cards |
+|---|---|---|---|
+| `vote-eligible` | vote | `vote-picked` | if this was the K-th vote: all remaining `vote-eligible` → `vote-cap-reached` |
+| `vote-picked` | unvote (count was < K) | `vote-eligible` | no change to others |
+| `vote-picked` | unvote (count was = K) | `vote-eligible` | all `vote-cap-reached` → `vote-eligible` |
+| `vote-cap-reached` | — | — | no direct action; unvoting a `vote-picked` card is required first |
+
+The dial for a given side therefore moves: `vote-eligible ↔ vote-picked ↔ vote-cap-reached`, where the cap boundary shifts every time a vote is cast or retracted.
+
+#### Navigation between featured statements
+
+Participants can move to any featured statement at any time, regardless of their contribute state on the current one. Navigation does not require completing or skipping either side first.
+
+**Intended design:** Each featured statement panel has a **Previous / Next** button pair at the bottom. Previous is disabled on the first statement; Next is disabled on the last. No statement counter is shown between the buttons. The TOC remains available for non-linear jumping but is not the primary navigation affordance.
+
+**Current implementation gap:** The only navigation affordance is the TOC at the top of the panel list. There are no prev/next buttons. Participants have no obvious way to move forward without scrolling back up to the TOC. This needs to be implemented.
+
+**Composing state across navigation:** Navigating away from a panel while in `composing` silently preserves the open composer and its text — the panel is hidden but not reset. On returning, the composer is still open. This behaviour is incidental; no warning or indicator is shown when leaving an unfinished composer.
+
 ---
 
 ## Admin panel

--- a/v2/spec_functional-design.md
+++ b/v2/spec_functional-design.md
@@ -46,6 +46,16 @@ A statement is an atomic claim: one idea, one sentence. Examples: *"Wikipedia's 
 
 Anyone who has joined a conversation can submit a statement. Statements go into a moderation queue before appearing to other participants. Moderators (scoped to their conversation) and admins approve or hide them.
 
+Statement moderation maps to three Polis `mod` values:
+
+| `mod` | State | Visible to participants |
+|---|---|---|
+| `1` | Approved | Yes — appears in the vote queue |
+| `0` | Pending | No — back in the moderation queue (default for new statements) |
+| `-1` | Hidden | No — removed from view; effectively rejected |
+
+Moving an approved statement to **pending** (`mod=0`) or **hidden** (`mod=-1`) removes it from participants' vote queues. Both actions are equivalent from the argument mapping perspective — if the statement is the last featured statement and argument mapping is active, both are blocked.
+
 Statements are presented to participants one at a time, in an order chosen to maximise the information gained from each vote and reduce order effects. *(pending — routing not yet implemented)*
 
 ---

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -86,7 +86,7 @@
       </label>
       <button type="submit" class="btn-small">save</button>
     </form>
-    {% if conversation.phase_submission or conversation.phase_argument_mapping %}
+    {% if conversation.phase_informed_voting and (conversation.phase_submission or conversation.phase_argument_mapping) %}
     <p class="muted" style="margin-top:.5rem;font-size:13px">
       ⚠️ Informed voting is most meaningful after argument mapping is complete.
       Statement submission and/or argument mapping are currently still on.

--- a/v2/templates/admin_featured.html
+++ b/v2/templates/admin_featured.html
@@ -14,14 +14,13 @@
     argument for each, then vote on the most important arguments submitted by others.
   </p>
 
-  {% if phase_active %}
-  <div style="background:#fffbeb;border:1px solid #fcd34d;color:#78350f;padding:.75rem 1rem;border-radius:6px;font-size:13px;margin-bottom:1.5rem">
-    <strong>Argument mapping phase is active.</strong>
-    Participants may have already submitted arguments for these statements.
-    Removing a statement will permanently delete all associated arguments and votes.
-    To remove the last featured statement, disable the argument mapping phase first.
+  {% with messages = get_flashed_messages(with_categories=true) %}
+  {% for category, message in messages %}
+  <div style="background:{% if category == 'error' %}#fef2f2;border-color:#fca5a5;color:#991b1b{% else %}#f0fdf4;border-color:#86efac;color:#166534{% endif %};border:1px solid;padding:.75rem 1rem;border-radius:6px;font-size:13px;margin-bottom:1.5rem">
+    {{ message }}
   </div>
-  {% endif %}
+  {% endfor %}
+  {% endwith %}
 
   <!-- ── Confirmed ──────────────────────────────────────── -->
   <h3 class="section-heading">Confirmed ({{ confirmed | length }})</h3>
@@ -69,17 +68,7 @@
                 action="{{ url_for('admin.admin_featured_remove', conv_id=conversation.id, fs_id=fs.id) }}"
                 style="display:inline">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            {% set is_last = (confirmed | length == 1) %}
-            {% if phase_active and is_last %}
-            <button type="button" class="btn-small btn-danger" disabled
-                    title="Cannot remove the last featured statement while argument mapping is active — disable the phase first.">remove</button>
-            {% elif phase_active %}
-            <button type="submit" class="btn-small btn-danger"
-                    onclick="return confirm('The argument mapping phase is active. Removing this statement will permanently delete all its arguments and votes. Continue?')">remove</button>
-            {% else %}
-            <button type="submit" class="btn-small btn-danger"
-                    onclick="return confirm('Remove this featured statement? All arguments and votes for it will be deleted.')">remove</button>
-            {% endif %}
+            <button type="submit" class="btn-small btn-danger">remove</button>
           </form>
         </td>
       </tr>

--- a/v2/templates/admin_statements.html
+++ b/v2/templates/admin_statements.html
@@ -9,13 +9,13 @@
   </p>
 
 
-  {% if phase_active and featured_tids %}
-  <div style="background:#fffbeb;border:1px solid #fcd34d;color:#78350f;padding:.75rem 1rem;border-radius:6px;font-size:13px;margin-bottom:1.5rem">
-    <strong>Argument mapping phase is active.</strong>
-    {{ featured_tids | length }} statement(s) are featured for argument mapping (marked ★ below).
-    To hide or move the last featured statement, disable the argument mapping phase first.
+  {% with messages = get_flashed_messages(with_categories=true) %}
+  {% for category, message in messages %}
+  <div style="background:{% if category == 'error' %}#fef2f2;border-color:#fca5a5;color:#991b1b{% else %}#f0fdf4;border-color:#86efac;color:#166534{% endif %};border:1px solid;padding:.75rem 1rem;border-radius:6px;font-size:13px;margin-bottom:1.5rem">
+    {{ message }}
   </div>
-  {% endif %}
+  {% endfor %}
+  {% endwith %}
 
   <!-- ── Add seed statement ──────────────────────────── -->
   <h3 class="section-heading">Add seed statement</h3>
@@ -134,15 +134,7 @@
                 action="{{ url_for('admin.admin_statement_moderate', conv_id=conversation.id, tid=s.tid) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="mod" value="-1">
-            {% if is_last_featured and phase_active %}
-            <button type="button" class="btn-small btn-danger" disabled
-                    title="Cannot hide the last featured statement while argument mapping is active — disable the phase first.">hide</button>
-            {% elif is_featured and phase_active %}
-            <button type="submit" class="btn-small btn-danger"
-                    onclick="return confirm('This is a featured statement and argument mapping is active. Hiding it will remove it from the argument view for participants. Continue?')">hide</button>
-            {% else %}
             <button type="submit" class="btn-small btn-danger">hide</button>
-            {% endif %}
           </form>
         </td>
       </tr>
@@ -186,29 +178,13 @@
                 action="{{ url_for('admin.admin_statement_moderate', conv_id=conversation.id, tid=s.tid) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="mod" value="-1">
-            {% if is_last_featured and phase_active %}
-            <button type="button" class="btn-small btn-danger" disabled
-                    title="Cannot hide the last featured statement while argument mapping is active — disable the phase first.">hide</button>
-            {% elif is_featured and phase_active %}
-            <button type="submit" class="btn-small btn-danger"
-                    onclick="return confirm('This is a featured statement and argument mapping is active. Hiding it will remove it from the argument view for participants. Continue?')">hide</button>
-            {% else %}
             <button type="submit" class="btn-small btn-danger">hide</button>
-            {% endif %}
           </form>
           <form method="post" style="display:inline"
                 action="{{ url_for('admin.admin_statement_moderate', conv_id=conversation.id, tid=s.tid) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="mod" value="0">
-            {% if is_last_featured and phase_active %}
-            <button type="button" class="btn-small" disabled
-                    title="Cannot move the last featured statement to pending while argument mapping is active — disable the phase first.">pending</button>
-            {% elif is_featured and phase_active %}
-            <button type="submit" class="btn-small"
-                    onclick="return confirm('This is a featured statement and argument mapping is active. Moving it to pending will remove it from the argument view for participants. Continue?')">pending</button>
-            {% else %}
             <button type="submit" class="btn-small">pending</button>
-            {% endif %}
           </form>
         </td>
       </tr>


### PR DESCRIPTION
## Summary

### Docs (#77)
- Documents the argument phase state machine in `v2/spec_functional-design.md` — per-side contribute states, cross-side gate, argument voting states (K-dial model)
- Documents Polis `mod` values (`1` = approved, `0` = pending, `-1` = hidden) and their effect on argument mapping
- Flags the change-my-mind un-skip bug and missing prev/next navigation (tracked in #151)

### Featured-statement guards
- Block hiding or moving to pending the **last featured statement** while argument mapping is active — flash error instead of a disabled button
- Block **enabling argument mapping** when there are zero featured statements
- Replace static warning banners and disabled buttons with normal buttons + server-side flash errors
- Add `error`/`success` flash rendering to `admin_statements.html` and `admin_featured.html`

### UX fixes
- Informed-voting warning only shows when informed voting is actually on (not whenever argument mapping is active)
- Slug validation error now shows the format rule inline instead of a bare 400 (#68)

### Verified on staging
- Slug error message ✅
- Last-featured-statement guard (hide, pending, remove) ✅
- Flash errors visible on both admin pages ✅
- Informed-voting warning scoped correctly ✅

Closes #68, closes #77

## Test plan
- [x] Create conversation with invalid slug → inline error message
- [x] Enable argument mapping with 0 featured statements → blocked with flash error
- [x] With 1 featured statement + argument mapping on: hide → flash error; pending → flash error; remove → flash error
- [x] With 2+ featured statements: all actions go through normally
- [x] Enable informed voting without argument mapping on → no spurious warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)