### PR TITLE
a11y: consultation-listing semantics + pseudonym labelling (+ pending UX copy edits)

### DIFF
--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -1185,7 +1185,9 @@ pa-statement:state(no-statement) ~ .vote-choice-row { display: none; }
      (clip/sr-only), because that keeps them in the a11y tree + tab order — a
      screen-reader/keyboard user would otherwise hit phantom Agree/Pass/Disagree
      + submit controls duplicating the visible UI. display:none removes them
-     from layout, the a11y tree, and the tab order while keeping .click() working. */
+     from layout, the a11y tree, and the tab order while keeping .click() working.
+     NOTE: this whole rule (and the .pvb-hidden span) goes away with #159, which
+     drops the pa-* proxy and talks to Particiapi directly — remove it then. */
   display: none;
 }
 

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -1180,14 +1180,13 @@ pa-statement:state(no-statement) ~ .vote-choice-row { display: none; }
 /* ── Hidden pa-vote-button/pa-submit-button for API submission ── */
 
 .pvb-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
+  /* These pa-* elements exist only so JS can fire them at the API via .click()
+     (which works on display:none elements). They must NOT be visually-hidden
+     (clip/sr-only), because that keeps them in the a11y tree + tab order — a
+     screen-reader/keyboard user would otherwise hit phantom Agree/Pass/Disagree
+     + submit controls duplicating the visible UI. display:none removes them
+     from layout, the a11y tree, and the tab order while keeping .click() working. */
+  display: none;
 }
 
 /* ── Statement display ── */

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -342,6 +342,25 @@ header {
   margin-bottom: 24px;
 }
 
