### PR TITLE
chore: commit Claude plugin config for cloud sessions

### DIFF
--- a/.claude/pr-check.json
+++ b/.claude/pr-check.json
@@ -1,0 +1,70 @@
+{
+  "_comment": "Per-project config for the pr-check skill. Copy to .claude/pr-check.json in the consuming repo and adjust. This example is the wiki-polis (Flask v2) binding.",
+  "base_ref": "origin/main",
+  "test_command": "cd v2 && DATABASE_URL=\"sqlite:///:memory:\" SECRET_KEY=\"00000000000000000000000000000000\" FLASK_DEBUG=1 uv run pytest -q",
+  "scope": {
+    "TEMPLATES_CSS": [
+      "v2/templates/*.html",
+      "v2/static/*.css"
+    ],
+    "JS": [
+      "*.js"
+    ],
+    "DB": [
+      "v2/migrations/*",
+      "v2/db.py"
+    ],
+    "OPS": [
+      "deploy.sh",
+      "*.ini",
+      "*.env*",
+      "*docker*"
+    ],
+    "PY": [
+      "v2/*.py"
+    ],
+    "RUNTIME": [
+      "v2/templates/conversation.html",
+      "v2/templates/reveal.html",
+      "v2/polis_admin.py"
+    ]
+  },
+  "sensitive_patterns": [
+    "oauth",
+    "login",
+    "session[",
+    "csrf",
+    "secret",
+    "token",
+    "access_policy",
+    "is_global_admin",
+    "_require_mod",
+    ".execute("
+  ],
+  "reviewers": {
+    "_always": [
+      "senior-engineer"
+    ],
+    "TEMPLATES_CSS": [
+      "accessibility",
+      "usability"
+    ],
+    "JS": [
+      "frontend-js"
+    ],
+    "DB": [
+      "database"
+    ],
+    "OPS": [
+      "ops"
+    ]
+  },
+  "a11y_spec": "v2/spec_accessibility.md",
+  "e2e_skill": "local-e2e",
+  "staging_skill": "staging-chrome-test",
+  "browser": {
+    "base_url": "http://localhost:5000",
+    "serve": "local-e2e",
+    "playwright": "python"
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "extraKnownMarketplaces": {
+    "wikimedia-agent-tooling": {
+      "source": { "source": "github", "repo": "lgelauff/wikimedia-coding-agent-lessons" }
+    }
+  },
+  "enabledPlugins": {
+    "agent-tooling@wikimedia-agent-tooling": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # Claude
-.claude/
+.claude/*
+# Cloud-session config: committed so Claude Code on the web installs the
+# agent-tooling plugin + reads its bindings. Both are secret-free.
+!.claude/settings.json
+!.claude/pr-check.json
 notes.md
 tmp/
 .dev-session


### PR DESCRIPTION
Declares the `wikimedia-agent-tooling` marketplace (github source) + enables the `agent-tooling` plugin in committed `.claude/settings.json`, so Claude Code on the web installs `/pr-check` and `/browser-verify` at session start. Un-ignores the two secret-free config files; rest of `.claude/` stays ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)