### PR TITLE
fix(#169): harden standalone phase6-init + deferred tests + a11y

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -200,7 +200,8 @@ def _check_confirmed_featured(conv):
     selected count against the recommended target so the organizer can judge coverage."""
     n = (FeaturedStatement.query
          .filter_by(conversation_id=conv.id, confirmed_by_admin=True).count())
-    return n > 0, f'{n} selected, {_RECOMMENDED_FEATURED} recommended'
+    note = f'{n} selected, {_RECOMMENDED_FEATURED} recommended' if n > 0 else None
+    return n > 0, note
 
 
 # Machine-verifiable preconditions: name → check(conv) -> (met: bool, note: str|None).
@@ -1181,11 +1182,21 @@ def admin_phase6_init(conv_id):
     if not ok:
         flash(msg, 'error')
         return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
+    orphan_id = conv.phase6_polis_conversation_id  # capture before any rollback expires it
+    slug = conv.slug
     try:
         db.session.commit()
     except IntegrityError:
         db.session.rollback()
         flash('Phase 6 was already initialised by a concurrent request.', 'error')
+        return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
+    except SQLAlchemyError:
+        db.session.rollback()
+        current_app.logger.error(
+            'Phase 6 standalone init: DB error after Polis I/O — '
+            'orphaned Polis conversation %s (conv %s)', orphan_id, slug)
+        flash('Phase 6 initialisation failed due to a database error. '
+              'Contact a site admin — the Polis conversation id has been logged.', 'error')
         return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
     flash(msg, 'success')
     return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))

--- a/v2/app.py
+++ b/v2/app.py
@@ -1192,6 +1192,10 @@ def admin_phase6_init(conv_id):
         return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
     except SQLAlchemyError:
         db.session.rollback()
+        # Logged unconditionally (unlike the guided route's `if created_p6:`
+        # guard): this route early-returns when an id already exists and has no
+        # re-sync path, so reaching the commit means _init_phase6 just created a
+        # fresh Polis conversation, now orphaned by the rollback.
         current_app.logger.error(
             'Phase 6 standalone init: DB error after Polis I/O — '
             'orphaned Polis conversation %s (conv %s)', orphan_id, slug)

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -1861,6 +1861,12 @@ a { color: var(--pass); }
   font-weight: 600;
 }
 
+.badge-paused-inline {
+  color: var(--spot);
+  font-size: 12px;
+  font-weight: 600;
+}
+
 /* ── Statement moderation table ── */
 
 .stmt-table .stmt-text {

--- a/v2/templates/admin.html
+++ b/v2/templates/admin.html
@@ -28,7 +28,7 @@
           {% if not c.active %}
             <span class="badge-inactive">closed</span>
           {% elif c.paused %}
-            <span style="color:#b07800;font-size:12px;font-weight:600">paused</span>
+            <span style="color:var(--spot);font-size:12px;font-weight:600">paused</span>
           {% else %}
             <span class="badge-active-inline">active</span>
           {% endif %}

--- a/v2/templates/admin.html
+++ b/v2/templates/admin.html
@@ -28,7 +28,7 @@
           {% if not c.active %}
             <span class="badge-inactive">closed</span>
           {% elif c.paused %}
-            <span style="color:var(--spot);font-size:12px;font-weight:600">paused</span>
+            <span class="badge-paused-inline">paused</span>
           {% else %}
             <span class="badge-active-inline">active</span>
           {% endif %}

--- a/v2/tests/test_admin.py
+++ b/v2/tests/test_admin.py
@@ -706,6 +706,17 @@ def test_featured_check_shows_selected_count_and_recommendation(admin_client, co
     assert b'2 selected, 15 recommended' in resp.data
 
 
+def test_featured_check_zero_confirmed_suppresses_count(admin_client, conv):
+    """With zero confirmed featured the row shows "not met yet" and suppresses the
+    redundant "(0 selected, ...)" note - _check_confirmed_featured returns note=None."""
+    conv.phase_personal_results = True
+    db.session.commit()
+    resp = admin_client.get(f'/admin/conversations/{conv.id}')
+    assert resp.status_code == 200
+    assert b'not met yet' in resp.data
+    assert b'selected, 15 recommended' not in resp.data
+
+
 def test_non_linear_state_suppresses_box(admin_client, conv):
     conv.phase_submission = True
     conv.phase_public_results = True

--- a/v2/tests/test_admin.py
+++ b/v2/tests/test_admin.py
@@ -728,6 +728,16 @@ def test_move_rejects_non_on_checkbox_value(admin_client, conv):
     assert conv.phase_submission is False
 
 
+@pytest.mark.parametrize('bad_value', ['true', ''])
+def test_move_rejects_non_on_checkbox_variants(admin_client, conv, bad_value):
+    """'true' and '' are not accepted — only the literal 'on' passes."""
+    data = {k: bad_value for k in _checks_for(conv)}
+    resp = _move(admin_client, conv, data=data)
+    assert resp.status_code == 302
+    db.session.refresh(conv)
+    assert conv.phase_submission is False
+
+
 def test_move_requires_every_checkbox(admin_client, conv):
     """Dropping ANY single precondition blocks — not just the first."""
     all_checks = _checks_for(conv)
@@ -813,6 +823,40 @@ def test_move_informed_voting_empty_text_aborts(admin_client, conv):
     assert conv.phase6_polis_conversation_id is None
     cc.assert_called_once()       # remote conversation was created…
     seed.assert_not_called()      # …but seeding never started (empty text aborts)
+
+
+def test_move_informed_voting_none_text_aborts(admin_client, conv):
+    """A statement_text of None (not '') aborts Phase 6 init — same path as empty string."""
+    conv.phase_cleanup = True
+    db.session.commit()
+    _add_featured(conv, text=None)
+    with patch('app.PolisServerClient.create_conversation', return_value='p6y') as cc, \
+         patch('app.PolisServerClient.add_seed_return_id', return_value=1) as seed:
+        admin_client.post(f'/admin/conversations/{conv.id}/phase/advance',
+                          data=_checks_for(conv))
+    db.session.refresh(conv)
+    assert conv.phase_informed_voting is False
+    assert conv.phase6_polis_conversation_id is None
+    cc.assert_called_once()
+    seed.assert_not_called()
+
+
+def test_move_polis_create_error_leaves_flags_untouched(admin_client, conv):
+    """If create_conversation raises, the phase flag must not be mutated and
+    set_vis_type must never be reached — the Polis I/O runs before the flag write."""
+    from app import PolisServerError
+    conv.phase_cleanup = True
+    db.session.commit()
+    _add_featured(conv)
+    with patch('app.PolisServerClient.set_vis_type') as vis, \
+         patch('app.PolisServerClient.create_conversation',
+               side_effect=PolisServerError('network error')):
+        admin_client.post(f'/admin/conversations/{conv.id}/phase/advance',
+                          data=_checks_for(conv))
+    db.session.refresh(conv)
+    assert conv.phase_informed_voting is False   # flag not set
+    assert conv.phase_cleanup is True            # current flag not cleared
+    vis.assert_not_called()                      # set_vis_type never reached
 
 
 def test_move_commit_failure_rolls_back_and_logs_orphan(admin_client, conv, caplog):
@@ -965,6 +1009,28 @@ def test_phase6_init_integrityerror_flashes(admin_client, conv):
         resp = admin_client.post(f'/admin/conversations/{conv.id}/phase6/init',
                                  follow_redirects=True)
     assert b'already initialised by a concurrent request' in resp.data.lower()
+
+
+def test_phase6_init_sqlalchemy_error_flashes_and_logs_orphan(admin_client, conv, caplog):
+    """A non-integrity DB error (deadlock/timeout) after Polis I/O must not 500:
+    it rolls back, logs the orphaned Polis conversation id, and shows an error flash."""
+    import logging
+    from sqlalchemy.exc import OperationalError
+    conv.phase_informed_voting = True
+    db.session.commit()
+    _add_featured(conv)
+    with patch('app.PolisServerClient.create_conversation', return_value='p6orphanSA'), \
+         patch('app.PolisServerClient.add_seed_return_id', return_value=7), \
+         patch('app.db.session.commit',
+               side_effect=OperationalError('stmt', {}, Exception('deadlock'))), \
+         caplog.at_level(logging.ERROR):
+        resp = admin_client.post(f'/admin/conversations/{conv.id}/phase6/init',
+                                 follow_redirects=True)
+    assert resp.status_code == 200
+    assert b'database error' in resp.data.lower()
+    assert 'p6orphanSA' in caplog.text
+    db.session.refresh(conv)
+    assert conv.phase6_polis_conversation_id is None   # rolled back
 
 
 # ── Pause / close ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #169 (all items).

## Changes

### Hardening — `admin_phase6_init` exception scope
`admin_phase6_init` previously caught only `IntegrityError` after the commit. A non-integrity failure (deadlock, timeout, lost connection) after Polis I/O would leave an orphaned Polis conversation with no log and an unhandled 500.

- Add `except SQLAlchemyError` handler: captures `orphan_id` and `slug` *before* the commit (so rollback can't expire them), rolls back, logs the orphaned Polis conversation id, and flashes an actionable message
- Mirrors the existing pattern in `admin_conversation_advance`

### Tests (breadth items from round-2 review)
- `'true'` and `''` checkbox values rejected (parametrized alongside the existing `'1'` test)
- `statement_text=None` abort path (same code branch as `''`, confirmed via `fs.statement_text or ''`)
- `create_conversation` error leaves flags and `set_vis_type` untouched — pins the Polis-I/O-before-flag-write ordering invariant
- Standalone `phase6_init` `SQLAlchemyError`: flashes correct message, logs orphan id, asserts `conv.phase6_polis_conversation_id is None` after rollback (matches sibling test)

### a11y
- `admin.html`: replace inline `#b07800` "paused" label with `var(--spot)` (`#b45309`, WCAG AA) — residual from the #150 sweep, flagged in #157

## Test plan
- [ ] `v2/.venv/bin/pytest v2/tests/` — 310 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)