### PR TITLE
fix(admin): flash on missing title in conversation edit, not bare 400 (#153)

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -957,7 +957,8 @@ def admin_conversation_edit(conv_id):
     fields = _parse_conversation_form()
 
     if not fields['title']:
-        abort(400)
+        flash('Title is required.', 'error')
+        return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
 
     conv.title         = fields['title']
     conv.intro_text    = fields['intro_text']

--- a/v2/tests/test_admin.py
+++ b/v2/tests/test_admin.py
@@ -96,6 +96,18 @@ def test_edit_conversation(admin_client, conv):
     assert conv.access_policy == 'invite_only'
 
 
+def test_edit_conversation_missing_title_flashes(admin_client, conv):
+    """Blank title flashes and redirects back (not a bare 400) — matches create (#153)."""
+    resp = admin_client.post(f'/admin/conversations/{conv.id}/edit', data={
+        'title': '   ',
+        'access_policy': 'public',
+    }, follow_redirects=True)
+    assert resp.status_code == 200
+    assert b'Title is required' in resp.data
+    db.session.refresh(conv)
+    assert conv.title == 'Admin Test Conv'          # unchanged
+
+
 # ── Phase toggles ─────────────────────────────────────────────────────────────
 
 def test_phase_toggles_on(admin_client, conv):


### PR DESCRIPTION
Mirrors the create-path behaviour (#152): a blank title on conversation **edit** now flashes "Title is required." and redirects back, instead of returning a bare HTTP 400.

Closes #153.

- `v2/app.py` — `admin_conversation_edit`: `abort(400)` → `flash + redirect`.
- `v2/tests/test_admin.py` — added `test_edit_conversation_missing_title_flashes`.

60 admin tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)