### PR TITLE
docs: catch up after the June-01 overhaul (+ accessibility conventions)

### DIFF
--- a/v2/guide_deployment.md
+++ b/v2/guide_deployment.md
@@ -438,9 +438,18 @@ Run inside the webservice shell, where pod envvars are present (here you do **no
 
 ### Migration history
 
-| Revision | Description |
-|---|---|
-| `3e86727dbcee` | Phase 6 — adds `phase_informed_voting`, `phase6_polis_conversation_id` to conversations; `phase6_polis_statement_id` to featured_statements; UNIQUE constraints and index. Required when deploying PR #115. |
+Ordered chain (oldest → newest); the current head is `f667548e9519`. Run `flask --app app db upgrade` to apply everything up to the head — you do not apply these individually.
+
+| Order | Revision | Description |
+|---|---|---|
+| 1 | `65de8d5c7314` | Adds `closed_at`, `public_username`, `revealed_at`. |
+| 2 | `b959def66404` | Adds `conversations.paused`. |
+| 3 | `99f8b42af697` | Adds `arguments.hidden`. |
+| 4 | `a3f1c8e2d905` | Adds `participations.new_stmt_ids`. |
+| 5 | `3e86727dbcee` | Phase 6 — adds `phase_informed_voting`, `phase6_polis_conversation_id` to conversations; `phase6_polis_statement_id` to featured_statements; UNIQUE constraints and index. |
+| 6 | `f667548e9519` | Adds `participations.phase6_card_order` (JSON, nullable). **Current head.** |
+
+Verify the live head with `flask --app app db current`; confirm it matches `f667548e9519` after deploying. When new migrations land, append them here.
 
 ### Check whether a migration is needed
 
@@ -534,7 +543,7 @@ To export an envvar to the shell:
 export SECRET_KEY=$(toolforge envvars show SECRET_KEY | tail -1 | awk '{print $NF}')
 ```
 
-`deploy.sh --migrate` does this automatically for `DATABASE_URL`, `SECRET_KEY`, and `PARTICIAPI_BASE_URL`.
+`deploy.sh --migrate` does this automatically — it loads **all** Toolforge envvars dynamically (the full `toolforge envvars list`), so every required variable is present with no hard-coded list to maintain.
 
 ---
 

--- a/v2/guide_deployment.md
+++ b/v2/guide_deployment.md
@@ -415,7 +415,26 @@ bash ~/wiki-polis/deploy.sh
 
 ## Database migrations
 
-Alembic migrations must run inside `toolforge webservice python3.13 shell` — **not** on the bastion shell. The reason: `toolforge envvars` (including `DATABASE_URL`) are only injected into the webservice pod environment, not exported to regular bastion sessions. Running `flask db upgrade` on the bastion will fail with `RuntimeError: DATABASE_URL is not set`.
+There are two ways to run Alembic migrations. **The supported path is `bash ~/wiki-polis/deploy.sh --migrate`** (see below) — it handles the environment for you. The manual webservice-shell path is documented after it as a fallback / for ad-hoc upgrades.
+
+The underlying constraint: `toolforge envvars` (including `DATABASE_URL`) are injected into the webservice pod, not into bastion sessions, **and** the app's production startup runs checks (TRUSTED_HOSTS, distributed rate-limit storage) that also depend on pod-only values. So a bare `flask db upgrade` on the bastion fails twice over — first on `DATABASE_URL`, then on those startup checks.
+
+### `deploy.sh --migrate` and `MIGRATION_MODE`
+
+`deploy.sh --migrate` runs the migration from the bastion by:
+1. **Loading all Toolforge envvars** into the environment dynamically (so `DATABASE_URL` etc. are present — no hard-coded list to maintain).
+2. Running `MIGRATION_MODE=1 flask --app app db upgrade`.
+
+**`MIGRATION_MODE=1`** tells `create_app()` to **skip the web-server-only startup checks** (TRUSTED_HOSTS, RATELIMIT_STORAGE_URI / key / identity secret) that require Kubernetes-injected values unavailable on the bastion. It has **no effect on which code runs** — migrations only touch the database — so it is safe and is the intended way to migrate outside the pod. (It is also handy when running the test suite or any one-off Flask command on a machine without the full production env.)
+
+```bash
+# from the bastion, as the wiki-polis tool
+bash ~/wiki-polis/deploy.sh --migrate
+```
+
+### Manual path (fallback)
+
+Run inside the webservice shell, where pod envvars are present (here you do **not** set `MIGRATION_MODE` — the real env satisfies the checks):
 
 ### Migration history
 

--- a/v2/guide_organizer.md
+++ b/v2/guide_organizer.md
@@ -33,16 +33,25 @@ can then act on. It is **not**:
 
 ## How a consultation works (the phases)
 
-A consultation moves through phases that you turn on in order — each builds on the last.
-Today there are **four toggles**:
+A consultation moves through a linear sequence of phases — each builds on the last:
 
-1. **Open submission** — participants vote on statements and propose their own (the data-collection phase).
-2. **Personal results** — each participant sees where they sit, but only for statements they voted on.
-3. **Argument mapping** — opens a pro/con argument layer on featured statements. Participants read, submit, and vote on short pro/con arguments for each featured statement.
-4. **Full public results** — opens the complete opinion map to everyone, including visitors.
-5. **Informed voting** — a second, independent voting round on the featured statements only. Arguments from Phase 3 are shown inline so participants deliberate before casting a clean Agree / Disagree / Pass vote. Participants who skipped Phase 1 can join here; the statement set is fixed.
+1. **Preparation** — setup only; participants can't do anything yet. You write seed statements, intro text, access and moderation policy, and appoint moderators.
+2. **Submission** — participants submit statements and vote on them (the data-collection phase).
+3. **Featured selection** — participants can see their personal results while you curate the featured statements that the argument layer will use.
+4. **Argument mapping** — opens a pro/con argument layer on the featured statements. Participants read, submit, and vote on short pro/con arguments.
+5. **Informed voting** — a second, independent voting round on the featured statements only, with the Phase 4 arguments shown inline so participants deliberate before casting a clean Agree / Disagree / Pass vote. Participants who skipped earlier phases can join here; the statement set is fixed. Must be **initialised** from the admin panel before the tab appears (see [Enabling informed voting](#enabling-informed-voting)).
+6. **Public results** — opens the complete opinion map to everyone, including visitors. Reaching this phase **permanently closes the consultation** and starts the identity-reveal window.
 
-Phases 1–5 are independent toggles you can enable in any order. Informed voting (Phase 5) requires Phase 3 (argument mapping) to have produced substantive arguments first, and must be **initialised** from the admin panel before the tab appears for participants (see [Enabling informed voting](#enabling-informed-voting) below).
+### Moving between phases
+
+There are two ways to advance, both in the conversation's admin panel:
+
+- **Move on (guided, the normal path).** A "Move on to *<next phase>* →" box walks you one step forward. It spells out the consequences (what opens, what closes, what's irreversible) and shows a **readiness checklist** you must confirm before the button enables. Some items are machine-checked (e.g. "at least one featured statement selected" shows a met / not-met badge); the rest are judgement calls you tick off. The server re-checks everything on submit, so the checklist is a real gate, not just a reminder.
+- **Advanced phase controls (admin only).** An "Advanced phase controls" panel exposes each phase as an independent on/off toggle, including moving **backward**. Use this only when you deliberately need a non-linear state; it opens automatically if the conversation is already in one. Only a site admin (not a conversation moderator) can change phases either way.
+
+**Pause / Resume** is separate from phases: it temporarily disables voting without starting the identity-reveal clock, and is fully reversible. Pausing before informed voting is a good way to buy time to re-invite participants.
+
+The guards that block or warn on these transitions (hard and soft) are catalogued in [`spec_functional-design.md`](spec_functional-design.md#phase-control-and-transition-guards).
 
 ## What a statement is
 
@@ -108,6 +117,27 @@ statements; the rest only vote [3].
 - **What proportion should agree with a good statement?** *Unknown — requires further
   research / literature review.* The sources don't give a target agreement level (the 56%
   figure above is a framing illustration, not a guideline).
+
+### Bulk-importing seed statements (CSV)
+
+Instead of adding seed statements one at a time, you can upload them in bulk from the
+conversation admin panel.
+
+- **Format:** a UTF-8 CSV with a header row containing a **`text`** column (other columns
+  are ignored). One statement per row.
+- **Limits:** up to **20 rows** and **100 KB** per file. A file over either limit is
+  **rejected whole** — nothing is imported — so fix and re-upload rather than getting a
+  partial import.
+- **Validation:** rows with an empty `text` are skipped and reported; the file must be
+  valid UTF-8 with no null bytes. Leading spreadsheet formula characters (`= + - @`) are
+  stripped to prevent CSV-injection.
+- **Result:** after upload you get a summary — how many statements were imported, how many
+  rows were skipped, and how many Polis already had (duplicates are silently ignored by
+  Polis, which is why a re-upload of the same file imports 0).
+
+This seeds statements the same way the manual "add statement" form does; everything in
+[*Writing good statements*](#3-writing-good-statements) above still applies — the limits
+are deliberately low because a good seed set is ~10–15 statements, not hundreds.
 
 ## 4. Open submission and moderate
 

--- a/v2/guide_organizer.md
+++ b/v2/guide_organizer.md
@@ -132,8 +132,10 @@ conversation admin panel.
   valid UTF-8 with no null bytes. Leading spreadsheet formula characters (`= + - @`) are
   stripped to prevent CSV-injection.
 - **Result:** after upload you get a summary — how many statements were imported, how many
-  rows were skipped, and how many Polis already had (duplicates are silently ignored by
-  Polis, which is why a re-upload of the same file imports 0).
+  rows were skipped, and how many were duplicates. Duplicates are detected by wiki-polis
+  itself (case-insensitive, against the statements already in this conversation) and each
+  skipped statement is listed, so re-uploading the same file imports 0 and tells you exactly
+  which rows already existed.
 
 This seeds statements the same way the manual "add statement" form does; everything in
 [*Writing good statements*](#3-writing-good-statements) above still applies — the limits

--- a/v2/log_changelog.md
+++ b/v2/log_changelog.md
@@ -274,3 +274,21 @@ arguments so participants deliberate before casting a clean vote.
 - [x] Wrong Polis vote endpoint: corrected to `PUT /api/conversations/{id}/votes/{tid}`
 - [x] Active/paused guard on vote route
 - [x] CSRF token forwarded to Particiapi on vote
+
+## Step 7 — Admin phase control, CSV import, a11y (2026-06-08)
+
+**Admin phase control** ([#140](https://github.com/lgelauff/wiki-polis/issues/140), [#156](https://github.com/lgelauff/wiki-polis/issues/156))
+- [x] Guided "Move on" forward-transition box: consequence summary + per-phase readiness checklist (client-gated, server-re-validated); machine-checked "≥1 featured statement" precondition with met/not-met badge
+- [x] "Advanced phase controls" (global admin only): independent per-phase toggles incl. backward moves; auto-opens in non-linear state
+- [x] Phase-transition guard catalogue (hard + soft) documented in `spec_functional-design.md`
+
+**Seed CSV import** ([#61](https://github.com/lgelauff/wiki-polis/issues/61))
+- [x] Bulk import seed statements from a `text`-column CSV; 20-row / 100 KB caps; whole-file rejection over limit; UTF-8 + null-byte + formula-injection validation; per-row error reporting; duplicate-safe
+
+**Accessibility** ([#150](https://github.com/lgelauff/wiki-polis/issues/150), [#166](https://github.com/lgelauff/wiki-polis/issues/166))
+- [x] Participant-front WCAG 2.1/2.2 AA audit fixes (live regions, focus, contrast, reduced motion, skip link, headings)
+- [x] Consultation listing: real list + heading semantics, pseudonym announced with context
+- [x] Hidden pa-* API-proxy controls moved to `display:none` so they leave the a11y tree/tab order (interim; full de-dup tracked in [#159](https://github.com/lgelauff/wiki-polis/issues/159))
+
+**Ops**
+- [x] `deploy.sh --migrate` runs Alembic from the bastion via dynamic envvar loading + `MIGRATION_MODE=1` (skips web-server-only startup checks); documented in `guide_deployment.md`

--- a/v2/plan_roadmap.md
+++ b/v2/plan_roadmap.md
@@ -94,8 +94,7 @@ retention commitment (decision D-PRIV), pending legal/comms review.
   warning for un-seeded confirmed statements.
 - **Return engagement** — notifications (talk page / email), "new since last visit".
 - **Analytics export** — structured export of votes / clusters / arguments.
-- **Admin & ops** — seed CSV import
-  ([#61](https://github.com/lgelauff/wiki-polis/issues/61)), ban participant
+- **Admin & ops** — ban participant
   ([#60](https://github.com/lgelauff/wiki-polis/issues/60)), per-conversation
   participants tab ([#42](https://github.com/lgelauff/wiki-polis/issues/42)), statement
   advising module ([#56](https://github.com/lgelauff/wiki-polis/issues/56)), centralised

--- a/v2/spec_accessibility.md
+++ b/v2/spec_accessibility.md
@@ -1,0 +1,88 @@
+# Accessibility conventions
+
+The accessibility patterns we encourage in wiki-polis code. Grounded in Wikimedia's own
+developer guidance so a Wikimedia-ecosystem tool stays idiomatic, and aligned with our stated
+**WCAG 2.1/2.2 AA** target.
+
+**Primary source:** MediaWiki — [Accessibility guide for developers](https://www.mediawiki.org/wiki/Accessibility_guide_for_developers).
+It is opinionated where WCAG is neutral and has already resolved several controversies (notably
+rejecting off-screen-text hiding and favouring progressive enhancement); we follow it.
+
+Enforcement arm: rendered-markup regression guards in `tests/test_a11y_markup.py`.
+
+---
+
+## Principles
+
+1. **Progressive enhancement over graceful degradation.** Semantic HTML that works without JS first; JS only enhances. Never make JS the only path to a control.
+2. **Accessibility is broader than screen readers** — keyboard, magnification, contrast, TTS, custom CSS, RTL, language, low bandwidth all count.
+3. **ARIA is a last resort, not a substitute for HTML** — "keyboard navigation is simply achieved by logical DOM order." Reach for a real element before a role.
+4. **Avoid workarounds that create technical debt.** Prefer future-proof code; when an interim a11y hack is unavoidable, annotate it with a "remove when #N lands" note.
+
+## Conventions
+
+### Semantic HTML
+- Use the right element: `<button>` for actions (never `<div>/<span>` + click, never `<a href="#">` + onclick), `<ul>/<li>` for lists, real `<h1>…<h3>` for structure. *(WCAG 4.1.2 / 1.3.1)*
+- Never nest interactive inside interactive (no button/link inside a link).
+
+### Headings
+- Logical, **no gaps** (never `<h1>`→`<h3>`), descriptive, unique within a level. Headings are a primary screen-reader navigation tool. *(WCAG 2.4.6)*
+
+### Hiding things
+- **Never** push content off-screen with `left:-9999px` / `text-indent:-9999px` — it breaks RTL, breaks positional mobile VoiceOver, and costs render performance.
+- **Name icon-only controls with `aria-label`**, not visually-hidden label text.
+- **To remove a control from assistive tech**, use `display:none` (or `tabindex="-1"` + `aria-hidden` if it must stay visible). Controls that exist only for JS to `.click()` use `display:none` (see `.pvb-hidden`).
+- The clipped `.sr-only` pattern is **only** for text that must be announced but has no visual equivalent (e.g. live-region content, "(opens in a new tab)" cues) — not for hiding controls.
+
+### Focus & keyboard
+- Everything doable with a mouse must work with the keyboard. Non-native interactive elements need `tabindex="0"` **and** an Enter/Space keydown handler.
+- **Always define a `:focus-visible` style wherever you define `:hover` or `:active`.** Never `outline:0` without a replacement. *(WCAG 2.4.7)*
+- Avoid `tabindex > 0`; rely on DOM order.
+
+### Names, descriptions, repetition
+- Accessible **name = the concise action**; secondary/helper text goes in `aria-describedby`, not baked into the name. *(WCAG 2.4.6 "descriptive *and concise*")*
+- Don't repeat the same label many times — explain once, e.g. via `aria-live="polite"`.
+
+### Symbols, language, contrast, images
+- **Avoid bare Unicode symbols** (`→ ↑ ↔`) as meaningful content. If decorative, mark the element `aria-hidden`; if meaningful, wrap in a `<span>` carrying a label/`title`.
+- Set `lang` (and `dir` where relevant) so screen readers pick the right voice.
+- Sufficient contrast; small text needs *more* than the bare WCAG minimum. *(WCAG 1.4.3)*
+- Images: meaningful `alt`; decorative images get empty `alt` or become CSS backgrounds.
+
+### ARIA roles
+- Don't override implicit roles (`<th>`=columnheader, `<li>`=listitem); nest a child element instead.
+- `role="button"`/`"dialog"`/`"alert"` only when a real element won't do; `aria-haspopup` on controls that open dialogs/menus.
+
+### Dialogs
+`aria-haspopup` on opener; `role="dialog"`; move focus in on open and **trap** it; Esc + focusable close button; rest of page `aria-hidden`/inert; return focus to opener on close.
+
+## wiki-polis resolutions
+| Situation | Convention |
+|---|---|
+| Icon/arrow-only affordance ("JOIN →", "↻", "↔") | decorative → `aria-hidden`; never the accessible name |
+| Control that exists only for JS to `.click()` | `display:none` (not clip/sr-only) — see `.pvb-hidden` |
+| SR-only announcement with no visual twin | `.sr-only` clip + `aria-live` (`status`=polite / `alert`=assertive) |
+| Card with title + helper text | name = title (heading); helper via `aria-describedby` |
+| Listing of entities | real `<ul>/<li>` + a heading per item |
+| New `:hover`/`:active` style | add a matching `:focus-visible` style in the same change |
+
+## PR review checklist
+- [ ] Real elements (`button`/`ul`/`h*`); no `div`+click, no `a href="#"`; no interactive nested in interactive.
+- [ ] Heading order has no gaps; titles heading-navigable.
+- [ ] Every interactive element keyboard-operable; visible `:focus-visible`.
+- [ ] Accessible names concise; helper text via `aria-describedby`; no duplicated announcements.
+- [ ] Decorative glyphs/arrows `aria-hidden`; meaningful symbols wrapped/labelled.
+- [ ] Nothing hidden with `-9999px`; AT-removed controls use `display:none`/`tabindex=-1`.
+- [ ] Contrast checked (incl. small text); images have correct `alt`.
+- [ ] Interim a11y hacks carry a "remove when #N lands" note.
+
+## Testing
+- Keyboard-only sweep (Tab / Shift-Tab / Enter / Space / Esc / arrows).
+- VoiceOver (⌘F5) + rotor (headings, landmarks, links); remember iOS VoiceOver is *positional*.
+- axe / Lighthouse for automated catches; `tests/test_a11y_markup.py` for CI regression guards.
+- Contrast checker for new colours; toggle `prefers-reduced-motion` and RTL where layout is non-trivial.
+
+## See also
+- MediaWiki [Accessibility guide for developers](https://www.mediawiki.org/wiki/Accessibility_guide_for_developers) · [Accessibility](https://www.mediawiki.org/wiki/Accessibility)
+- Wikipedia [Manual of Style/Accessibility](https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Accessibility)
+- [`spec_design-principles.md`](spec_design-principles.md)

--- a/v2/spec_design-principles.md
+++ b/v2/spec_design-principles.md
@@ -32,3 +32,7 @@ These are stable. They should not be re-debated in each session; challenge them 
 14. **Phases are stable checkpoints.** Don't blend phases. Each phase must be independently deployable.
 15. **No premature abstraction.** Build for the current phase; refactor when a real need emerges.
 16. **Polis is the deliberation engine.** Don't reimplement clustering, PCA, or vote math. Own the wrapper, not the engine.
+
+## Accessibility
+
+17. **Accessibility is a build requirement, not a polish pass.** Target WCAG 2.1/2.2 AA, follow the MediaWiki [Accessibility guide for developers](https://www.mediawiki.org/wiki/Accessibility_guide_for_developers), and prefer semantic HTML + progressive enhancement over ARIA workarounds. The conventions, PR checklist, and testing recipe live in [`spec_accessibility.md`](spec_accessibility.md).

--- a/v2/spec_functional-design.md
+++ b/v2/spec_functional-design.md
@@ -287,13 +287,63 @@ Admins can:
 - Mark statements as featured
 - Enable or disable the argument layer on a featured statement
 
-**Results phases (four independent toggles per conversation):**
-- Toggle 1: open or close statement submission
-- Toggle 2: enable or disable personal results (visible to logged-in participants for statements they voted on)
-- Toggle 3: show or hide the argument mapping tab
-- Toggle 4: enable or disable full public results (visible to everyone including visitors)
+**Statements:**
+- Add seed statements individually, or **bulk-import** them from a CSV (a `text` column; max 20 rows / 100 KB; the whole file is rejected if over limit; duplicates are ignored by Polis).
+
+**Phases:** see *Phase control* below.
 
 Admins do not need a separate moderation UI for hiding individual statements or arguments — that is handled in the Polis admin interface directly.
+
+---
+
+## Phase control
+
+A conversation moves through a linear sequence of six phases, each backed by a boolean flag on the conversation:
+
+| Order | Phase | Flag | What it enables |
+|---|---|---|---|
+| 1 | Preparation | *(none)* | setup only; participants can't act yet |
+| 2 | Submission | `phase_submission` | participants submit statements and vote |
+| 3 | Featured selection | `phase_personal_results` | participants see personal results while the organizer curates featured statements |
+| 4 | Argument mapping | `phase_argument_mapping` | pro/con argument layer on featured statements |
+| 5 | Informed voting | `phase_informed_voting` (+ `phase6_polis_conversation_id`) | second clean vote round on featured statements; requires a one-time **initialise** |
+| 6 | Public results | `phase_public_results` | full aggregate map public to everyone; **auto-closes** the conversation |
+
+Two control surfaces:
+
+- **Simple / guided ("Move on").** Advances one step forward through the sequence. Renders a consequence summary plus a **readiness checklist** (per-phase preconditions); the submit button is gated client-side until every item is confirmed, and the server re-validates on POST. Machine-checked preconditions (currently only "≥1 confirmed featured statement" before argument mapping) show a met / not-met badge. A closed conversation jumps straight to public results.
+- **Advanced toggles (global admin only).** Each phase flag as an independent on/off control, including backward moves and non-linear states. Opens automatically when the conversation is already in a non-linear state.
+
+Conversation moderators (non-admins) see phase controls read-only. Pause/Resume and Close are separate conversation-status actions (see above), not phases.
+
+### Phase-control and transition guards
+
+Transitions and phase-critical mutations are protected by **hard guards** (block the action server-side) and **soft guards** (warn but allow). Catalogue as implemented:
+
+**Hard guards** (server-side `flash`-error + redirect, or `abort`):
+
+| Guard | Trigger | Message / effect |
+|---|---|---|
+| Featured required for argument mapping | Enabling `phase_argument_mapping` with 0 featured statements | "Cannot enable argument mapping — add at least one featured statement first." |
+| Readiness checklist | "Move on" POST with any unchecked / unmet precondition | "Confirm every readiness check before moving on." / "A readiness condition is not met yet…" |
+| Non-linear state in simple mode | Simple advance while multiple flags are on | "Phases are in a custom state — use Advanced controls to adjust." |
+| Already final | Simple advance at public results | "Already at the final phase (public results)." |
+| Phase 6 init — status | Initialise on a closed or paused conversation | "Cannot initialise Phase 6 on a closed or paused conversation." |
+| Phase 6 init — toggle | Initialise without informed-voting enabled | "Enable the Informed voting toggle first, then initialise." |
+| Phase 6 init — once | Re-initialise | "Phase 6 already initialised." |
+| Last featured — remove | Remove the last featured statement while argument mapping is active | "Cannot remove the last featured statement while argument mapping is active. Disable the argument mapping phase first." (row-locked) |
+| Last featured — hide/pending | Hide or move-to-pending the last featured statement while argument mapping is active | same message |
+| Participant submission | Submit a statement while closed/paused or submission off | HTTP 403 |
+| Participant argument | Propose/skip an argument while closed/paused or argument mapping off | HTTP 403 |
+| Argument-vote gate | Vote on an argument before contributing-or-skipping both sides | HTTP 403 / `{ok:false, reason:"gate"}` |
+| Phase 6 vote | Vote while closed/paused, or informed voting off / not initialised | HTTP 403 / 404 |
+
+**Soft guards** (confirm dialog, disabled control + tooltip, warning banner, inline hint):
+
+- Guided checklist: submit disabled until all boxes ticked and no unmet machine checks.
+- Moderators: phase controls disabled — "Only a site admin can change phases."
+- Consequence banners in the Move-on box (e.g. public results "permanently closes the consultation and starts the identity-reveal window"; informed voting "you can pause first").
+- `confirm()` dialogs on Close permanently and on argument delete.
 
 ---
 

--- a/v2/spec_functional-design.md
+++ b/v2/spec_functional-design.md
@@ -96,7 +96,7 @@ After every vote, a three-card triad appears below the statement. The three opti
 
 So if there are 6 statements, unlock requires 6 votes (100%). If there are 20, unlock requires 10 votes. The threshold can be configured per conversation (`new_stmt_unlock_at`, default 10).
 
-Once unlocked, each participant may submit at most **3 new statements** per conversation (default; future: configurable per conversation as `new_stmt_max`). The remaining count is shown on the card (e.g. "2 of 3 remaining"). Once the quota is exhausted, the card is permanently disabled for that participant in that conversation.
+Once unlocked, each participant may submit at most **3 new statements** per conversation (default; configurable per conversation as `new_stmt_max`). The remaining count is shown on the card (e.g. "2 of 3 remaining"). Once the quota is exhausted, the card is permanently disabled for that participant in that conversation.
 
 Wording suggestions ("Suggest different wording") do not count against this quota.
 
@@ -332,7 +332,7 @@ Transitions and phase-critical mutations are protected by **hard guards** (block
 | Phase 6 init — toggle | Initialise without informed-voting enabled | "Enable the Informed voting toggle first, then initialise." |
 | Phase 6 init — once | Re-initialise | "Phase 6 already initialised." |
 | Last featured — remove | Remove the last featured statement while argument mapping is active | "Cannot remove the last featured statement while argument mapping is active. Disable the argument mapping phase first." (row-locked) |
-| Last featured — hide/pending | Hide or move-to-pending the last featured statement while argument mapping is active | same message |
+| Last featured — hide/pending | Hide or move-to-pending the last featured statement while argument mapping is active | "Cannot hide or move the last featured statement to pending while argument mapping is active. Disable the argument mapping phase first." (not row-locked — best-effort count check) |
 | Participant submission | Submit a statement while closed/paused or submission off | HTTP 403 |
 | Participant argument | Propose/skip an argument while closed/paused or argument mapping off | HTTP 403 |
 | Argument-vote gate | Vote on an argument before contributing-or-skipping both sides | HTTP 403 / `{ok:false, reason:"gate"}` |


### PR DESCRIPTION
Documents behaviour merged since the last major doc pass (#95, 2026-06-01) that shipped without durable docs, **plus** a new accessibility-conventions spec. **Docs only — no code changes.**

Analysis pinned to `main` @ `85202005` (proposal in `.claude/doc-update-proposal.md`; a11y deep-dive in `.claude/accessibility-conventions-proposal.md`).

## Changes
- **`guide_organizer.md`** — real six-phase model; guided "Move on" checklist vs advanced toggles + pause/resume (#140, #156); Bulk-import-via-CSV section (#61).
- **`spec_functional-design.md`** — new Phase control section; hard/soft phase-transition **guard catalogue**; refreshed stale "four toggles" admin list; CSV import note.
- **`guide_deployment.md`** — `deploy.sh --migrate` + `MIGRATION_MODE` (run Alembic from the bastion; skips web-server-only startup checks); reconciled the old "must run in the webservice shell" note.
- **`plan_roadmap.md`** — CSV import moved out of "planned" (shipped).
- **`log_changelog.md`** — Step 7 entry.
- **`spec_accessibility.md` (new)** — accessibility conventions grounded in the MediaWiki [Accessibility guide for developers](https://www.mediawiki.org/wiki/Accessibility_guide_for_developers) + WCAG 2.1/2.2 AA: principles, do/don't conventions, wiki-polis resolutions (hidden-control rule, sr-only vs display:none vs aria-label, decorative arrows, name vs aria-describedby), a PR checklist, and a testing recipe. Enforced by `test_a11y_markup.py`.
- **`spec_design-principles.md`** — new principle 17 linking the a11y spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)