### PR TITLE
feat(admin): guided "Move on" phase-transition box (#156)

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -182,10 +182,24 @@ PHASE_TRANSITIONS = {
     ]},
 }
 
-# Machine-verifiable preconditions: name → predicate(conv) -> bool.
+# Recommended number of featured statements. Advisory only (Phase 6 needs ≥1); the
+# ideal count depends on topic complexity — surfaced to the organizer as guidance.
+# TODO: make this per-conversation configurable when complexity tiers land.
+_RECOMMENDED_FEATURED = 15
+
+
+def _check_confirmed_featured(conv):
+    """Machine check for the featured-statement precondition. Returns (met, note):
+    met is True when at least one is confirmed (the hard requirement); note shows the
+    selected count against the recommended target so the organizer can judge coverage."""
+    n = (FeaturedStatement.query
+         .filter_by(conversation_id=conv.id, confirmed_by_admin=True).count())
+    return n > 0, f'{n} selected, {_RECOMMENDED_FEATURED} recommended'
+
+
+# Machine-verifiable preconditions: name → check(conv) -> (met: bool, note: str|None).
 _PRECONDITION_CHECKS = {
-    'has_confirmed_featured': lambda conv: FeaturedStatement.query.filter_by(
-        conversation_id=conv.id, confirmed_by_admin=True).count() > 0,
+    'has_confirmed_featured': _check_confirmed_featured,
 }
 
 
@@ -204,10 +218,10 @@ def _transition_context(conv):
     cfg = PHASE_TRANSITIONS.get(nxt['key'], {})
     preconds = []
     for p in cfg.get('preconditions', []):
-        met = None
+        met, note = None, None
         if p.get('check'):
-            met = bool(_PRECONDITION_CHECKS[p['check']](conv))
-        preconds.append({**p, 'met': met})
+            met, note = _PRECONDITION_CHECKS[p['check']](conv)
+        preconds.append({**p, 'met': met, 'note': note})
     # Consequence text — what opens, what closes, irreversibility.
     consequence = {
         'opens':  nxt['effect'],

--- a/v2/app.py
+++ b/v2/app.py
@@ -139,6 +139,93 @@ def _advance_confirm_message(conv) -> str:
     return ' '.join(parts)
 
 
+# Guided phase transitions (#156). Keyed by the TARGET stage. Each transition lists
+# the preconditions the organizer must affirm (one checkbox each) before the "Move on"
+# button enables. `check` (optional) names a machine-verifiable predicate, shown met/
+# unmet and enforced server-side. Behavioural flags: runs_phase6_init, auto_close,
+# show_pause.
+PHASE_TRANSITIONS = {
+    'submission': {'preconditions': [
+        {'id': 'seeds',       'label': 'Enough seed statements added (the voting loop isn’t empty)'},
+        {'id': 'intro',       'label': 'Intro text / topic framing finalized'},
+        {'id': 'access',      'label': 'Access policy (public / invite-only) set correctly'},
+        {'id': 'modpolicy',   'label': 'Moderation policy decided and configured'},
+        {'id': 'mods',        'label': 'Moderators appointed for this conversation'},
+        {'id': 'live',        'label': 'I understand participants can submit and vote immediately'},
+    ]},
+    'featured_selection': {'preconditions': [
+        {'id': 'no_submit',   'label': 'Participants no longer expect to submit new statements'},
+        {'id': 'no_agree',    'label': 'Participants no longer expect to express agreement (voting closes)'},
+        {'id': 'spectrum',    'label': 'The current statements cover the full spectrum of my theme'},
+        {'id': 'ready_curate', 'label': 'I’m ready to select featured statements as a representative set'},
+    ]},
+    'argument_mapping': {'preconditions': [
+        {'id': 'all_featured', 'label': 'I have selected all featured statements as a representative set',
+         'check': 'has_confirmed_featured'},
+        {'id': 'no_more_feat', 'label': 'I understand no further featured statements can be added later'},
+        {'id': 'no_more_stmt', 'label': 'I understand participants cannot add further statements later'},
+        {'id': 'args_visible', 'label': 'I understand featured statements become visible and participants add/rate arguments'},
+    ]},
+    'informed_voting': {'runs_phase6_init': True, 'show_pause': True, 'preconditions': [
+        {'id': 'args_done',   'label': 'We’ve collected all the necessary arguments to move on'},
+        {'id': 'args_modded', 'label': 'I’ve reviewed all arguments and removed those against moderation expectations'},
+        {'id': 'reinvite',    'label': 'I’m ready to invite participants back for the informed voting phase'},
+        {'id': 'newcomers',   'label': 'I understand participants who didn’t take part earlier can join this round',
+         'check': 'has_confirmed_featured'},
+    ]},
+    'public_results': {'auto_close': True, 'preconditions': [
+        {'id': 'ran_long',    'label': 'The informed voting round has run long enough / had enough participation'},
+        {'id': 'public',      'label': 'I understand full aggregate results become public to everyone'},
+        {'id': 'no_identity', 'label': 'I understand results won’t expose individual identities (aggregate only)'},
+        {'id': 'disclosure',  'label': 'I understand participants can now begin disclosing their identities'},
+        {'id': 'inform',      'label': 'I’m ready to inform participants of the results and that they may disclose'},
+        {'id': 'final',       'label': 'I understand this is the final phase and closes the consultation'},
+    ]},
+}
+
+# Machine-verifiable preconditions: name → predicate(conv) -> bool.
+_PRECONDITION_CHECKS = {
+    'has_confirmed_featured': lambda conv: FeaturedStatement.query.filter_by(
+        conversation_id=conv.id, confirmed_by_admin=True).count() > 0,
+}
+
+
+def _transition_context(conv):
+    """Context for the guided 'Move on' box and the route. Returns None when there is
+    no forward move (non-linear state or already final). Otherwise a dict with the
+    target stage, the source stage, the consequence text, and the preconditions with
+    each machine `check` evaluated (met/unmet)."""
+    if not _is_linear_phase_state(conv):
+        return None
+    target = _advance_target_index(conv)
+    if target is None:
+        return None
+    cur = PHASE_SEQUENCE[_current_stage_index(conv)]
+    nxt = PHASE_SEQUENCE[target]
+    cfg = PHASE_TRANSITIONS.get(nxt['key'], {})
+    preconds = []
+    for p in cfg.get('preconditions', []):
+        met = None
+        if p.get('check'):
+            met = bool(_PRECONDITION_CHECKS[p['check']](conv))
+        preconds.append({**p, 'met': met})
+    # Consequence text — what opens, what closes, irreversibility.
+    consequence = {
+        'opens':  nxt['effect'],
+        'closes': cur['effect'] if cur['flag'] else None,
+        'auto_close': bool(cfg.get('auto_close')),
+    }
+    return {
+        'target': nxt,
+        'source': cur,
+        'preconditions': preconds,
+        'consequence': consequence,
+        'runs_phase6_init': bool(cfg.get('runs_phase6_init')),
+        'show_pause': bool(cfg.get('show_pause')),
+        'auto_close': bool(cfg.get('auto_close')),
+    }
+
+
 csrf    = CSRFProtect()
 # No global default — limits applied per endpoint only.
 # Toolforge provides TOOL_REDIS_URI; production startup validates Redis isolation.
@@ -807,7 +894,7 @@ def admin_conversation_detail(conv_id):
                            current_stage_index=_current_stage_index(conv),
                            linear_phase_state=_is_linear_phase_state(conv),
                            advance_target_index=_advance_target_index(conv),
-                           advance_confirm=_advance_confirm_message(conv))
+                           transition=_transition_context(conv))
 
 @admin_bp.post('/admin/conversations/new')
 @login_required
@@ -932,41 +1019,62 @@ def admin_conversation_phases(conv_id):
 
 @admin_bp.post('/admin/conversations/<int:conv_id>/phase/advance')
 @login_required
-@admin_required                      # simple-mode forward move — global admin (later: organizer)
+@admin_required                      # guided forward move — global admin (later: organizer)
 def admin_conversation_advance(conv_id):