+/* Consultation listing uses real list + heading semantics (a11y); these resets
+   keep the visual appearance identical by neutralising UA list/heading styles. */
+.conv-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+h2.home-section-label {
+  margin: 0;
+  font-weight: 400;
+}
+h3.conv-card-title {
+  margin: 0;
+}
+h3.conv-card-title-wrap {
+  margin: 0;
+  font: inherit;
+}
+
 .home-section-header {
   display: flex;
   align-items: baseline;

--- a/v2/templates/accept.html
+++ b/v2/templates/accept.html
@@ -33,7 +33,7 @@
   {% endif %}
 
   <p style="font-size:14px;color:var(--muted);margin-top:18px;margin-bottom:0">
-    Quick setup before you start — pick a pseudonym and review how your data is handled.
+    Quick setup before you start — pick a pseudonym for this topic and review how your data is handled.
   </p>
 
   <form method="post"
@@ -49,7 +49,6 @@
          aria-labelledby="pseudonym-title"
          aria-describedby="pseudonym-help pseudonym-status">
       <div class="pseudonym-card-header">
-        <div class="pseudonym-card-title" id="pseudonym-title">Pick a name for yourself for this consultation</div>
         <button type="button"
                 class="reroll-btn"
                 id="reroll-btn"
@@ -57,7 +56,7 @@
                 aria-label="Generate new pseudonym options">↻ reroll</button>
       </div>
       <div class="pseudonym-card-sub" id="pseudonym-help">
-        This name appears inside this consultation. It is separate from your Wikimedia username.
+        This name appears next to your opinions in this consultation. It is separate from your Wikimedia username.
       </div>
       <p class="sr-only" id="pseudonym-status" role="status" aria-live="polite"></p>
 
@@ -157,7 +156,7 @@
              required
              aria-required="true">
       <span>
-        I understand that my individual votes are private, my pseudonym may appear
+        I understand that my individual votes will appear with my pseudonym
         in consultation records, and wiki-polis keeps an internal username link
         while the consultation is running.
       </span>

--- a/v2/templates/home.html
+++ b/v2/templates/home.html
@@ -25,7 +25,7 @@
         <ellipse cx="12" cy="12" rx="9" ry="3.5"/>
         <ellipse cx="12" cy="12" rx="3.5" ry="9"/>
       </svg>
-      Continue with Wikimedia
+      Login with Wikimedia
     </a>
     {% if dev_test_users %}
     <div style="margin-top:1.25rem;padding:10px 14px;border:1px dashed var(--spot);border-radius:8px;background:rgba(245,158,11,0.05);display:flex;align-items:center;gap:10px;flex-wrap:wrap">

--- a/v2/templates/home.html
+++ b/v2/templates/home.html
@@ -40,22 +40,26 @@
   </div>
 
   {% if public_conversations %}
-  <section aria-label="Open consultations">
+  <section aria-labelledby="sec-open">
     <div class="home-section">
       <div class="home-section-header">
-        <span class="home-section-label">Open consultations</span>
+        <h2 class="home-section-label" id="sec-open">Open consultations</h2>
         <span class="home-section-count" aria-hidden="true">{{ public_conversations | length }} total</span>
       </div>
-      {% for c in public_conversations %}
-      <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card"
-         aria-label="{{ c.title }} — join consultation">
-        <div class="conv-card-left">
-          <span class="conv-dot conv-dot--available" aria-hidden="true"></span>
-          <span class="conv-card-title">{{ c.title }}</span>
-        </div>
-        <span class="conv-card-action" aria-hidden="true">JOIN →</span>
-      </a>
-      {% endfor %}
+      <ul class="conv-list">
+        {% for c in public_conversations %}
+        <li>
+          <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card"
+             aria-label="{{ c.title }} — join consultation">
+            <div class="conv-card-left">
+              <span class="conv-dot conv-dot--available" aria-hidden="true"></span>
+              <h3 class="conv-card-title">{{ c.title }}</h3>
+            </div>
+            <span class="conv-card-action" aria-hidden="true">JOIN →</span>
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
     </div>
   </section>
   {% endif %}
@@ -65,110 +69,126 @@
   <h1 class="sr-only">Your consultations</h1>
 
   {% if active_joined %}
-  <section aria-label="Active consultations">
+  <section aria-labelledby="sec-active">
     <div class="home-section">
       <div class="home-section-header">
-        <span class="home-section-label">Active</span>
+        <h2 class="home-section-label" id="sec-active">Active</h2>
         <span class="home-section-count" aria-hidden="true">{{ active_joined | length }} consultation{{ 's' if active_joined | length != 1 }}</span>
       </div>
-      {% for c in active_joined %}
-      {% set part = pseudonym_map.get(c.id) %}
-      <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card"
-         aria-label="{{ c.title }}{% if part %} — {{ part.pseudonym }}{% endif %} — {{ 'temporarily paused' if c.paused else 'voting open' }} — continue">
-        <div class="conv-card-left">
-          <span class="conv-dot conv-dot--active" aria-hidden="true"></span>
-          <div class="conv-card-info">
-            <div class="conv-card-title-row">
-              <span class="conv-card-title">{{ c.title }}</span>
-              {% if part %}<span class="conv-card-badge">{{ part.pseudonym }}</span>{% endif %}
+      <ul class="conv-list">
+        {% for c in active_joined %}
+        {% set part = pseudonym_map.get(c.id) %}
+        <li>
+          <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card"
+             aria-label="{{ c.title }}{% if part and part.pseudonym %} — your pseudonym: {{ part.pseudonym }}{% endif %} — {{ 'temporarily paused' if c.paused else 'voting open' }} — continue">
+            <div class="conv-card-left">
+              <span class="conv-dot conv-dot--active" aria-hidden="true"></span>
+              <div class="conv-card-info">
+                <div class="conv-card-title-row">
+                  <h3 class="conv-card-title">{{ c.title }}</h3>
+                  {% if part and part.pseudonym %}<span class="conv-card-badge" aria-hidden="true">{{ part.pseudonym }}</span>{% endif %}
+                </div>
+                <div class="conv-card-sub">
+                  {%- if c.paused -%}temporarily paused{%- else -%}voting open{%- endif -%}
+                </div>
+              </div>
             </div>
-            <div class="conv-card-sub">
-              {%- if c.paused -%}temporarily paused{%- else -%}voting open{%- endif -%}
-            </div>
-          </div>
-        </div>
-        <span class="conv-card-action" aria-hidden="true">CONTINUE →</span>
-      </a>
-      {% endfor %}
+            <span class="conv-card-action" aria-hidden="true">CONTINUE →</span>
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
     </div>
   </section>
   {% endif %}
 
   {% if available %}
-  <section aria-label="Open to you">
+  <section aria-labelledby="sec-available">
     <div class="home-section">
       <div class="home-section-header">
-        <span class="home-section-label">Open to you</span>
+        <h2 class="home-section-label" id="sec-available">Open to you</h2>
         <span class="home-section-count" aria-hidden="true">{{ available | length }} consultation{{ 's' if available | length != 1 }}</span>
       </div>
-      {% for c in available %}
-      <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card"
-         aria-label="{{ c.title }} — join consultation">
-        <div class="conv-card-left">
-          <span class="conv-dot conv-dot--available" aria-hidden="true"></span>
-          <div class="conv-card-info">
-            <span class="conv-card-title">{{ c.title }}</span>
-          </div>
-        </div>
-        <span class="conv-card-action" aria-hidden="true">JOIN →</span>
-      </a>
-      {% endfor %}
+      <ul class="conv-list">
+        {% for c in available %}
+        <li>
+          <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card"
+             aria-label="{{ c.title }} — join consultation">
+            <div class="conv-card-left">
+              <span class="conv-dot conv-dot--available" aria-hidden="true"></span>
+              <div class="conv-card-info">
+                <h3 class="conv-card-title">{{ c.title }}</h3>
+              </div>
+            </div>
+            <span class="conv-card-action" aria-hidden="true">JOIN →</span>
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
     </div>
   </section>
   {% endif %}
 
   {% if archived_joined %}
-  <section aria-label="Closed consultations">
+  <section aria-labelledby="sec-closed">
     <div class="home-section">
       <div class="home-section-header">
-        <span class="home-section-label">Closed</span>
+        <h2 class="home-section-label" id="sec-closed">Closed</h2>
         <span class="home-section-count" aria-hidden="true">{{ archived_joined | length }} consultation{{ 's' if archived_joined | length != 1 }}</span>
       </div>
-      {% for c in archived_joined %}
-      {% set part = pseudonym_map.get(c.id) %}
-      <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card"
-         aria-label="{{ c.title }}{% if part %} — {{ part.pseudonym }}{% endif %} — closed{% if c.closed_at %} {{ c.closed_at.strftime('%B %Y') }}{% endif %}">
-        <div class="conv-card-left">
-          <span class="conv-dot conv-dot--closed" aria-hidden="true"></span>
-          <div class="conv-card-info">
-            <div class="conv-card-title-row">
-              <span class="conv-card-title">{{ c.title }}</span>
-              {% if part %}<span class="conv-card-badge">{{ part.pseudonym }}</span>{% endif %}
+      <ul class="conv-list">
+        {% for c in archived_joined %}
+        {% set part = pseudonym_map.get(c.id) %}
+        <li>
+          <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card"
+             aria-label="{{ c.title }}{% if part and part.pseudonym %} — your pseudonym: {{ part.pseudonym }}{% endif %} — closed{% if c.closed_at %} {{ c.closed_at.strftime('%B %Y') }}{% endif %}">
+            <div class="conv-card-left">
+              <span class="conv-dot conv-dot--closed" aria-hidden="true"></span>
+              <div class="conv-card-info">
+                <div class="conv-card-title-row">
+                  <h3 class="conv-card-title">{{ c.title }}</h3>
+                  {% if part and part.pseudonym %}<span class="conv-card-badge" aria-hidden="true">{{ part.pseudonym }}</span>{% endif %}
+                </div>
+                {% if c.closed_at %}
+                <div class="conv-card-sub">closed {{ c.closed_at.strftime('%b %Y') }}</div>
+                {% endif %}
+              </div>
             </div>
-            {% if c.closed_at %}
-            <div class="conv-card-sub">closed {{ c.closed_at.strftime('%b %Y') }}</div>
-            {% endif %}
-          </div>
-        </div>
-        <span class="conv-card-action" aria-hidden="true">VIEW →</span>
-      </a>
-      {% endfor %}
+            <span class="conv-card-action" aria-hidden="true">VIEW →</span>
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
     </div>
   </section>
   {% endif %}
 
   {% if moderating %}
-  <section aria-label="Consultations you moderate">
+  <section aria-labelledby="sec-moderate">
     <div class="home-section">
       <div class="home-section-header">
-        <span class="home-section-label">You moderate</span>
+        <h2 class="home-section-label" id="sec-moderate">You moderate</h2>
         <span class="home-section-count" aria-hidden="true">{{ moderating | length }} consultation{{ 's' if moderating | length != 1 }}</span>
       </div>
-      {% for c in moderating %}
-      <div class="conv-card conv-card--split">
-        <span class="conv-card-left">
-          <span class="conv-dot {{ 'conv-dot--active' if c.active else 'conv-dot--closed' }}" aria-hidden="true"></span>
-          <a href="{{ url_for('participant.conversation', slug=c.slug) }}"
-             class="conv-card-title">{{ c.title }}</a>
-          {% if not c.active %}<span class="conv-card-badge">closed</span>{% endif %}
-        </span>
-        <span class="conv-card-divider" aria-hidden="true"></span>
-        {# → aria-hidden on "Admin →" not needed — the aria-label overrides the text content #}
-        <a href="{{ url_for('admin.admin_conversation_detail', conv_id=c.id) }}"
-           class="admin-action-btn"
-           aria-label="Open admin panel for {{ c.title }}">Admin →</a>
-      </div>
-      {% endfor %}
+      <ul class="conv-list">
+        {% for c in moderating %}
+        <li>
+          <div class="conv-card conv-card--split">
+            <div class="conv-card-left">
+              <span class="conv-dot {{ 'conv-dot--active' if c.active else 'conv-dot--closed' }}" aria-hidden="true"></span>
+              <h3 class="conv-card-title-wrap"><a href="{{ url_for('participant.conversation', slug=c.slug) }}"
+                 class="conv-card-title" aria-label="{{ c.title }} — open consultation">{{ c.title }}</a></h3>
+              {% if not c.active %}<span class="conv-card-badge">closed</span>{% endif %}
+            </div>
+            <span class="conv-card-divider" aria-hidden="true"></span>
+            {# → aria-hidden on "Admin →" not needed — the aria-label overrides the text content #}
+            <a href="{{ url_for('admin.admin_conversation_detail', conv_id=c.id) }}"
+               class="admin-action-btn"
+               aria-label="Open admin panel for {{ c.title }}">Admin →</a>
+          </div>
+        </li>
+        {% endfor %}
+      </ul>
     </div>
   </section>
   {% endif %}

--- a/v2/tests/test_a11y_markup.py
+++ b/v2/tests/test_a11y_markup.py
@@ -78,6 +78,10 @@ def test_pvb_hidden_uses_display_none_not_sr_only():
     They are fired only via JS .click() (works under display:none). If hidden with
     the visually-hidden clip pattern they stay focusable + in the a11y tree, so a
     screen-reader/keyboard user hits phantom Agree/Pass/Disagree + submit controls.
+
+    REMOVE THIS GUARD when #159 lands: that refactor deletes the hidden pa-*
+    proxy entirely (calling Particiapi directly), so `.pvb-hidden` ceases to
+    exist and this interim test becomes obsolete.
     """
     css = open(_STYLE_CSS, encoding='utf-8').read()
     m = re.search(r'\.pvb-hidden\s*\{([^}]*)\}', css)

--- a/v2/tests/test_a11y_markup.py
+++ b/v2/tests/test_a11y_markup.py
@@ -5,11 +5,14 @@ so a future template edit that drops an aria hook or breaks the
 tab `aria-controls` -> panel `id` coupling fails CI instead of silently
 regressing (the rest of the suite only proves templates still render).
 """
+import os
 import re
 
 import pytest
 
 from db import Conversation, Participation, db
+
+_STYLE_CSS = os.path.join(os.path.dirname(__file__), os.pardir, 'static', 'style.css')
 
 
 @pytest.fixture
@@ -65,6 +68,23 @@ def test_conversation_has_h1_with_title(auth_client, conv, participation):
     resp = auth_client.get('/c/test-conv')
     assert resp.status_code == 200
     assert re.search(rb'<h1[^>]*>\s*Test Conversation\s*</h1>', resp.data)
+
+
+# ── Hidden API-proxy controls must be out of the a11y tree (4.1.2) ─────────────
+
+def test_pvb_hidden_uses_display_none_not_sr_only():
+    """The hidden pa-* vote/submit proxies must be display:none, not clip/sr-only.
+
+    They are fired only via JS .click() (works under display:none). If hidden with
+    the visually-hidden clip pattern they stay focusable + in the a11y tree, so a
+    screen-reader/keyboard user hits phantom Agree/Pass/Disagree + submit controls.
+    """
+    css = open(_STYLE_CSS, encoding='utf-8').read()
+    m = re.search(r'\.pvb-hidden\s*\{([^}]*)\}', css)
+    assert m, '.pvb-hidden rule not found'
+    body = m.group(1)
+    assert re.search(r'display:\s*none', body), '.pvb-hidden must use display:none'
+    assert 'clip:' not in body, '.pvb-hidden must not use the clip/sr-only pattern'
 
 
 # ── Consultation listing semantics (1.3.1 / 2.4.6 / 4.1.2) ─────────────────────

--- a/v2/tests/test_a11y_markup.py
+++ b/v2/tests/test_a11y_markup.py
@@ -67,6 +67,32 @@ def test_conversation_has_h1_with_title(auth_client, conv, participation):
     assert re.search(rb'<h1[^>]*>\s*Test Conversation\s*</h1>', resp.data)
 
 
+# ── Consultation listing semantics (1.3.1 / 2.4.6 / 4.1.2) ─────────────────────
+
+def test_home_listing_has_list_and_heading_semantics(client, conv):
+    """The consultation listing is a real list with heading-navigable titles.
+
+    Sibling <a> cards with no list role gave SR users no "list, N items" / item
+    position; plain <span> titles were not heading-navigable (1.3.1 / 2.4.6).
+    """
+    resp = client.get('/')
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    assert '<ul class="conv-list">' in html
+    assert '<h2 class="home-section-label"' in html
+    assert re.search(r'<h3 class="conv-card-title">\s*Test Conversation\s*</h3>', html)
+
+
+def test_home_pseudonym_announced_with_context(auth_client, conv, participation):
+    """A joined consultation announces the pseudonym labelled as such, not as a
+    bare token, and the redundant visible badge is hidden from AT (1.3.1 / 4.1.2)."""
+    resp = auth_client.get('/')
+    assert resp.status_code == 200
+    html = resp.data.decode()
+    assert 'your pseudonym: happy-fox' in html
+    assert '<span class="conv-card-badge" aria-hidden="true">happy-fox</span>' in html
+
+
 # ── Name/role/value affordances (4.1.2 / 1.3.1) ────────────────────────────────
 
 def test_composer_textareas_have_accessible_names(auth_client, conv, participation):


### PR DESCRIPTION
Follow-up to the a11y audit work, from findings surfaced during **screen-reader testing on staging** of the home/landing page. Addresses items 1–4 of the consultation-listing review (#157), and folds in a previously-unpushed UX copy commit (see below).

Retargeted to `main` now that #150 has merged. Two commits:

## Commit 1 — listing a11y

- **List semantics (WCAG 1.3.1).** Consultation cards were sibling `<a>` elements with no list role — screen readers announced no list, item count, or position. Each section's cards are now `<ul class="conv-list"><li>…`.
- **Heading-navigable titles (WCAG 2.4.6).** Section labels → `<h2>` (referenced by the `<section>` via `aria-labelledby`); card titles → `<h3>`.
- **Pseudonym announced with meaning (WCAG 1.3.1 / 4.1.2).** The pseudonym reached AT only as a bare token in the card's `aria-label` (*"… — wandering-otter — …"*). Now labelled **"your pseudonym: &lt;name&gt;"**, redundant visible badge hidden from AT, empty pseudonym guarded.
- **"You moderate" card (WCAG 2.4.4).** Added the contextual `aria-label` the other cards have.
- No visual change (CSS resets neutralise UA list/heading styling). New rendered-markup regression guards.

## Commit 2 — pending UX copy (recovered)

Cherry-picked a previously-**unpushed** local commit (`ff3dbcc`, authored earlier) so it isn't lost — it overlaps `home.html` with commit 1, so bundling avoids a revert conflict:
- accept page: "pick a pseudonym **for this topic**…"; removed redundant pseudonym-card title; reworded consent line to be direct about vote visibility.
- home: "Continue with Wikimedia" → **"Login with Wikimedia"**.

## Testing
- Full suite green (**247 passed**), incl. new listing-a11y guards.
- **Needs a manual screen-reader pass on staging**: list/item-count announcement, heading navigation, the labelled pseudonym, and the reworded copy.

## Not in this PR (tracked in #157)
Results block (visually tabular, no table semantics) still to be audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)