-    """Simple-mode forward move through PHASE_SEQUENCE. Exclusive: the target
-    stage's flag is turned on and the current stage's flag turned off.
+    """Guided 'Move on' phase transition (#156). The organizer must affirm every
+    precondition (one checkbox each) before this is accepted; the route re-enforces
+    that server-side and re-runs machine-checkable preconditions.
 
-    Active conversation → one step forward. Closed conversation → jump straight
-    to the final stage (public results). Going backward or fixing a custom
-    (non-linear) flag combination is an advanced-mode, global-admin action — so
-    this route refuses to operate on a non-linear state and points there.
+    Exclusive: the target stage's flag is set and the current stage's flag cleared.
+    Active conversation → one step forward; closed → jump to public results. Backward
+    / custom-state repair is an advanced-mode action, so a non-linear state is refused.
+    The Informed-voting transition runs Phase 6 init atomically; the Public-results
+    transition auto-closes the conversation (starting the identity-reveal window).
     """
     conv = Conversation.query.get_or_404(conv_id)
+    redirect_to = redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
 
-    # Backward / custom-state repair lives in advanced mode. Refuse to advance
-    # from a non-linear state rather than perpetuate it (the UI hides the button
-    # here, but a stale page or direct POST must not silently corrupt state).
-    if not _is_linear_phase_state(conv):
-        flash('Phases are in a custom state — use Advanced controls to adjust.', 'error')
-        return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
+    ctx = _transition_context(conv)
+    if ctx is None:
+        if not _is_linear_phase_state(conv):
+            flash('Phases are in a custom state — use Advanced controls to adjust.', 'error')
+        else:
+            flash('Already at the final phase (public results).', 'error')
+        return redirect_to
 
-    i = _current_stage_index(conv)
-    target = _advance_target_index(conv)
-    if target is None:
-        flash('Already at the final phase (public results).', 'error')
-        return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
+    # Server-side enforcement of the readiness checklist (the UI disables the button
+    # until all are ticked; a stale page or direct POST must not bypass it).
+    for p in ctx['preconditions']:
+        if request.form.get(p['id']) != 'on':
+            flash('Confirm every readiness check before moving on.', 'error')
+            return redirect_to
+        if p.get('met') is False:                 # machine-checkable and currently unmet
+            flash('A readiness condition is not met yet — fix it before moving on.', 'error')
+            return redirect_to
 
-    cur, nxt = PHASE_SEQUENCE[i], PHASE_SEQUENCE[target]
-    if cur['flag']:                  # preparation has flag=None
+    cur, nxt = ctx['source'], ctx['target']
+    if cur['flag']:                               # preparation has flag=None
         setattr(conv, cur['flag'], False)
     setattr(conv, nxt['flag'], True)
-    db.session.commit()
+
+    if ctx['runs_phase6_init']:
+        ok, msg = _init_phase6(conv)              # assigns ids; does not commit
+        if not ok:
+            db.session.rollback()                 # flag flip discarded too
+            flash(msg, 'error')
+            return redirect_to
+
+    if ctx['auto_close'] and conv.closed_at is None:
+        conv.active    = False
+        conv.paused    = False
+        conv.closed_at = datetime.now(timezone.utc)
+
+    db.session.commit()                           # flag flip (+ phase6 ids / close) atomic
 
     if not _sync_vis_type(conv):
-        flash('Phase advanced, but updating results visibility in Polis failed.', 'error')
+        flash('Phase moved, but updating results visibility in Polis failed.', 'error')
     flash(f'Moved to: {nxt["label"]}.', 'success')
-    return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
+    return redirect_to
 
 
 @admin_bp.post('/admin/conversations/<int:conv_id>/phase6/init')
@@ -997,72 +1105,65 @@ def admin_phase6_init(conv_id):
         flash('Phase 6 already initialised.', 'error')
         return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
 
-    statements = (FeaturedStatement.query
-                  .filter_by(conversation_id=conv_id, confirmed_by_admin=True)
-                  .all())
-    if not statements:
-        flash('No confirmed featured statements — confirm at least one before initialising Phase 6.', 'error')
+    ok, msg = _init_phase6(conv)
+    if not ok:
+        flash(msg, 'error')
         return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
-
-    client = _polis_server_client()
-    try:
-        p6_conv_id = client.create_conversation(
-            f'{conv.title} — Informed Voting',
-            strict_moderation=True,
-        )
-    except PolisServerError as exc:
-        current_app.logger.error('Phase 6 conversation creation failed: %s', exc)
-        flash(f'Could not create Phase 6 Polis conversation: {exc}', 'error')
-        return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
-
-    # Seed each confirmed featured statement and collect tids.
-    # All-or-nothing: if any seed fails, do not commit — log the orphaned Polis
-    # conversation ID for manual cleanup and let the admin retry cleanly.
-    seeded: list[tuple[FeaturedStatement, int]] = []
-    for fs in statements:
-        text = fs.statement_text or ''
-        if not text:
-            current_app.logger.error(
-                'Phase 6 init: fs %s has no cached text — skipping; '
-                'abandoning Polis conversation %s', fs.id, p6_conv_id)
-            flash(
-                f'Phase 6 init failed: statement {fs.id} has no cached text. '
-                f'The orphaned Polis conversation ID has been logged. '
-                f'Fix the statement text and retry.',
-                'error',
-            )
-            return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
-        try:
-            tid = client.add_seed_return_id(p6_conv_id, text)
-            seeded.append((fs, tid))
-        except PolisServerError as exc:
-            current_app.logger.error(
-                'Phase 6 init: seed failed for fs %s: %s; '
-                'abandoning Polis conversation %s', fs.id, exc, p6_conv_id)
-            flash(
-                f'Phase 6 init failed while seeding statement {fs.id}. '
-                f'The orphaned Polis conversation ID has been logged. '
-                f'Retry initialisation.',
-                'error',
-            )
-            return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
-
-    # All seeds succeeded — write atomically.
-    for fs, tid in seeded:
-        fs.phase6_polis_statement_id = tid
-    conv.phase6_polis_conversation_id = p6_conv_id
     try:
         db.session.commit()
     except IntegrityError:
         db.session.rollback()
         flash('Phase 6 was already initialised by a concurrent request.', 'error')
         return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
-
-    flash(
-        f'Phase 6 initialised — {len(seeded)} statement(s) seeded.',
-        'success',
-    )
+    flash(msg, 'success')
     return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
+
+
+def _init_phase6(conv) -> tuple[bool, str]:
+    """Create the Phase 6 Polis conversation and seed all confirmed featured statements,
+    assigning the resulting ids onto the conversation and featured rows.
+
+    Does NOT commit — the caller commits so a flag flip plus this init are one
+    transaction. All-or-nothing: on any Polis failure no model fields are changed and
+    the orphaned remote conversation id is logged for manual cleanup. Returns
+    (ok, message).
+    """
+    statements = (FeaturedStatement.query
+                  .filter_by(conversation_id=conv.id, confirmed_by_admin=True)
+                  .all())
+    if not statements:
+        return False, 'No confirmed featured statements — confirm at least one before initialising Phase 6.'
+
+    client = _polis_server_client()
+    try:
+        p6_conv_id = client.create_conversation(
+            f'{conv.title} — Informed Voting', strict_moderation=True)
+    except PolisServerError as exc:
+        current_app.logger.error('Phase 6 conversation creation failed: %s', exc)
+        return False, f'Could not create Phase 6 Polis conversation: {exc}'
+
+    seeded: list[tuple[FeaturedStatement, int]] = []
+    for fs in statements:
+        text = fs.statement_text or ''
+        if not text:
+            current_app.logger.error(
+                'Phase 6 init: fs %s has no cached text — abandoning Polis conversation %s',
+                fs.id, p6_conv_id)
+            return False, (f'Phase 6 init failed: statement {fs.id} has no cached text. '
+                           'The orphaned Polis conversation id has been logged.')
+        try:
+            seeded.append((fs, client.add_seed_return_id(p6_conv_id, text)))
+        except PolisServerError as exc:
+            current_app.logger.error(
+                'Phase 6 init: seed failed for fs %s: %s; abandoning Polis conversation %s',
+                fs.id, exc, p6_conv_id)
+            return False, (f'Phase 6 init failed while seeding statement {fs.id}. '
+                           'The orphaned Polis conversation id has been logged.')
+
+    for fs, tid in seeded:
+        fs.phase6_polis_statement_id = tid
+    conv.phase6_polis_conversation_id = p6_conv_id
+    return True, f'Phase 6 initialised — {len(seeded)} statement(s) seeded.'
 
 
 @admin_bp.post('/admin/global-admins/add')

--- a/v2/app.py
+++ b/v2/app.py
@@ -170,8 +170,7 @@ PHASE_TRANSITIONS = {
         {'id': 'args_done',   'label': 'We’ve collected all the necessary arguments to move on'},
         {'id': 'args_modded', 'label': 'I’ve reviewed all arguments and removed those against moderation expectations'},
         {'id': 'reinvite',    'label': 'I’m ready to invite participants back for the informed voting phase'},
-        {'id': 'newcomers',   'label': 'I understand participants who didn’t take part earlier can join this round',
-         'check': 'has_confirmed_featured'},
+        {'id': 'newcomers',   'label': 'I understand participants who didn’t take part earlier can join this round'},
     ]},
     'public_results': {'auto_close': True, 'preconditions': [
         {'id': 'ran_long',    'label': 'The informed voting round has run long enough / had enough participation'},
@@ -1052,24 +1051,44 @@ def admin_conversation_advance(conv_id):
             flash('A readiness condition is not met yet — fix it before moving on.', 'error')
             return redirect_to
 
+    # Run the Phase 6 Polis I/O FIRST, before mutating conv. This keeps the network
+    # round-trips out of the open write transaction: the only DB write happens at the
+    # commit below, so a slow Polis backend never holds a row lock on the conversation.
+    created_p6 = None
+    if ctx['runs_phase6_init']:
+        if conv.phase6_polis_conversation_id:     # already initialised (advanced/concurrent)
+            flash('Phase 6 is already initialised.', 'error')
+            return redirect_to
+        ok, msg = _init_phase6(conv)              # assigns ids onto conv/featured; no commit
+        if not ok:
+            db.session.rollback()
+            flash(msg, 'error')
+            return redirect_to
+        created_p6 = conv.phase6_polis_conversation_id
+
     cur, nxt = ctx['source'], ctx['target']
     if cur['flag']:                               # preparation has flag=None
         setattr(conv, cur['flag'], False)
     setattr(conv, nxt['flag'], True)
-
-    if ctx['runs_phase6_init']:
-        ok, msg = _init_phase6(conv)              # assigns ids; does not commit
-        if not ok:
-            db.session.rollback()                 # flag flip discarded too
-            flash(msg, 'error')
-            return redirect_to
 
     if ctx['auto_close'] and conv.closed_at is None:
         conv.active    = False
         conv.paused    = False
         conv.closed_at = datetime.now(timezone.utc)
 
-    db.session.commit()                           # flag flip (+ phase6 ids / close) atomic
+    try:
+        db.session.commit()                       # flag flip (+ phase6 ids / close) atomic
+    except IntegrityError:
+        db.session.rollback()
+        # A concurrent transition won the UNIQUE race. If we created a Phase 6 Polis
+        # conversation in this request it is now orphaned — log it for manual cleanup.
+        if created_p6:
+            current_app.logger.error(
+                'Phase advance lost a concurrent race after Phase 6 init — '
+                'orphaned Polis conversation %s (conv %s)', created_p6, conv.slug)
+        flash('Could not move on — the conversation changed at the same time. '
+              'Reload and try again.', 'error')
+        return redirect_to
 
     if not _sync_vis_type(conv):
         flash('Phase moved, but updating results visibility in Polis failed.', 'error')

--- a/v2/app.py
+++ b/v2/app.py
@@ -27,7 +27,7 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_wtf.csrf import CSRFProtect, validate_csrf
 from sqlalchemy import text as _sa_text
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import joinedload
 from wtforms.validators import ValidationError
 
@@ -1098,18 +1098,36 @@ def admin_conversation_advance(conv_id):
         conv.paused    = False
         conv.closed_at = datetime.now(timezone.utc)
 
+    slug = conv.slug                              # capture before any rollback expires it
     try:
         db.session.commit()                       # flag flip (+ phase6 ids / close) atomic
     except IntegrityError:
         db.session.rollback()
-        # A concurrent transition won the UNIQUE race. If we created a Phase 6 Polis
-        # conversation in this request it is now orphaned — log it for manual cleanup.
+        # A concurrent transition won the UNIQUE race. The winner committed cleanly, so
+        # reload-and-retry resolves it. If we created a Phase 6 Polis conversation in this
+        # request it is now orphaned — log it for manual cleanup.
         if created_p6:
             current_app.logger.error(
                 'Phase advance lost a concurrent race after Phase 6 init — '
-                'orphaned Polis conversation %s (conv %s)', created_p6, conv.slug)
+                'orphaned Polis conversation %s (conv %s)', created_p6, slug)
         flash('Could not move on — the conversation changed at the same time. '
               'Reload and try again.', 'error')
+        return redirect_to
+    except SQLAlchemyError:
+        # Any other DB failure (deadlock, timeout, lost connection). Scoped to
+        # SQLAlchemyError so genuine programming errors still surface. If Phase 6 init
+        # already created a remote conversation it is orphaned — a blind retry would
+        # create a SECOND one, so warn the organizer rather than inviting a re-submit.
+        db.session.rollback()
+        if created_p6:
+            current_app.logger.error(
+                'Phase advance commit failed after Phase 6 init — '
+                'orphaned Polis conversation %s (conv %s)', created_p6, slug)
+            flash('Could not complete the move — a database error occurred, and a '
+                  'linked Polis conversation may already have been created. Do not '
+                  'simply retry; check with a site admin first.', 'error')
+        else:
+            flash('Could not move on — a database error occurred. Please try again.', 'error')
         return redirect_to
 
     if not _sync_vis_type(conv):

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -1977,6 +1977,8 @@ a { color: var(--pass); }
 
 .phase-move-submit[disabled] { opacity: .5; cursor: not-allowed; }
 
+.phase-move-hint { font-size: 12px; margin: 0 0 .5rem; }
+
 .phase-move-pause { margin-top: .75rem; }
 
 /* ── Stats grid ── */

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -1917,6 +1917,68 @@ a { color: var(--pass); }
 }
 .phase-advanced > summary:hover { color: var(--ink); }
 
+/* ── Guided "Move on" box (#156) ── */
+.phase-move-box {
+  border: 1px solid var(--hairline);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  background: var(--surface);
+  margin-top: .5rem;
+  max-width: 640px;
+}
+
+.phase-move-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  margin-bottom: .6rem;
+}
+.phase-move-from { color: var(--muted); }
+.phase-move-arrow { color: var(--spot); }
+.phase-move-to { color: var(--ink); }
+
+.phase-move-consequences {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 .9rem;
+  font-size: 13px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.phase-move-warn { color: var(--disagree); }
+
+.phase-move-checklist {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 .9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.phase-move-checklist li {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  font-size: 13px;
+}
+.phase-move-checklist label {
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
+  cursor: pointer;
+  margin: 0;
+}
+.phase-move-checklist input { margin-top: 3px; flex-shrink: 0; }
+
+.phase-check-met   { color: var(--agree); font-weight: 600; }
+.phase-check-unmet { color: var(--disagree); font-weight: 600; font-size: 12px; }
+
+.phase-move-submit[disabled] { opacity: .5; cursor: not-allowed; }
+
+.phase-move-pause { margin-top: .75rem; }
+
 /* ── Stats grid ── */
 
 .stats-grid {

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -1688,10 +1688,10 @@ a { color: var(--pass); }
 
 .btn-danger { border-color: var(--red); color: var(--red); }
 .btn-danger:hover { background: var(--red); color: white; border-color: var(--red); }
-.btn-warn { border-color: #b07800; color: #b07800; }
-.btn-warn:hover { background: #b07800; color: white; border-color: #b07800; }
-.btn-pause        { border-color: #b07800; color: #b07800; }
-.btn-pause:hover  { background: #b07800; color: white; }
+.btn-warn { border-color: var(--spot); color: var(--spot); }
+.btn-warn:hover { background: var(--spot); color: white; border-color: var(--spot); }
+.btn-pause        { border-color: var(--spot); color: var(--spot); }
+.btn-pause:hover  { background: var(--spot); color: white; }
 
 .close-warning {
   border: 1px solid #f0d060;
@@ -2633,7 +2633,7 @@ a { color: var(--pass); }
   letter-spacing: 0.06em;
   padding: 1px 5px;
   border-radius: 3px;
-  color: #b07800;
+  color: var(--spot);
   background: #fff8e1;
   border: 1px solid #ffe082;
 }

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -1974,6 +1974,7 @@ a { color: var(--pass); }
 
 .phase-check-met   { color: var(--agree); font-weight: 600; }
 .phase-check-unmet { color: var(--disagree); font-weight: 600; font-size: 12px; }
+.phase-check-note  { color: var(--muted); font-size: 12px; }
 
 .phase-move-submit[disabled] { opacity: .5; cursor: not-allowed; }
 

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -74,6 +74,28 @@
       {% endfor %}
     </ol>
 
+    {# Pause / Resume — lives here in Phases (it governs the running consultation),
+       not under Status. Global admin only; hidden once closed. #}
+    {% if is_admin and conversation.active %}
+    <div class="phase-pause-row" style="display:flex;align-items:center;gap:1rem;margin:.75rem 0 1rem">
+      <form method="post" style="display:inline"
+            action="{{ url_for('admin.admin_conversation_pause', conv_id=conversation.id) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <button type="submit"
+                class="btn-small {% if conversation.paused %}btn-approve{% else %}btn-pause{% endif %}">
+          {{ 'Resume' if conversation.paused else 'Pause' }}
+        </button>
+      </form>
+      <span class="muted" style="font-size:13px">
+        {% if conversation.paused %}
+          Paused — participants cannot vote. The identity-reveal clock has <strong>not</strong> started; resuming is possible.
+        {% else %}
+          Pause temporarily disables voting without starting the reveal timeline.
+        {% endif %}
+      </span>
+    </div>
+    {% endif %}
+
     {% if transition %}
       {% if is_admin %}
       {# Guided 'Move on' box (#156): consequences + tick-each-precondition checklist.
@@ -126,25 +148,10 @@
         </form>
 
         {% if transition.show_pause %}
-        <div class="phase-move-pause muted" style="font-size:12px">
-          {% if conversation.paused %}
-          The conversation is paused.
-          <form method="post" style="display:inline"
-                action="{{ url_for('admin.admin_conversation_pause', conv_id=conversation.id) }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="link-btn">Resume it</button>
-          </form>
-          when you’re ready to invite people back.
-          {% else %}
-          Need time to coordinate inviting people back? You can
-          <form method="post" style="display:inline"
-                action="{{ url_for('admin.admin_conversation_pause', conv_id=conversation.id) }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="link-btn">pause the conversation</button>
-          </form>
-          first.
-          {% endif %}
-        </div>
+        <p class="phase-move-pause muted" style="font-size:12px">
+          Need time to coordinate inviting people back? Use the
+          {{ 'Resume' if conversation.paused else 'Pause' }} button above first.
+        </p>
         {% endif %}
       </div>
       <script nonce="{{ csp_nonce }}">
@@ -290,26 +297,7 @@
 
     {% else %}
 
-    <!-- Pause / Resume -->
-    <div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.25rem">
-      <form method="post"
-            action="{{ url_for('admin.admin_conversation_pause', conv_id=conversation.id) }}"
-            style="display:inline">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        <button type="submit"
-                class="btn-small {% if conversation.paused %}btn-approve{% else %}btn-pause{% endif %}">
-          {{ 'Resume' if conversation.paused else 'Pause' }}
-        </button>
-      </form>
-      <span class="muted" style="font-size:13px">
-        {% if conversation.paused %}
-          Consultation is paused — participants cannot vote.
-          The identity reveal clock has <strong>not</strong> started; resuming is possible.
-        {% else %}
-          Pause temporarily disables voting without starting the reveal timeline.
-        {% endif %}
-      </span>
-    </div>
+    <!-- Pause / Resume now lives in the Phases block above. -->
 
     <!-- Close (irreversible) -->
     <div class="close-warning">

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -160,8 +160,12 @@
           var boxes  = box.querySelectorAll('.phase-move-check');
           var submit = box.querySelector('.phase-move-submit');
           var form   = box.querySelector('.phase-move-form');
+          // A machine-checked precondition rendered as unmet gates the move server-side
+          // too — keep the button disabled so it never enables-then-bounces.
+          var hasUnmet = box.querySelector('.phase-check-unmet') != null;
           function sync() {
-            submit.disabled = !Array.prototype.every.call(boxes, function (c) { return c.checked; });
+            submit.disabled = hasUnmet ||
+              !Array.prototype.every.call(boxes, function (c) { return c.checked; });
           }
           box.addEventListener('change', sync);
           sync();   // progressive enhancement: disable on load until all ticked

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -127,13 +127,23 @@
 
         {% if transition.show_pause %}
         <div class="phase-move-pause muted" style="font-size:12px">
-          Coordinating inviting people back? You can
+          {% if conversation.paused %}
+          The conversation is paused.
           <form method="post" style="display:inline"
                 action="{{ url_for('admin.admin_conversation_pause', conv_id=conversation.id) }}">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="link-btn">{{ 'resume' if conversation.paused else 'pause the conversation' }}</button>
+            <button type="submit" class="link-btn">Resume it</button>
+          </form>
+          when you’re ready to invite people back.
+          {% else %}
+          Need time to coordinate inviting people back? You can
+          <form method="post" style="display:inline"
+                action="{{ url_for('admin.admin_conversation_pause', conv_id=conversation.id) }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="link-btn">pause the conversation</button>
           </form>
           first.
+          {% endif %}
         </div>
         {% endif %}
       </div>

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -74,28 +74,6 @@
       {% endfor %}
     </ol>
 
-    {# Pause / Resume — lives here in Phases (it governs the running consultation),
-       not under Status. Global admin only; hidden once closed. #}
-    {% if is_admin and conversation.active %}
-    <div class="phase-pause-row" style="display:flex;align-items:center;gap:1rem;margin:.75rem 0 1rem">
-      <form method="post" style="display:inline"
-            action="{{ url_for('admin.admin_conversation_pause', conv_id=conversation.id) }}">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        <button type="submit"
-                class="btn-small {% if conversation.paused %}btn-approve{% else %}btn-pause{% endif %}">
-          {{ 'Resume' if conversation.paused else 'Pause' }}
-        </button>
-      </form>
-      <span class="muted" style="font-size:13px">
-        {% if conversation.paused %}
-          Paused — participants cannot vote. The identity-reveal clock has <strong>not</strong> started; resuming is possible.
-        {% else %}
-          Pause temporarily disables voting without starting the reveal timeline.
-        {% endif %}
-      </span>
-    </div>
-    {% endif %}
-
     {% if transition %}
       {% if is_admin %}
       {# Guided 'Move on' box (#156): consequences + tick-each-precondition checklist.
@@ -149,8 +127,7 @@
 
         {% if transition.show_pause %}
         <p class="phase-move-pause muted" style="font-size:12px">
-          Need time to coordinate inviting people back? Use the
-          {{ 'Resume' if conversation.paused else 'Pause' }} button above first.
+          Need time to coordinate inviting people back? You can pause first.
         </p>
         {% endif %}
       </div>
@@ -185,6 +162,28 @@
       </p>
     {% else %}
       <p class="muted" style="font-size:13px">Final phase reached — public results are open.</p>
+    {% endif %}
+
+    {# Pause / Resume — governs the running consultation; sits just above the advanced
+       controls. Global admin only; hidden once closed. #}
+    {% if is_admin and conversation.active %}
+    <div class="phase-pause-row" style="display:flex;align-items:center;gap:1rem;margin:1rem 0 .5rem">
+      <form method="post" style="display:inline"
+            action="{{ url_for('admin.admin_conversation_pause', conv_id=conversation.id) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <button type="submit"
+                class="btn-small {% if conversation.paused %}btn-approve{% else %}btn-pause{% endif %}">
+          {{ 'Resume' if conversation.paused else 'Pause' }}
+        </button>
+      </form>
+      <span class="muted" style="font-size:13px">
+        {% if conversation.paused %}
+          Paused — participants cannot vote. The identity-reveal clock has <strong>not</strong> started; resuming is possible.
+        {% else %}
+          Pause temporarily disables voting without starting the reveal timeline.
+        {% endif %}
+      </span>
+    </div>
     {% endif %}
 
     {# Advanced controls — global admin only: independent toggles, go backward,

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -12,7 +12,7 @@
     {% if not conversation.active %}
       <span class="badge-inactive">closed</span>
     {% elif conversation.paused %}
-      <span style="color:#b07800;font-size:13px;font-weight:600">paused</span>
+      <span style="color:var(--spot);font-size:13px;font-weight:600">paused</span>
     {% else %}
       <span style="color:var(--green);font-size:13px;font-weight:600">active</span>
     {% endif %}

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -141,7 +141,7 @@
             </li>
             {% endfor %}
           </ul>
-          <p class="phase-move-hint muted">Confirm every item above to enable “Move on”.</p>
+          <p class="phase-move-hint muted">Confirm every item above to enable “Move on”. Anything marked “not met yet” must be resolved first.</p>
           <button type="submit" class="btn-small phase-move-submit">
             Move on to {{ transition.target.label }} →
           </button>

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -74,6 +74,28 @@
       {% endfor %}
     </ol>
 
+    {# Pause / Resume — directly under the phase bar; governs the running
+       consultation. Global admin only; hidden once closed. #}
+    {% if is_admin and conversation.active %}
+    <div class="phase-pause-row" style="display:flex;align-items:center;gap:1rem;margin:.75rem 0 1rem">
+      <form method="post" style="display:inline"
+            action="{{ url_for('admin.admin_conversation_pause', conv_id=conversation.id) }}">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+        <button type="submit"
+                class="btn-small {% if conversation.paused %}btn-approve{% else %}btn-pause{% endif %}">
+          {{ 'Resume' if conversation.paused else 'Pause' }}
+        </button>
+      </form>
+      <span class="muted" style="font-size:13px">
+        {% if conversation.paused %}
+          Paused — participants cannot vote. The identity-reveal clock has <strong>not</strong> started; resuming is possible.
+        {% else %}
+          Pause temporarily disables voting without starting the reveal timeline.
+        {% endif %}
+      </span>
+    </div>
+    {% endif %}
+
     {% if transition %}
       {% if is_admin %}
       {# Guided 'Move on' box (#156): consequences + tick-each-precondition checklist.
@@ -162,28 +184,6 @@
       </p>
     {% else %}
       <p class="muted" style="font-size:13px">Final phase reached — public results are open.</p>
-    {% endif %}
-
-    {# Pause / Resume — governs the running consultation; sits just above the advanced
-       controls. Global admin only; hidden once closed. #}
-    {% if is_admin and conversation.active %}
-    <div class="phase-pause-row" style="display:flex;align-items:center;gap:1rem;margin:1rem 0 .5rem">
-      <form method="post" style="display:inline"
-            action="{{ url_for('admin.admin_conversation_pause', conv_id=conversation.id) }}">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        <button type="submit"
-                class="btn-small {% if conversation.paused %}btn-approve{% else %}btn-pause{% endif %}">
-          {{ 'Resume' if conversation.paused else 'Pause' }}
-        </button>
-      </form>
-      <span class="muted" style="font-size:13px">
-        {% if conversation.paused %}
-          Paused — participants cannot vote. The identity-reveal clock has <strong>not</strong> started; resuming is possible.
-        {% else %}
-          Pause temporarily disables voting without starting the reveal timeline.
-        {% endif %}
-      </span>
-    </div>
     {% endif %}
 
     {# Advanced controls — global admin only: independent toggles, go backward,

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -76,8 +76,9 @@
 
     {% if transition %}
       {% if is_admin %}
-      {# Guided 'Move on' box (#156): consequences + tick-each-precondition checklist;
-         the Move on button stays disabled until every box is ticked. #}
+      {# Guided 'Move on' box (#156): consequences + tick-each-precondition checklist.
+         The submit ships ENABLED so no-JS users can still advance (the route enforces
+         the checklist server-side); JS disables it until every box is ticked. #}
       <div class="phase-move-box">
         <div class="phase-move-head">
           <span class="phase-move-from">{{ transition.source.label }}</span>
@@ -91,7 +92,7 @@
           <li><strong>Closes:</strong> {{ transition.consequence.closes }}</li>
           {% endif %}
           {% if transition.auto_close %}
-          <li class="phase-move-warn">⚠️ This <strong>permanently closes the consultation</strong> and starts the identity-reveal window.</li>
+          <li class="phase-move-warn"><span aria-hidden="true">⚠️</span> This <strong>permanently closes the consultation</strong> and starts the identity-reveal window.</li>
           {% endif %}
           <li class="muted">This cannot be undone here — only a site admin can reopen a phase via advanced controls.</li>
         </ul>
@@ -111,19 +112,20 @@
                 <span>{{ p.label }}</span>
               </label>
               {% if p.met is not none %}
-                {% if p.met %}<span class="phase-check-met" title="Condition met">✓</span>
-                {% else %}<span class="phase-check-unmet" title="Condition not met yet">✗ not met</span>{% endif %}
+                {% if p.met %}<span class="phase-check-met"><span aria-hidden="true">✓</span><span class="sr-only">condition met</span></span>
+                {% else %}<span class="phase-check-unmet"><span aria-hidden="true">✗</span> not met yet</span>{% endif %}
               {% endif %}
             </li>
             {% endfor %}
           </ul>
-          <button type="submit" class="btn-small phase-move-submit" disabled>
+          <p class="phase-move-hint muted">Confirm every item above to enable “Move on”.</p>
+          <button type="submit" class="btn-small phase-move-submit">
             Move on to {{ transition.target.label }} →
           </button>
         </form>
 
         {% if transition.show_pause %}
-        <p class="phase-move-pause muted" style="font-size:12px">
+        <div class="phase-move-pause muted" style="font-size:12px">
           Coordinating inviting people back? You can
           <form method="post" style="display:inline"
                 action="{{ url_for('admin.admin_conversation_pause', conv_id=conversation.id) }}">
@@ -131,7 +133,7 @@
             <button type="submit" class="link-btn">{{ 'resume' if conversation.paused else 'pause the conversation' }}</button>
           </form>
           first.
-        </p>
+        </div>
         {% endif %}
       </div>
       <script nonce="{{ csp_nonce }}">
@@ -140,16 +142,21 @@
           if (!box) return;
           var boxes  = box.querySelectorAll('.phase-move-check');
           var submit = box.querySelector('.phase-move-submit');
+          var form   = box.querySelector('.phase-move-form');
           function sync() {
-            var all = Array.prototype.every.call(boxes, function (c) { return c.checked; });
-            submit.disabled = !all;
+            submit.disabled = !Array.prototype.every.call(boxes, function (c) { return c.checked; });
           }
           box.addEventListener('change', sync);
-          sync();
+          sync();   // progressive enhancement: disable on load until all ticked
+          form.addEventListener('submit', function () {
+            submit.disabled = true;            // prevent double-submit during Polis I/O
+            submit.textContent = 'Moving on…';
+          });
         }());
       </script>
       {% else %}
       {# Moderator: same stepper, read-only — cannot move phases. #}
+      <p class="muted" style="font-size:13px">Only a site admin can change phases.</p>
       <button type="button" class="btn-small" disabled
               title="Only a site admin can change phases">Move on to {{ transition.target.label }} →</button>
       {% endif %}

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -74,34 +74,92 @@
       {% endfor %}
     </ol>
 
-    {% if linear_phase_state %}
-      {% if target_stage %}
-        {% if is_admin %}
-        <form method="post"
-              action="{{ url_for('admin.admin_conversation_advance', conv_id=conversation.id) }}"
-              onsubmit="return confirm(this.dataset.confirm);"
-              data-confirm="{{ advance_confirm }}">
-          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-          <button type="submit" class="btn-small">Move to {{ target_stage.label }} →</button>
-        </form>
+    {% if transition %}
+      {% if is_admin %}
+      {# Guided 'Move on' box (#156): consequences + tick-each-precondition checklist;
+         the Move on button stays disabled until every box is ticked. #}
+      <div class="phase-move-box">
+        <div class="phase-move-head">
+          <span class="phase-move-from">{{ transition.source.label }}</span>
+          <span class="phase-move-arrow" aria-hidden="true">→</span>
+          <span class="phase-move-to">{{ transition.target.label }}</span>
+        </div>
+
+        <ul class="phase-move-consequences">
+          <li><strong>Opens:</strong> {{ transition.consequence.opens }}</li>
+          {% if transition.consequence.closes %}
+          <li><strong>Closes:</strong> {{ transition.consequence.closes }}</li>
+          {% endif %}
+          {% if transition.auto_close %}
+          <li class="phase-move-warn">⚠️ This <strong>permanently closes the consultation</strong> and starts the identity-reveal window.</li>
+          {% endif %}
+          <li class="muted">This cannot be undone here — only a site admin can reopen a phase via advanced controls.</li>
+        </ul>
+
         {% if not conversation.active %}
-        <p class="muted" style="margin-top:.4rem;font-size:12px">
-          This consultation is closed — the only move is to open public results.
+        <p class="muted" style="font-size:12px">This consultation is closed — the only move is to open public results.</p>
+        {% endif %}
+
+        <form method="post" class="phase-move-form"
+              action="{{ url_for('admin.admin_conversation_advance', conv_id=conversation.id) }}">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <ul class="phase-move-checklist">
+            {% for p in transition.preconditions %}
+            <li>
+              <label>
+                <input type="checkbox" name="{{ p.id }}" class="phase-move-check">
+                <span>{{ p.label }}</span>
+              </label>
+              {% if p.met is not none %}
+                {% if p.met %}<span class="phase-check-met" title="Condition met">✓</span>
+                {% else %}<span class="phase-check-unmet" title="Condition not met yet">✗ not met</span>{% endif %}
+              {% endif %}
+            </li>
+            {% endfor %}
+          </ul>
+          <button type="submit" class="btn-small phase-move-submit" disabled>
+            Move on to {{ transition.target.label }} →
+          </button>
+        </form>
+
+        {% if transition.show_pause %}
+        <p class="phase-move-pause muted" style="font-size:12px">
+          Coordinating inviting people back? You can
+          <form method="post" style="display:inline"
+                action="{{ url_for('admin.admin_conversation_pause', conv_id=conversation.id) }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="link-btn">{{ 'resume' if conversation.paused else 'pause the conversation' }}</button>
+          </form>
+          first.
         </p>
         {% endif %}
-        {% else %}
-        {# Moderator: same interface, but cannot act. #}
-        <button type="button" class="btn-small" disabled
-                title="Only a site admin can change phases">Move to {{ target_stage.label }} →</button>
-        {% endif %}
+      </div>
+      <script nonce="{{ csp_nonce }}">
+        (function () {
+          var box = document.querySelector('.phase-move-box');
+          if (!box) return;
+          var boxes  = box.querySelectorAll('.phase-move-check');
+          var submit = box.querySelector('.phase-move-submit');
+          function sync() {
+            var all = Array.prototype.every.call(boxes, function (c) { return c.checked; });
+            submit.disabled = !all;
+          }
+          box.addEventListener('change', sync);
+          sync();
+        }());
+      </script>
       {% else %}
-      <p class="muted" style="font-size:13px">Final phase reached — public results are open.</p>
+      {# Moderator: same stepper, read-only — cannot move phases. #}
+      <button type="button" class="btn-small" disabled
+              title="Only a site admin can change phases">Move on to {{ transition.target.label }} →</button>
       {% endif %}
-    {% else %}
+    {% elif not linear_phase_state %}
       <p class="muted" style="margin-top:.5rem;font-size:13px">
         ⚠️ Phases are in a custom state (more than one active).
         {% if is_admin %}Use advanced controls below to adjust.{% else %}A site admin can adjust this.{% endif %}
       </p>
+    {% else %}
+      <p class="muted" style="font-size:13px">Final phase reached — public results are open.</p>
     {% endif %}
 
     {# Advanced controls — global admin only: independent toggles, go backward,

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -114,6 +114,7 @@
               {% if p.met is not none %}
                 {% if p.met %}<span class="phase-check-met"><span aria-hidden="true">✓</span><span class="sr-only">condition met</span></span>
                 {% else %}<span class="phase-check-unmet"><span aria-hidden="true">✗</span> not met yet</span>{% endif %}
+                {% if p.note %}<span class="phase-check-note">({{ p.note }})</span>{% endif %}
               {% endif %}
             </li>
             {% endfor %}

--- a/v2/tests/test_admin.py
+++ b/v2/tests/test_admin.py
@@ -1,4 +1,5 @@
 """Tests for admin conversation management, roles, and phase toggles."""
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
@@ -119,73 +120,100 @@ def test_phase_toggles_off(admin_client, conv):
     assert conv.phase_submission is False
 
 
-# ── Simple-mode phase advance (#140) ──────────────────────────────────────────
+# ── Guided phase transition (#140 + #156) ─────────────────────────────────────
 
-from app import PHASE_SEQUENCE, _current_stage_index, _is_linear_phase_state
-
-
-def _advance(admin_client, conv):
-    """POST the advance route with set_vis_type stubbed; return the response."""
-    with patch('app.PolisServerClient.set_vis_type'):
-        return admin_client.post(f'/admin/conversations/{conv.id}/phase/advance')
+from app import (PHASE_SEQUENCE, PHASE_TRANSITIONS, _current_stage_index,
+                 _is_linear_phase_state, _advance_target_index)
+from db import FeaturedStatement
 
 
-def test_advance_from_preparation_opens_submission(admin_client, conv):
-    resp = _advance(admin_client, conv)
+def _checks_for(conv):
+    """All precondition checkbox ids for the conversation's next transition, ticked."""
+    target = _advance_target_index(conv)
+    if target is None:
+        return {}
+    key = PHASE_SEQUENCE[target]['key']
+    return {p['id']: 'on' for p in PHASE_TRANSITIONS[key]['preconditions']}
+
+
+def _add_featured(conv, tid=1, text='A featured statement'):
+    fs = FeaturedStatement(conversation_id=conv.id, polis_statement_id=tid,
+                           statement_text=text, confirmed_by_admin=True)
+    db.session.add(fs)
+    db.session.commit()
+    return fs
+
+
+def _move(admin_client, conv, data=None):
+    """POST the guided transition with all readiness checks ticked and Polis stubbed."""
+    payload = _checks_for(conv) if data is None else data
+    with patch('app.PolisServerClient.set_vis_type'), \
+         patch('app.PolisServerClient.create_conversation', return_value='p6conv1234'), \
+         patch('app.PolisServerClient.add_seed_return_id', return_value=42):
+        return admin_client.post(f'/admin/conversations/{conv.id}/phase/advance', data=payload)
+
+
+def test_move_from_preparation_opens_submission(admin_client, conv):
+    resp = _move(admin_client, conv)
     assert resp.status_code == 302
     db.session.refresh(conv)
     assert conv.phase_submission is True
     assert conv.phase_personal_results is False
-    assert conv.phase_argument_mapping is False
-    assert conv.phase_informed_voting is False
     assert conv.phase_public_results is False
 
 
-def test_advance_is_exclusive_through_full_sequence(admin_client, conv):
-    """Each advance turns the next flag on and the prior flag off — one active stage."""
-    flags = [s['flag'] for s in PHASE_SEQUENCE]   # [None, submission, ...]
+def test_move_blocked_without_all_checks(admin_client, conv):
+    """Omitting any readiness checkbox blocks the transition (server-side gate)."""
+    checks = _checks_for(conv)
+    checks.pop(next(iter(checks)))                 # drop one
+    resp = _move(admin_client, conv, data=checks)
+    assert resp.status_code == 302
+    db.session.refresh(conv)
+    assert conv.phase_submission is False          # no change
+
+
+def test_move_is_exclusive_through_full_sequence(admin_client, conv):
+    """Each move turns the next flag on and the prior off — one active stage."""
+    _add_featured(conv)                            # needed for the machine-checked stages
+    flags = [s['flag'] for s in PHASE_SEQUENCE]
     for i in range(1, len(PHASE_SEQUENCE)):
-        _advance(admin_client, conv)
+        _move(admin_client, conv)
         db.session.refresh(conv)
-        # Exactly one phase flag should be on: the i-th stage's flag.
         on = [f for f in flags if f and getattr(conv, f)]
         assert on == [flags[i]], f'stage {i}: expected only {flags[i]} on, got {on}'
 
 
-def test_advance_at_final_stage_is_noop(admin_client, conv):
-    conv.phase_public_results = True   # already at the final stage
+def test_move_at_final_stage_is_noop(admin_client, conv):
+    conv.phase_public_results = True
     db.session.commit()
-    resp = _advance(admin_client, conv)
+    resp = _move(admin_client, conv)
     assert resp.status_code == 302
     db.session.refresh(conv)
     assert conv.phase_public_results is True
     assert _current_stage_index(conv) == len(PHASE_SEQUENCE) - 1
 
 
-def test_advance_forbidden_for_regular_participant(auth_client, conv):
-    """A logged-in participant with no role cannot advance."""
+def test_move_forbidden_for_regular_participant(auth_client, conv):
     resp = auth_client.post(f'/admin/conversations/{conv.id}/phase/advance')
     assert resp.status_code == 403
     db.session.refresh(conv)
     assert conv.phase_submission is False
 
 
-def test_advance_forbidden_for_moderator(client, conv, participant):
-    """A conversation MODERATOR (not a global admin) cannot advance phases —
-    phase control is global-admin only in this PR."""
+def test_move_forbidden_for_moderator(client, conv, participant):
+    """Phase control is global-admin only — a moderator cannot move phases."""
     db.session.add(AdminRole(participant_id=participant.id,
                              conversation_id=conv.id, role='moderator'))
     db.session.commit()
     login(client, 'testuser')
-    resp = client.post(f'/admin/conversations/{conv.id}/phase/advance')
+    resp = client.post(f'/admin/conversations/{conv.id}/phase/advance',
+                       data=_checks_for(conv))
     assert resp.status_code == 403
     db.session.refresh(conv)
     assert conv.phase_submission is False
 
 
 def test_moderator_sees_readonly_stepper(client, conv, participant):
-    """A moderator reaches the detail page and sees the stepper, but the forward
-    control is disabled and the advanced controls are absent."""
     db.session.add(AdminRole(participant_id=participant.id,
                              conversation_id=conv.id, role='moderator'))
     db.session.commit()
@@ -193,120 +221,160 @@ def test_moderator_sees_readonly_stepper(client, conv, participant):
     resp = client.get(f'/admin/conversations/{conv.id}')
     assert resp.status_code == 200
     assert b'phase-stepper' in resp.data           # same interface
-    assert b'disabled' in resp.data                # button inert
+    assert b'phase-move-box' not in resp.data       # no guided box
+    assert b'disabled' in resp.data                # read-only button
     assert b'Advanced phase controls' not in resp.data
-    assert b'phase/advance' not in resp.data        # no actionable advance form
+    assert b'phase/advance' not in resp.data        # no actionable form
 
 
-def test_advance_from_non_linear_state_rejected(admin_client, conv):
-    """The route refuses to advance from a custom (non-linear) state instead of
-    perpetuating it — backward/custom repair is an advanced-mode action."""
+def test_move_from_non_linear_state_rejected(admin_client, conv):
     conv.phase_submission = True
-    conv.phase_argument_mapping = True            # two flags on → non-linear
+    conv.phase_argument_mapping = True            # non-linear
     db.session.commit()
-    resp = _advance(admin_client, conv)
+    resp = admin_client.post(f'/admin/conversations/{conv.id}/phase/advance')
     assert resp.status_code == 302
     db.session.refresh(conv)
-    # Unchanged — no silent normalisation, no extra flag flipped.
     assert conv.phase_submission is True
     assert conv.phase_argument_mapping is True
     assert conv.phase_informed_voting is False
 
 
-def test_advance_on_closed_conversation_jumps_to_public_results(admin_client, conv):
-    """A closed conversation jumps straight to public results, skipping steps."""
-    conv.phase_submission = True                  # mid-sequence
-    conv.active = False
+def test_move_to_argument_mapping_blocked_without_featured(admin_client, conv):
+    """A machine-checked precondition (≥1 confirmed featured statement) is enforced
+    server-side even when all checkboxes are ticked."""
+    conv.phase_personal_results = True            # at featured selection
     db.session.commit()
-    _advance(admin_client, conv)
+    resp = _move(admin_client, conv)              # no featured statement exists
+    assert resp.status_code == 302
     db.session.refresh(conv)
-    assert conv.phase_public_results is True
-    assert conv.phase_submission is False         # exclusive: prior cleared
-    assert conv.phase_argument_mapping is False
+    assert conv.phase_argument_mapping is False    # blocked
+    assert conv.phase_personal_results is True
 
 
-def test_advance_vis_type_failure_flashes(admin_client, conv):
-    """If the Polis vis_type sync fails, the phase change still persists and a
-    warning is flashed."""
-    with patch('app.PolisServerClient.set_vis_type',
-               side_effect=PolisServerError('boom')):
-        resp = admin_client.post(f'/admin/conversations/{conv.id}/phase/advance',
-                                 follow_redirects=True)
-    assert resp.status_code == 200
-    assert b'results visibility in Polis failed' in resp.data
-    db.session.refresh(conv)
-    assert conv.phase_submission is True          # change persisted despite failure
-
-
-def test_advance_to_informed_voting_does_not_init_phase6(admin_client, conv):
-    """Advancing to the informed-voting stage flips the flag but does not create
-    a Phase 6 Polis conversation — that stays an explicit separate action."""
-    conv.phase_argument_mapping = True   # at stage 4; next advance → informed voting
+def test_move_to_informed_voting_runs_phase6_init(admin_client, conv):
+    """Moving into Informed voting folds in Phase 6 init: creates the Polis
+    conversation and seeds the confirmed featured statements, atomically."""
+    conv.phase_argument_mapping = True
     db.session.commit()
-    _advance(admin_client, conv)
+    fs = _add_featured(conv)
+    _move(admin_client, conv)
     db.session.refresh(conv)
+    db.session.refresh(fs)
     assert conv.phase_informed_voting is True
     assert conv.phase_argument_mapping is False
+    assert conv.phase6_polis_conversation_id == 'p6conv1234'
+    assert fs.phase6_polis_statement_id == 42
+
+
+def test_move_to_informed_voting_init_failure_rolls_back(admin_client, conv):
+    """If Phase 6 seeding fails, the informed-voting flag is NOT set (atomic)."""
+    conv.phase_argument_mapping = True
+    db.session.commit()
+    _add_featured(conv)
+    with patch('app.PolisServerClient.set_vis_type'), \
+         patch('app.PolisServerClient.create_conversation', return_value='p6conv1234'), \
+         patch('app.PolisServerClient.add_seed_return_id',
+               side_effect=PolisServerError('seed failed')):
+        admin_client.post(f'/admin/conversations/{conv.id}/phase/advance',
+                          data=_checks_for(conv))
+    db.session.refresh(conv)
+    assert conv.phase_informed_voting is False     # rolled back
+    assert conv.phase_argument_mapping is True     # prior flag preserved
     assert conv.phase6_polis_conversation_id is None
 
 
-def test_advance_syncs_vis_type(admin_client, conv):
-    """vis_type=1 when advancing into a results stage, 0 otherwise."""
-    # Preparation → submission: no results phase → vis_type 0.
-    with patch('app.PolisServerClient.set_vis_type') as m:
-        admin_client.post(f'/admin/conversations/{conv.id}/phase/advance')
-    m.assert_called_once_with(conv.polis_id, 0)
+def test_move_to_public_results_auto_closes(admin_client, conv):
+    """The final transition opens public results and permanently closes the
+    conversation, starting the identity-reveal flow."""
+    conv.phase_informed_voting = True
+    db.session.commit()
+    _move(admin_client, conv)
+    db.session.refresh(conv)
+    assert conv.phase_public_results is True
+    assert conv.active is False
+    assert conv.closed_at is not None
 
-    # Submission → featured selection (personal results) → vis_type 1.
-    with patch('app.PolisServerClient.set_vis_type') as m:
-        admin_client.post(f'/admin/conversations/{conv.id}/phase/advance')
-    m.assert_called_once_with(conv.polis_id, 1)
 
-    # Featured selection → argument mapping → vis_type 0.
-    with patch('app.PolisServerClient.set_vis_type') as m:
-        admin_client.post(f'/admin/conversations/{conv.id}/phase/advance')
-    m.assert_called_once_with(conv.polis_id, 0)
+def test_move_on_closed_conversation_jumps_to_public_results(admin_client, conv):
+    conv.phase_submission = True
+    conv.active = False
+    conv.closed_at = datetime.now(timezone.utc)
+    db.session.commit()
+    original_closed = conv.closed_at.replace(tzinfo=None)   # SQLite stores naive
+    _move(admin_client, conv)
+    db.session.refresh(conv)
+    assert conv.phase_public_results is True
+    assert conv.phase_submission is False
+    assert conv.closed_at.replace(tzinfo=None) == original_closed   # not re-stamped
 
-    # Argument mapping → informed voting → vis_type 0.
-    with patch('app.PolisServerClient.set_vis_type') as m:
-        admin_client.post(f'/admin/conversations/{conv.id}/phase/advance')
-    m.assert_called_once_with(conv.polis_id, 0)
 
-    # Informed voting → public results → vis_type 1.
-    with patch('app.PolisServerClient.set_vis_type') as m:
-        admin_client.post(f'/admin/conversations/{conv.id}/phase/advance')
-    m.assert_called_once_with(conv.polis_id, 1)
+def test_move_vis_type_failure_flashes(admin_client, conv):
+    with patch('app.PolisServerClient.set_vis_type',
+               side_effect=PolisServerError('boom')):
+        resp = admin_client.post(f'/admin/conversations/{conv.id}/phase/advance',
+                                 data=_checks_for(conv), follow_redirects=True)
+    assert resp.status_code == 200
+    assert b'results visibility in Polis failed' in resp.data
+    db.session.refresh(conv)
+    assert conv.phase_submission is True
+
+
+def test_move_syncs_vis_type(admin_client, conv):
+    """vis_type=1 entering a results stage, 0 otherwise."""
+    _add_featured(conv)
+    expectations = [0, 1, 0, 0, 1]   # submission, featured(personal), argument, informed, public
+    for expected in expectations:
+        with patch('app.PolisServerClient.set_vis_type') as m, \
+             patch('app.PolisServerClient.create_conversation', return_value='p6conv1234'), \
+             patch('app.PolisServerClient.add_seed_return_id', return_value=42):
+            admin_client.post(f'/admin/conversations/{conv.id}/phase/advance',
+                              data=_checks_for(conv))
+        m.assert_called_once_with(conv.polis_id, expected)
+        db.session.refresh(conv)
 
 
 def test_current_stage_index_and_linearity():
     c = Conversation(slug='x', polis_id='p', title='t', active=True,
                      access_policy='public')
-    assert _current_stage_index(c) == 0          # all off → preparation
+    assert _current_stage_index(c) == 0
     assert _is_linear_phase_state(c) is True
     c.phase_argument_mapping = True
     assert _current_stage_index(c) == 3
     assert _is_linear_phase_state(c) is True
-    c.phase_submission = True                     # two flags on → non-linear
+    c.phase_submission = True
     assert _is_linear_phase_state(c) is False
-    assert _current_stage_index(c) == 3           # still furthest-along
+    assert _current_stage_index(c) == 3
 
 
-def test_simple_panel_shows_advance_button(admin_client, conv):
+def test_guided_box_renders_checklist_disabled_submit(admin_client, conv):
     resp = admin_client.get(f'/admin/conversations/{conv.id}')
     assert resp.status_code == 200
-    assert b'Move to Submission' in resp.data       # forward control, contextual label
-    assert b'phase-stepper' in resp.data
-    assert b'aria-current="step"' in resp.data      # a11y: current stage marked
+    assert b'phase-move-box' in resp.data
+    assert b'phase-move-check' in resp.data          # checklist present
+    assert b'Move on to Submission' in resp.data
+    assert b'phase-move-submit' in resp.data
+    assert b'disabled' in resp.data                  # submit starts disabled
+    assert b'aria-current="step"' in resp.data       # a11y
 
 
-def test_non_linear_state_suppresses_advance_button(admin_client, conv):
+def test_guided_box_shows_unmet_machine_check(admin_client, conv):
+    """At Featured selection with no featured statement, the featured precondition
+    shows as not met."""
+    conv.phase_personal_results = True
+    db.session.commit()
+    resp = admin_client.get(f'/admin/conversations/{conv.id}')
+    assert resp.status_code == 200
+    assert b'not met' in resp.data
+
+
+def test_non_linear_state_suppresses_box(admin_client, conv):
     conv.phase_submission = True
-    conv.phase_public_results = True              # non-linear
+    conv.phase_public_results = True
     db.session.commit()
     resp = admin_client.get(f'/admin/conversations/{conv.id}')
     assert resp.status_code == 200
     assert b'custom state' in resp.data
-    assert b'Move to ' not in resp.data           # no actionable forward control
+    assert b'phase-move-box' not in resp.data
     assert b'phase/advance' not in resp.data
 
 

--- a/v2/tests/test_admin.py
+++ b/v2/tests/test_admin.py
@@ -370,6 +370,32 @@ def test_guided_box_shows_unmet_machine_check(admin_client, conv):
     assert b'not met' in resp.data
 
 
+def test_pause_control_in_phases_block_not_status(admin_client, conv):
+    """Pause/Resume lives in the Phases block (once), not the Status block."""
+    conv.phase_personal_results = True            # a live, mid-flow phase
+    db.session.commit()
+    resp = admin_client.get(f'/admin/conversations/{conv.id}')
+    assert resp.status_code == 200
+    assert b'phase-pause-row' in resp.data
+    assert resp.data.count(b'/pause"') == 1                       # one pause form, not duplicated
+    assert b'temporarily disables voting without starting' in resp.data   # active copy
+    assert b'btn-pause' in resp.data
+    # Not in the Status block.
+    status_tail = resp.data.split(b'<h3 class="section-heading">Status</h3>')[1]
+    assert b'/pause"' not in status_tail
+
+
+def test_pause_control_paused_state_copy(admin_client, conv):
+    conv.phase_personal_results = True
+    conv.paused = True
+    db.session.commit()
+    resp = admin_client.get(f'/admin/conversations/{conv.id}')
+    assert resp.status_code == 200
+    assert b'identity-reveal clock has' in resp.data       # paused safety copy
+    assert b'btn-approve' in resp.data                     # Resume styling
+    assert b'temporarily disables voting without starting' not in resp.data
+
+
 def test_featured_check_shows_selected_count_and_recommendation(admin_client, conv):
     """The featured-statement precondition reports '(N selected, 15 recommended)'."""
     conv.phase_personal_results = True            # next transition → argument mapping

--- a/v2/tests/test_admin.py
+++ b/v2/tests/test_admin.py
@@ -346,14 +346,17 @@ def test_current_stage_index_and_linearity():
     assert _current_stage_index(c) == 3
 
 
-def test_guided_box_renders_checklist_disabled_submit(admin_client, conv):
+def test_guided_box_renders_checklist(admin_client, conv):
     resp = admin_client.get(f'/admin/conversations/{conv.id}')
     assert resp.status_code == 200
     assert b'phase-move-box' in resp.data
     assert b'phase-move-check' in resp.data          # checklist present
     assert b'Move on to Submission' in resp.data
     assert b'phase-move-submit' in resp.data
-    assert b'disabled' in resp.data                  # submit starts disabled
+    # Submit ships enabled (no-JS can advance; route enforces server-side); JS
+    # disables it until all ticked.
+    assert b'submit.disabled' in resp.data           # JS gate present
+    assert b'Confirm every item' in resp.data        # disabled-reason hint
     assert b'aria-current="step"' in resp.data       # a11y
 
 
@@ -376,6 +379,171 @@ def test_non_linear_state_suppresses_box(admin_client, conv):
     assert b'custom state' in resp.data
     assert b'phase-move-box' not in resp.data
     assert b'phase/advance' not in resp.data
+
+
+# ── Guided transition — review follow-ups (#158) ──────────────────────────────
+
+def test_move_rejects_non_on_checkbox_value(admin_client, conv):
+    """Only the literal 'on' value satisfies a precondition; '1'/'true' do not."""
+    data = {k: '1' for k in _checks_for(conv)}
+    resp = _move(admin_client, conv, data=data)
+    assert resp.status_code == 302
+    db.session.refresh(conv)
+    assert conv.phase_submission is False
+
+
+def test_move_requires_every_checkbox(admin_client, conv):
+    """Dropping ANY single precondition blocks — not just the first."""
+    all_checks = _checks_for(conv)
+    assert len(all_checks) > 1
+    for drop in list(all_checks):
+        data = {k: v for k, v in all_checks.items() if k != drop}
+        resp = _move(admin_client, conv, data=data)
+        assert resp.status_code == 302
+        db.session.refresh(conv)
+        assert conv.phase_submission is False, f'dropping {drop} should block'
+
+
+def test_informed_voting_newcomers_has_no_machine_check():
+    """U6 regression: the 'newcomers' precondition must not carry a machine check —
+    its badge would otherwise render against an unrelated label."""
+    iv = {p['id']: p for p in PHASE_TRANSITIONS['informed_voting']['preconditions']}
+    assert iv['newcomers'].get('check') is None
+
+
+def test_move_to_informed_voting_blocked_if_already_initialised(admin_client, conv):
+    """The guided route refuses to re-init Phase 6 (precheck), without any Polis call."""
+    conv.phase_argument_mapping = True
+    conv.phase6_polis_conversation_id = 'pre-existing'
+    db.session.commit()
+    _add_featured(conv)
+    with patch('app.PolisServerClient.create_conversation') as cc, \
+         patch('app.PolisServerClient.set_vis_type'):
+        resp = admin_client.post(f'/admin/conversations/{conv.id}/phase/advance',
+                                 data=_checks_for(conv), follow_redirects=True)
+    assert b'already initialised' in resp.data.lower()
+    db.session.refresh(conv)
+    assert conv.phase_informed_voting is False
+    cc.assert_not_called()
+
+
+def test_move_informed_voting_empty_text_aborts(admin_client, conv):
+    """A confirmed featured statement with no cached text aborts Phase 6 init before
+    seeding; the phase flag is not set."""
+    conv.phase_argument_mapping = True
+    db.session.commit()
+    _add_featured(conv, text='')
+    with patch('app.PolisServerClient.set_vis_type'), \
+         patch('app.PolisServerClient.create_conversation', return_value='p6x') as cc, \
+         patch('app.PolisServerClient.add_seed_return_id', return_value=1) as seed:
+        admin_client.post(f'/admin/conversations/{conv.id}/phase/advance',
+                          data=_checks_for(conv))
+    db.session.refresh(conv)
+    assert conv.phase_informed_voting is False
+    assert conv.phase6_polis_conversation_id is None
+    cc.assert_called_once()       # remote conversation was created…
+    seed.assert_not_called()      # …but seeding never started (empty text aborts)
+
+
+def test_move_commit_failure_rolls_back_and_logs_orphan(admin_client, conv, caplog):
+    """If the commit loses a UNIQUE race after Phase 6 init, the transition rolls
+    back and the orphaned Polis conversation id is logged for cleanup."""
+    import logging
+    from sqlalchemy.exc import IntegrityError
+    conv.phase_argument_mapping = True
+    db.session.commit()
+    _add_featured(conv)
+    with patch('app.PolisServerClient.set_vis_type'), \
+         patch('app.PolisServerClient.create_conversation', return_value='p6orphan99'), \
+         patch('app.PolisServerClient.add_seed_return_id', return_value=42), \
+         patch('app.db.session.commit', side_effect=IntegrityError('x', 'y', 'z')), \
+         caplog.at_level(logging.ERROR):
+        resp = admin_client.post(f'/admin/conversations/{conv.id}/phase/advance',
+                                 data=_checks_for(conv), follow_redirects=True)
+    assert b'changed at the same time' in resp.data.lower()
+    db.session.refresh(conv)
+    assert conv.phase_informed_voting is False     # rolled back
+    assert 'p6orphan99' in caplog.text             # orphan logged
+
+
+# ── Standalone Phase 6 init route (advanced/demo fallback) ────────────────────
+
+def test_phase6_init_success(admin_client, conv):
+    conv.phase_informed_voting = True
+    db.session.commit()
+    fs = _add_featured(conv)
+    with patch('app.PolisServerClient.create_conversation', return_value='p6conv1234'), \
+         patch('app.PolisServerClient.add_seed_return_id', return_value=7):
+        resp = admin_client.post(f'/admin/conversations/{conv.id}/phase6/init')
+    assert resp.status_code == 302
+    db.session.refresh(conv)
+    db.session.refresh(fs)
+    assert conv.phase6_polis_conversation_id == 'p6conv1234'
+    assert fs.phase6_polis_statement_id == 7
+
+
+def test_phase6_init_requires_informed_voting_enabled(admin_client, conv):
+    _add_featured(conv)
+    resp = admin_client.post(f'/admin/conversations/{conv.id}/phase6/init',
+                             follow_redirects=True)
+    assert b'enable the informed voting toggle first' in resp.data.lower()
+    db.session.refresh(conv)
+    assert conv.phase6_polis_conversation_id is None
+
+
+def test_phase6_init_blocked_when_already_initialised(admin_client, conv):
+    conv.phase_informed_voting = True
+    conv.phase6_polis_conversation_id = 'existing123'
+    db.session.commit()
+    resp = admin_client.post(f'/admin/conversations/{conv.id}/phase6/init',
+                             follow_redirects=True)
+    assert b'already initialised' in resp.data.lower()
+
+
+def test_phase6_init_blocked_on_closed_conversation(admin_client, conv):
+    conv.phase_informed_voting = True
+    conv.active = False
+    db.session.commit()
+    resp = admin_client.post(f'/admin/conversations/{conv.id}/phase6/init',
+                             follow_redirects=True)
+    assert b'closed or paused' in resp.data.lower()
+
+
+def test_phase6_init_no_confirmed_featured(admin_client, conv):
+    conv.phase_informed_voting = True
+    db.session.commit()
+    resp = admin_client.post(f'/admin/conversations/{conv.id}/phase6/init',
+                             follow_redirects=True)
+    assert b'no confirmed featured statements' in resp.data.lower()
+
+
+def test_phase6_init_accessible_to_moderator(client, conv, participant):
+    """Unlike the guided advance, the standalone init allows conversation moderators."""
+    conv.phase_informed_voting = True
+    db.session.add(AdminRole(participant_id=participant.id,
+                             conversation_id=conv.id, role='moderator'))
+    db.session.commit()
+    _add_featured(conv)
+    login(client, 'testuser')
+    with patch('app.PolisServerClient.create_conversation', return_value='p6modok'), \
+         patch('app.PolisServerClient.add_seed_return_id', return_value=9):
+        resp = client.post(f'/admin/conversations/{conv.id}/phase6/init')
+    assert resp.status_code == 302
+    db.session.refresh(conv)
+    assert conv.phase6_polis_conversation_id == 'p6modok'
+
+
+def test_phase6_init_integrityerror_flashes(admin_client, conv):
+    from sqlalchemy.exc import IntegrityError
+    conv.phase_informed_voting = True
+    db.session.commit()
+    _add_featured(conv)
+    with patch('app.PolisServerClient.create_conversation', return_value='p6conv1234'), \
+         patch('app.PolisServerClient.add_seed_return_id', return_value=7), \
+         patch('app.db.session.commit', side_effect=IntegrityError('x', 'y', 'z')):
+        resp = admin_client.post(f'/admin/conversations/{conv.id}/phase6/init',
+                                 follow_redirects=True)
+    assert b'already initialised by a concurrent request' in resp.data.lower()
 
 
 # ── Pause / close ─────────────────────────────────────────────────────────────

--- a/v2/tests/test_admin.py
+++ b/v2/tests/test_admin.py
@@ -502,6 +502,41 @@ def test_move_commit_failure_rolls_back_and_logs_orphan(admin_client, conv, capl
     assert 'p6orphan99' in caplog.text             # orphan logged
 
 
+def test_move_commit_db_error_rolls_back_and_logs_orphan(admin_client, conv, caplog):
+    """A non-IntegrityError commit failure (deadlock/timeout) after Phase 6 init must
+    NOT 500 with the orphan unlogged: it rolls back, logs the orphaned Polis
+    conversation id, and warns the organizer not to blind-retry."""
+    import logging
+    from sqlalchemy.exc import OperationalError
+    conv.phase_argument_mapping = True
+    db.session.commit()
+    _add_featured(conv)
+    with patch('app.PolisServerClient.set_vis_type'), \
+         patch('app.PolisServerClient.create_conversation', return_value='p6orphanOE'), \
+         patch('app.PolisServerClient.add_seed_return_id', return_value=42), \
+         patch('app.db.session.commit',
+               side_effect=OperationalError('stmt', {}, Exception('deadlock'))), \
+         caplog.at_level(logging.ERROR):
+        resp = admin_client.post(f'/admin/conversations/{conv.id}/phase/advance',
+                                 data=_checks_for(conv), follow_redirects=True)
+    assert resp.status_code == 200                 # graceful, not a 500
+    db.session.refresh(conv)
+    assert conv.phase_informed_voting is False     # rolled back
+    assert conv.phase6_polis_conversation_id is None
+    assert 'p6orphanOE' in caplog.text             # orphan logged for cleanup
+    assert b'site admin' in resp.data.lower()      # warned against blind retry
+
+
+def test_unmet_machine_check_renders_gating_hook(admin_client, conv):
+    """An unmet machine-checked precondition renders the .phase-check-unmet marker the
+    JS uses to keep 'Move on' disabled (so it can't enable-then-server-bounce)."""
+    conv.phase_personal_results = True             # → argument mapping next, machine-checked
+    db.session.commit()                            # no featured statement ⇒ unmet
+    resp = admin_client.get(f'/admin/conversations/{conv.id}')
+    assert resp.status_code == 200
+    assert b'phase-check-unmet' in resp.data
+
+
 # ── Standalone Phase 6 init route (advanced/demo fallback) ────────────────────
 
 def test_phase6_init_success(admin_client, conv):
@@ -543,6 +578,22 @@ def test_phase6_init_blocked_on_closed_conversation(admin_client, conv):
     resp = admin_client.post(f'/admin/conversations/{conv.id}/phase6/init',
                              follow_redirects=True)
     assert b'closed or paused' in resp.data.lower()
+
+
+def test_phase6_init_blocked_on_paused_conversation(admin_client, conv):
+    """An active-but-PAUSED conversation must not initialise Phase 6 — and the guard
+    must fire before any Polis call (no orphan)."""
+    conv.phase_informed_voting = True
+    conv.paused = True                             # active stays True
+    db.session.commit()
+    _add_featured(conv)
+    with patch('app.PolisServerClient.create_conversation') as cc:
+        resp = admin_client.post(f'/admin/conversations/{conv.id}/phase6/init',
+                                 follow_redirects=True)
+    assert b'closed or paused' in resp.data.lower()
+    cc.assert_not_called()                         # guard fired before touching Polis
+    db.session.refresh(conv)
+    assert conv.phase6_polis_conversation_id is None
 
 
 def test_phase6_init_no_confirmed_featured(admin_client, conv):

--- a/v2/tests/test_admin.py
+++ b/v2/tests/test_admin.py
@@ -370,6 +370,16 @@ def test_guided_box_shows_unmet_machine_check(admin_client, conv):
     assert b'not met' in resp.data
 
 
+def test_featured_check_shows_selected_count_and_recommendation(admin_client, conv):
+    """The featured-statement precondition reports '(N selected, 15 recommended)'."""
+    conv.phase_personal_results = True            # next transition → argument mapping
+    db.session.commit()
+    _add_featured(conv); _add_featured(conv, tid=2)   # 2 confirmed
+    resp = admin_client.get(f'/admin/conversations/{conv.id}')
+    assert resp.status_code == 200
+    assert b'2 selected, 15 recommended' in resp.data
+
+
 def test_non_linear_state_suppresses_box(admin_client, conv):
     conv.phase_submission = True
     conv.phase_public_results = True


### PR DESCRIPTION
Closes #156. Absorbs #126, #120, #12. (Foundation #155/#140 is now merged; this PR is rebased onto `main` and ready.)

## What this does

Replaces the inline "Move to {stage}" button with a dedicated **guided "Move on" box** that makes advancing a consultation deliberate and informed:

- **Consequence explanation** per transition — what opens, what closes, irreversibility, and the auto-close warning.
- **Tick-each-precondition checklist** — "Move on" stays disabled until every checkbox is ticked (and until any machine-checked precondition is met), re-enforced **server-side**.
- **Machine-verifiable preconditions** (e.g. "N selected, 15 recommended" featured statements) shown met/✗ and enforced.
- **Phase 6 init folded** into the Informed-voting transition — creates the Polis conversation + seeds featured statements **atomically**; flag not set if it fails.
- **Public results auto-closes** the conversation (`closed_at`), starting the identity-reveal flow.
- **Pause/Resume** lives in the Phases block (under the phase bar); context-aware copy.
- Moderators see the stepper read-only; advanced controls + standalone Phase 6 init remain global-admin only (the latter a demo/advanced fallback).

## Review

Two full review rounds (database + usability + QA), each with cross-review, plus a verification pass on the applied fixes. All findings resolved:

- [x] Concurrency hardening — precheck + reorder (Polis I/O before mutating conv) + `try/except IntegrityError`/`SQLAlchemyError` with orphan logging.
- [x] U6 — dropped the mismatched `has_confirmed_featured` check on `newcomers`.
- [x] JS gate inverted (enabled by default, disabled via JS) + disable-on-submit; also gates on unmet machine-checks.
- [x] a11y/markup — `<form>`-in-`<p>` removed, met-badge sr-only text, moderator visible note, WCAG-AA pause color.
- [x] Tests — standalone `/phase6/init` guards (incl. moderator + IntegrityError + paused), non-IntegrityError commit failure + orphan log, `== 'on'` strictness, empty `statement_text`, unmet gating-hook, count rendering.

**286 tests pass.**

Deferred low-priority items tracked in #169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)