### PR TITLE
feat(admin): phase-specific statistics in the conversation window (#165)

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -286,6 +286,105 @@ def _transition_context(conv):
     }
 
 
+def _featured_counts(conv):
+    """(confirmed, total) featured statements for one conversation."""
+    base = FeaturedStatement.query.filter_by(conversation_id=conv.id)
+    return (base.filter_by(confirmed_by_admin=True).count(), base.count())
+
+
+def _argument_stats(conv):
+    """Argument-phase aggregates for one conversation (Flask DB only).
+
+    Counts human-authored, visible arguments — seeds (NULL proposer_id) and
+    hidden/moderated arguments are excluded — plus the distinct participants
+    who contributed or rated arguments.
+    """
+    visible = (db.session.query(Argument)
+               .join(FeaturedStatement, Argument.featured_statement_id == FeaturedStatement.id)
+               .filter(FeaturedStatement.conversation_id == conv.id,
+                       Argument.hidden.is_(False),
+                       Argument.proposer_id.isnot(None)))
+    by_side = dict(visible.with_entities(Argument.side, db.func.count(Argument.id))
+                          .group_by(Argument.side).all())
+    n_contributors = (visible.with_entities(db.func.count(db.distinct(Argument.proposer_id)))
+                             .scalar() or 0)
+    n_raters = (db.session.query(db.func.count(db.distinct(ArgumentVote.participant_id)))
+                .join(Argument, ArgumentVote.argument_id == Argument.id)
+                .join(FeaturedStatement, Argument.featured_statement_id == FeaturedStatement.id)
+                .filter(FeaturedStatement.conversation_id == conv.id).scalar() or 0)
+    return {
+        'n_pro':          int(by_side.get('pro', 0)),
+        'n_con':          int(by_side.get('con', 0)),
+        'n_contributors': int(n_contributors),
+        'n_raters':       int(n_raters),
+    }
+
+
+def _phase_stats(conv, polis_stats, phase6_stats=None):
+    """Tiles for the phase-hero readout, scoped to the conversation's current phase
+    (#165). Each tile is {value, label, unit?, note?}.
+
+    Polis-derived tiles (vote/participant counts) are omitted when polis_stats is
+    None — the template shows a loud warning instead. Flask-derived tiles (featured
+    statements, arguments) always render, since they don't depend on Polis PG.
+    """
+    def polis_basic():
+        if not polis_stats:
+            return []
+        return [
+            {'value': polis_stats['n_participants'], 'label': 'participants'},
+            {'value': polis_stats['n_votes'],        'label': 'votes cast'},
+            {'value': polis_stats['n_statements'],
+             'label': 'statements ({} seed)'.format(polis_stats['n_seed'])},
+        ]
+
+    key   = PHASE_SEQUENCE[_current_stage_index(conv)]['key']
+    tiles = []
+
+    if key == 'submission':
+        tiles = polis_basic()
+        if polis_stats:
+            tiles.append({'value': polis_stats['avg_votes'],    'label': 'avg votes / person'})
+            tiles.append({'value': polis_stats['median_votes'], 'label': 'median votes / person'})
+
+    elif key == 'featured_selection':
+        confirmed, _ = _featured_counts(conv)
+        tiles.append({'value': confirmed, 'label': 'featured selected',
+                      'note': '{} recommended'.format(_RECOMMENDED_FEATURED)})
+        if polis_stats:
+            tiles.append({'value': polis_stats['n_statements'],   'label': 'candidate statements'})
+            tiles.append({'value': polis_stats['n_participants'], 'label': 'participants'})
+
+    elif key in ('argument_mapping', 'cleanup'):
+        confirmed, _ = _featured_counts(conv)
+        a = _argument_stats(conv)
+        tiles.append({'value': confirmed,          'label': 'featured statements'})
+        tiles.append({'value': a['n_pro'],         'label': 'pro arguments'})
+        tiles.append({'value': a['n_con'],         'label': 'con arguments'})
+        tiles.append({'value': a['n_contributors'], 'label': 'contributors'})
+        if key == 'argument_mapping':
+            tiles.append({'value': a['n_raters'],  'label': 'rating arguments'})
+
+    elif key == 'informed_voting':
+        confirmed, _ = _featured_counts(conv)
+        seeded = (FeaturedStatement.query
+                  .filter(FeaturedStatement.conversation_id == conv.id,
+                          FeaturedStatement.confirmed_by_admin.is_(True),
+                          FeaturedStatement.phase6_polis_statement_id.isnot(None))
+                  .count())
+        tiles.append({'value': '{}/{}'.format(seeded, confirmed), 'label': 'statements seeded'})
+        if phase6_stats:
+            tiles.append({'value': phase6_stats['n_participants'], 'label': 'voted this round'})
+            tiles.append({'value': phase6_stats['n_votes'],        'label': 'informed votes'})
+        if polis_stats:
+            tiles.append({'value': polis_stats['n_participants'], 'label': 'round 1 participants'})
+
+    else:  # preparation, public_results — show the headline totals
+        tiles = polis_basic()
+
+    return tiles
+
+
 csrf    = CSRFProtect()
 # No global default — limits applied per endpoint only.
 # Toolforge provides TOOL_REDIS_URI; production startup validates Redis isolation.
@@ -940,7 +1039,15 @@ def admin_conversation_detail(conv_id):
     )
     invite_count      = ConversationInvite.query.filter_by(conversation_id=conv_id).count()
     participant_count = Participation.query.filter_by(conversation_id=conv_id).count()
-    polis_stats       = _polis_server_client().get_polis_stats(conv.polis_id)
+    client            = _polis_server_client()
+    polis_stats       = client.get_polis_stats(conv.polis_id)
+    phase6_stats      = (client.get_polis_stats(conv.phase6_polis_conversation_id)
+                         if conv.phase_informed_voting and conv.phase6_polis_conversation_id
+                         else None)
+    # Loud warning only when Polis PG is configured but unreachable — never when it is
+    # deliberately not wired (local/dev), where None is expected.
+    polis_pg_configured     = bool(current_app.config.get('POLIS_DATABASE_URL'))
+    polis_stats_unavailable = polis_pg_configured and polis_stats is None
     return render_template('admin_conversation.html',
                            conversation=conv,
                            conv_roles=conv_roles,
@@ -948,6 +1055,8 @@ def admin_conversation_detail(conv_id):
                            invite_count=invite_count,
                            participant_count=participant_count,
                            polis_stats=polis_stats,
+                           phase_stats=_phase_stats(conv, polis_stats, phase6_stats),
+                           polis_stats_unavailable=polis_stats_unavailable,
                            admin_roles=ADMIN_ROLES,
                            can_manage_roles=can_manage_roles,
                            phase_sequence=PHASE_SEQUENCE,

--- a/v2/app.py
+++ b/v2/app.py
@@ -1042,18 +1042,22 @@ def admin_conversation_detail(conv_id):
     participant_count = Participation.query.filter_by(conversation_id=conv_id).count()
     client            = _polis_server_client()
     polis_stats       = client.get_polis_stats(conv.polis_id)
+    # Round-2 tiles render only when the *displayed* stage is informed voting (the
+    # furthest-along flag), which can differ from the raw phase_informed_voting flag in
+    # non-linear states. Key the phase-6 fetch and its warning off the same stage, so the
+    # banner can't fire for round-2 tiles that were never shown (#165).
+    in_informed_voting = PHASE_SEQUENCE[_current_stage_index(conv)]['key'] == 'informed_voting'
     phase6_stats      = (client.get_polis_stats(conv.phase6_polis_conversation_id)
-                         if conv.phase_informed_voting and conv.phase6_polis_conversation_id
+                         if in_informed_voting and conv.phase6_polis_conversation_id
                          else None)
     # Loud warning only when Polis PG is configured but unreachable — never when it is
-    # deliberately not wired (local/dev), where None is expected.
+    # deliberately not wired (local/dev), where None is expected. Unavailable if the
+    # round-1 fetch failed, or — in informed voting — the round-2 (phase-6) fetch failed
+    # (without that a phase-6 outage would drop the round-2 tiles silently).
     polis_pg_configured     = bool(current_app.config.get('POLIS_DATABASE_URL'))
-    # Unavailable if the round-1 fetch failed, or — in informed voting — the round-2
-    # (phase-6) fetch failed. Without the second clause a phase-6 outage would drop the
-    # round-2 tiles silently, defeating the warning's purpose (#165).
     polis_stats_unavailable = polis_pg_configured and (
         polis_stats is None
-        or (conv.phase_informed_voting and conv.phase6_polis_conversation_id
+        or (in_informed_voting and conv.phase6_polis_conversation_id
             and phase6_stats is None))
     return render_template('admin_conversation.html',
                            conversation=conv,

--- a/v2/app.py
+++ b/v2/app.py
@@ -311,7 +311,8 @@ def _argument_stats(conv):
     n_raters = (db.session.query(db.func.count(db.distinct(ArgumentVote.participant_id)))
                 .join(Argument, ArgumentVote.argument_id == Argument.id)
                 .join(FeaturedStatement, Argument.featured_statement_id == FeaturedStatement.id)
-                .filter(FeaturedStatement.conversation_id == conv.id).scalar() or 0)
+                .filter(FeaturedStatement.conversation_id == conv.id,
+                        Argument.hidden.is_(False)).scalar() or 0)
     return {
         'n_pro':          int(by_side.get('pro', 0)),
         'n_con':          int(by_side.get('con', 0)),
@@ -1047,7 +1048,13 @@ def admin_conversation_detail(conv_id):
     # Loud warning only when Polis PG is configured but unreachable — never when it is
     # deliberately not wired (local/dev), where None is expected.
     polis_pg_configured     = bool(current_app.config.get('POLIS_DATABASE_URL'))
-    polis_stats_unavailable = polis_pg_configured and polis_stats is None
+    # Unavailable if the round-1 fetch failed, or — in informed voting — the round-2
+    # (phase-6) fetch failed. Without the second clause a phase-6 outage would drop the
+    # round-2 tiles silently, defeating the warning's purpose (#165).
+    polis_stats_unavailable = polis_pg_configured and (
+        polis_stats is None
+        or (conv.phase_informed_voting and conv.phase6_polis_conversation_id
+            and phase6_stats is None))
     return render_template('admin_conversation.html',
                            conversation=conv,
                            conv_roles=conv_roles,

--- a/v2/log_changelog.md
+++ b/v2/log_changelog.md
@@ -312,3 +312,13 @@ the guided "Move on" box and double as readiness signals (#156).
   not wired (local/dev), where None is expected
 - [x] Tests: per-phase tile correctness (featured-selection, argument-mapping, informed-vote
   with mocked Phase 6 stats) + warning shown / not-shown by PG-configured state
+
+**Review fixes (pr-check #183)**
+- [x] Warning banner now also fires when the **round-2 (Phase 6) stats fetch fails** during
+  informed voting — previously a phase-6 outage dropped the round-2 tiles silently
+- [x] `n_raters` excludes raters whose only votes were on hidden/moderated arguments,
+  matching the `Argument.hidden` filter the sibling tiles already apply
+- [x] a11y: each stat tile carries an `aria-label` tying value→label→note together (screen
+  readers read one phrase, not a stream of loose numbers); warning banner uses `role="status"`
+  (not the render-time-inappropriate `role="alert"`); warning text darkened to clear AA
+  contrast on the tinted panel

--- a/v2/log_changelog.md
+++ b/v2/log_changelog.md
@@ -292,3 +292,23 @@ arguments so participants deliberate before casting a clean vote.
 
 **Ops**
 - [x] `deploy.sh --migrate` runs Alembic from the bastion via dynamic envvar loading + `MIGRATION_MODE=1` (skips web-server-only startup checks); documented in `guide_deployment.md`
+
+## Phase-specific admin statistics (2026-06-09, [#165](https://github.com/lgelauff/wiki-polis/issues/165))
+
+The admin conversation window's phase-hero stat block now shows numbers **scoped to the
+current phase** instead of a fixed participants/votes/statements readout — they sit above
+the guided "Move on" box and double as readiness signals (#156).
+
+- [x] `_phase_stats(conv, polis_stats, phase6_stats)` builds per-phase tiles: Explore →
+  participants / votes / statements + avg & median votes; Featured selection → selected vs
+  recommended + candidate pool; Arguments & Cleanup → featured count, pro/con argument
+  counts (human, visible — seeds and hidden excluded), distinct contributors & raters;
+  Informed vote → statements seeded, round-2 participants/votes (from the Phase 6 Polis
+  conversation) vs round-1 participants; Report → headline totals
+- [x] Flask-derived tiles (featured, arguments) render even when Polis PG is down — only
+  Polis-derived counts depend on it
+- [x] **Loud warning banner** in the hero when `POLIS_DATABASE_URL` is configured but the
+  stats DB is unreachable (`get_polis_stats` → None); stays silent when PG is intentionally
+  not wired (local/dev), where None is expected
+- [x] Tests: per-phase tile correctness (featured-selection, argument-mapping, informed-vote
+  with mocked Phase 6 stats) + warning shown / not-shown by PG-configured state

--- a/v2/plan_roadmap.md
+++ b/v2/plan_roadmap.md
@@ -17,9 +17,11 @@ Production is **live** at `wiki-polis.toolforge.org` (Toolforge Flask app + VPS 
 up). Provisioning, OAuth, secrets, and the Flask↔VPS wiring are done. Remaining
 operational hardening:
 
-- **Backups — top priority, not confirmed running.** Production is live without
-  verified backups; set up / confirm the nightly `pg_dump` → offsite, then rehearse a
-  restore. Address before other hardening.
+- **Backups — top priority, not confirmed running**
+  ([#139](https://github.com/lgelauff/wiki-polis/issues/139)). Production is live without
+  verified backups; the plan (daily `pg_dump` → Backblaze B2 via `rclone`, 14-day
+  retention, dead-man's-switch alert, restore drill in the runbook) is scoped on #139 but
+  not yet running. Address before other hardening.
 - Monitoring / alerting — deferred (D-MON,
   [#49](https://github.com/lgelauff/wiki-polis/issues/49)).
 
@@ -39,9 +41,12 @@ retention commitment (decision D-PRIV), pending legal/comms review.
   `participant_bp`; `_register_routes` complexity 177→33. Steps 1–4 (PR #88), 5–6 (#97),
   7 (#98), 8 (#99), 9 (#100); issues #89–93 closed. See
   [`log_changelog.md`](log_changelog.md).
-- **Soak harness follow-up** — `synthetic_traffic.py` soaks the proxy/vote path; its
-  accept step doesn't yet establish a Participation, so `statements/new` returns 401 and is
-  not exercised. Fix the accept step so statement-submit gets soak coverage too.
+- **Soak harness follow-up**
+  ([#130](https://github.com/lgelauff/wiki-polis/issues/130)) — `synthetic_traffic.py`
+  soaks the proxy/vote path, but its `act_submit` step broke after the same-origin CSRF
+  validation landed (#106) and the accept step doesn't establish a Participation, so
+  `statements/new` returns 401 and is not exercised. Fix the accept step so
+  statement-submit gets soak coverage too.
 - **Testing strategy / CI** — decision pending (D-TEST); recommendation in
   `.claude/testing-strategy-recommendations.md`. Leaning toward a CI gate on PRs plus
   coverage for the untested risky paths (proxy, reveal-window timing, Polis-Postgres
@@ -53,26 +58,30 @@ retention commitment (decision D-PRIV), pending legal/comms review.
 
 ## 4. Product / UX
 
-- **Voting** — "change vote" reopens + resubmits to Polis
-  ([#69](https://github.com/lgelauff/wiki-polis/issues/69)); three-action footer polish
-  ([#64](https://github.com/lgelauff/wiki-polis/issues/64)); slug-format hint on
-  validation ([#68](https://github.com/lgelauff/wiki-polis/issues/68)); mobile tap
-  affordance ([#71](https://github.com/lgelauff/wiki-polis/issues/71)).
-- **Arguments tab** — visual + interaction overhaul to the design handoff (Screen 2):
-  status strip, dashed contribute affordance, reserved checkbox slot, importance-vote
-  gating ([#79](https://github.com/lgelauff/wiki-polis/issues/79),
-  [#80](https://github.com/lgelauff/wiki-polis/issues/80),
-  [#47](https://github.com/lgelauff/wiki-polis/issues/47)); clarify when importance
-  voting unlocks ([#11](https://github.com/lgelauff/wiki-polis/issues/11)) and gate the
-  Arguments phase toggle on ≥1 featured proposal
-  ([#12](https://github.com/lgelauff/wiki-polis/issues/12)). _(The detailed visual spec
+- **Voting** — ✅ "change vote" reopens + resubmits to Polis
+  ([#69](https://github.com/lgelauff/wiki-polis/issues/69)), the three-action footer
+  ([#64](https://github.com/lgelauff/wiki-polis/issues/64)), and the slug-format hint on
+  validation ([#68](https://github.com/lgelauff/wiki-polis/issues/68)) all shipped.
+  Remaining: mobile tap affordance on listing cards
+  ([#71](https://github.com/lgelauff/wiki-polis/issues/71)).
+- **Arguments tab** — ✅ the visual + interaction overhaul to the design handoff (Screen 2)
+  shipped (PR #174): status strip, dashed contribute affordance, reserved checkbox slot,
+  importance-vote gating, the top-of-tab explanation
+  ([#80](https://github.com/lgelauff/wiki-polis/issues/80)), the clarified
+  importance-vote unlock state ([#11](https://github.com/lgelauff/wiki-polis/issues/11)),
+  and the Arguments-phase toggle gated on ≥1 featured proposal
+  ([#12](https://github.com/lgelauff/wiki-polis/issues/12)). Remaining: resolve the
+  concurrent-active-phases tab navigation
+  ([#79](https://github.com/lgelauff/wiki-polis/issues/79)) and the cleaner
+  admin/participant UI split with a visual mode indicator
+  ([#47](https://github.com/lgelauff/wiki-polis/issues/47)). _(The detailed visual spec
   lives in the design-handoff doc; the pre-rename build-log history has the full
   checklist.)_
-- **Results / identity** — fix the participant results tab
-  ([#81](https://github.com/lgelauff/wiki-polis/issues/81)); simplify the pseudonym
-  selection screen ([#82](https://github.com/lgelauff/wiki-polis/issues/82)); show the
-  reveal-window end date on closed conversations
-  ([#70](https://github.com/lgelauff/wiki-polis/issues/70)).
+- **Results / identity** — ✅ participant results tab fixed
+  ([#81](https://github.com/lgelauff/wiki-polis/issues/81)) and the reveal-window end date
+  + "what happens next" now shown on closed conversations
+  ([#70](https://github.com/lgelauff/wiki-polis/issues/70)). Remaining: simplify the
+  pseudonym selection screen ([#82](https://github.com/lgelauff/wiki-polis/issues/82)).
 - **Internal-link removal still needed.** Per D-PRIV (clarified), a voluntary reveal is
   permanent and is no longer nullified by the app. The remaining work is a separate
   data-minimisation mechanism that removes the *internal* account↔pseudonym link for
@@ -88,10 +97,13 @@ retention commitment (decision D-PRIV), pending legal/comms review.
 
 ## 5. Deferred / later
 
-- ~~**Phase 6 — informed voting**~~ ✅ Implemented (PR #115, 2026-06-04). Data model,
-  admin init, participant UI, vote route. See `log_changelog.md` for detail.
-  Follow-up: dedup table for repeat votes, 409 UX, tab on closed convs, admin
-  warning for un-seeded confirmed statements.
+- ~~**Phase 6 — informed voting**~~ ✅ Implemented (PR #115, 2026-06-04); standalone
+  phase6-init hardened (PR #179). Data model, admin init, participant UI, vote route. See
+  `log_changelog.md` for detail. Follow-up: informed-voting card layout polish
+  ([#119](https://github.com/lgelauff/wiki-polis/issues/119)), a Phase-2-vs-informed
+  results report ([#122](https://github.com/lgelauff/wiki-polis/issues/122)), and the
+  "Done" completion screen after all cards are voted/skipped
+  ([#128](https://github.com/lgelauff/wiki-polis/issues/128)).
 - **Return engagement** — notifications (talk page / email), "new since last visit".
 - **Analytics export** — structured export of votes / clusters / arguments.
 - **Admin & ops** — ban participant

--- a/v2/static/redesign.css
+++ b/v2/static/redesign.css
@@ -281,10 +281,12 @@
   display: flex;
   flex-wrap: wrap;
   gap: 26px;
-  margin-top: 18px;
+  /* margin set on all sides so the <dl> element carries no UA margin (#165). */
+  margin: 18px 0 0;
   padding-top: 18px;
   border-top: 1px solid var(--hairline-soft);
 }
+.phase-stats dd { margin: 0; }  /* drop the UA dd indent — tiles stack value over label */
 .phase-stat-value {
   font-size: 24px;
   font-weight: 700;

--- a/v2/static/redesign.css
+++ b/v2/static/redesign.css
@@ -304,6 +304,27 @@
 .phase-stat-delta { font-size: 11px; font-weight: 600; font-family: var(--mono); }
 .phase-stat-delta--up   { color: var(--agree); }
 .phase-stat-delta--down { color: var(--disagree); }
+.phase-stat-note {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin-top: 2px;
+}
+/* Loud, always-visible banner when Polis PG is configured but unreachable (#165).
+   Unlike .box-adv-note this is not gated on advanced mode — the organizer must see it. */
+.phase-stats-warning {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-top: 18px;
+  padding: 11px 14px;
+  border-radius: 8px;
+  background: rgba(180,83,9,0.10);
+  border: 1px solid rgba(180,83,9,0.45);
+  font-size: 13px;
+  color: var(--spot);
+}
 
 /* readiness + move-on launcher footer */
 .phase-foot {

--- a/v2/static/redesign.css
+++ b/v2/static/redesign.css
@@ -323,7 +323,9 @@
   background: rgba(180,83,9,0.10);
   border: 1px solid rgba(180,83,9,0.45);
   font-size: 13px;
-  color: var(--spot);
+  /* Darker than --spot (#b45309): at 13px on the tinted amber panel --spot lands
+     ~4.2:1, under AA. #7c2d12 clears 4.5:1 on this background (#165 a11y). */
+  color: #7c2d12;
 }
 
 /* readiness + move-on launcher footer */

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -95,7 +95,7 @@
            arguments) render even when Polis PG is down; the warning below fires only
            when PG is configured but unreachable. #}
         {% if polis_stats_unavailable %}
-        <div class="phase-stats-warning" role="alert">
+        <div class="phase-stats-warning" role="status">
           <span aria-hidden="true">⚠️</span>
           <span><strong>Live statistics unavailable.</strong> The Polis statistics database
             could not be reached, so vote and participant counts may be missing or stale.
@@ -104,11 +104,14 @@
         {% endif %}
         {% if phase_stats %}
         <div class="phase-stats">
+          {# Each tile carries an aria-label tying value→label→note together, so a screen
+             reader reads one coherent phrase instead of a stream of disconnected numbers
+             and captions; the visual pieces are hidden from the a11y tree (#165). #}
           {% for t in phase_stats %}
-          <div>
-            <div class="phase-stat-value">{{ t.value }}{% if t.unit %}<span class="unit">{{ t.unit }}</span>{% endif %}</div>
-            <div class="phase-stat-label">{{ t.label }}</div>
-            {% if t.note %}<div class="phase-stat-note">{{ t.note }}</div>{% endif %}
+          <div role="group" aria-label="{{ t.value }}{% if t.unit %} {{ t.unit }}{% endif %} {{ t.label }}{% if t.note %} ({{ t.note }}){% endif %}">
+            <div aria-hidden="true" class="phase-stat-value">{{ t.value }}{% if t.unit %}<span class="unit">{{ t.unit }}</span>{% endif %}</div>
+            <div aria-hidden="true" class="phase-stat-label">{{ t.label }}</div>
+            {% if t.note %}<div aria-hidden="true" class="phase-stat-note">{{ t.note }}</div>{% endif %}
           </div>
           {% endfor %}
         </div>

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -97,24 +97,23 @@
         {% if polis_stats_unavailable %}
         <div class="phase-stats-warning" role="status">
           <span aria-hidden="true">⚠️</span>
-          <span><strong>Live statistics unavailable.</strong> The Polis statistics database
-            could not be reached, so vote and participant counts may be missing or stale.
-            Check the server logs.</span>
+          <span><strong>Live statistics unavailable.</strong> Vote and participant counts may be
+            missing or stale — the Polis statistics database may be unreachable, or this
+            conversation may not yet be registered in Polis. Check the server logs.</span>
         </div>
         {% endif %}
         {% if phase_stats %}
-        <div class="phase-stats">
-          {# Each tile carries an aria-label tying value→label→note together, so a screen
-             reader reads one coherent phrase instead of a stream of disconnected numbers
-             and captions; the visual pieces are hidden from the a11y tree (#165). #}
+        {# A <dl> ties each value to its label programmatically: a screen reader reads each
+           tile as "<value> <label>" rather than a stream of disconnected numbers. Native
+           dt/dd needs no ARIA — the visible text is the accessible text (#165). #}
+        <dl class="phase-stats">
           {% for t in phase_stats %}
-          <div role="group" aria-label="{{ t.value }}{% if t.unit %} {{ t.unit }}{% endif %} {{ t.label }}{% if t.note %} ({{ t.note }}){% endif %}">
-            <div aria-hidden="true" class="phase-stat-value">{{ t.value }}{% if t.unit %}<span class="unit">{{ t.unit }}</span>{% endif %}</div>
-            <div aria-hidden="true" class="phase-stat-label">{{ t.label }}</div>
-            {% if t.note %}<div aria-hidden="true" class="phase-stat-note">{{ t.note }}</div>{% endif %}
+          <div>
+            <dt class="phase-stat-value">{{ t.value }}{% if t.unit %}<span class="unit">{{ t.unit }}</span>{% endif %}</dt>
+            <dd class="phase-stat-label">{{ t.label }}{% if t.note %}<div class="phase-stat-note">{{ t.note }}</div>{% endif %}</dd>
           </div>
           {% endfor %}
-        </div>
+        </dl>
         {% endif %}
       </div>
 

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -90,16 +90,27 @@
         </div>
         <p class="phase-now-desc">{{ phase_sequence[current_stage_index].effect }}</p>
 
-        {# The few numbers we already fetch. TODO(#165/#42): per-phase statistics
-           (e.g. featured-with-arguments, awaiting moderation) replace these. #}
-        {% if polis_stats %}
+        {# Phase-specific statistics (#165). Tiles are scoped to the current phase and
+           built server-side by _phase_stats(). Flask-derived numbers (featured,
+           arguments) render even when Polis PG is down; the warning below fires only
+           when PG is configured but unreachable. #}
+        {% if polis_stats_unavailable %}
+        <div class="phase-stats-warning" role="alert">
+          <span aria-hidden="true">⚠️</span>
+          <span><strong>Live statistics unavailable.</strong> The Polis statistics database
+            could not be reached, so vote and participant counts may be missing or stale.
+            Check the server logs.</span>
+        </div>
+        {% endif %}
+        {% if phase_stats %}
         <div class="phase-stats">
-          <div><div class="phase-stat-value">{{ polis_stats.n_participants }}</div>
-               <div class="phase-stat-label">participants</div></div>
-          <div><div class="phase-stat-value">{{ polis_stats.n_votes }}</div>
-               <div class="phase-stat-label">votes cast</div></div>
-          <div><div class="phase-stat-value">{{ polis_stats.n_statements }}</div>
-               <div class="phase-stat-label">statements ({{ polis_stats.n_seed }} seed)</div></div>
+          {% for t in phase_stats %}
+          <div>
+            <div class="phase-stat-value">{{ t.value }}{% if t.unit %}<span class="unit">{{ t.unit }}</span>{% endif %}</div>
+            <div class="phase-stat-label">{{ t.label }}</div>
+            {% if t.note %}<div class="phase-stat-note">{{ t.note }}</div>{% endif %}
+          </div>
+          {% endfor %}
         </div>
         {% endif %}
       </div>

--- a/v2/tests/test_phase_stats.py
+++ b/v2/tests/test_phase_stats.py
@@ -1,0 +1,140 @@
+"""Tests for phase-specific statistics in the admin conversation window (#165).
+
+Covers the per-phase tile selection in _phase_stats() and the loud warning shown
+when Polis PG is configured but unreachable.
+"""
+import re
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from db import (Argument, ArgumentVote, Conversation, FeaturedStatement,
+                Participant, Participation, db)
+
+
+@pytest.fixture
+def conv(app):
+    c = Conversation(
+        slug='stats-conv', polis_id='sta1234567',
+        title='Stats Test Conv', active=True, access_policy='public',
+    )
+    db.session.add(c)
+    db.session.commit()
+    return c
+
+
+def _participant(uid, name):
+    p = Participant(mw_user_id=uid, mw_username=name, xid=f'xid{uid}')
+    db.session.add(p)
+    db.session.commit()
+    return p
+
+
+def _tile_value(html, label):
+    """Return the tile value rendered next to the given phase-stat label, or None.
+
+    The negative lookahead keeps the captured value within the same tile — it must
+    not skip across an intervening phase-stat-value div to reach the label.
+    """
+    m = re.search(
+        r'phase-stat-value">([^<]*)<(?:(?!phase-stat-value).)*?phase-stat-label">'
+        + re.escape(label) + '<',
+        html, re.DOTALL)
+    return m.group(1).strip() if m else None
+
+
+# ── Featured-selection phase ────────────────────────────────────────────────────
+
+def test_featured_selection_shows_selected_vs_recommended(admin_client, conv):
+    conv.phase_personal_results = True            # featured_selection stage
+    for i in range(3):
+        db.session.add(FeaturedStatement(conversation_id=conv.id, polis_statement_id=i,
+                                         confirmed_by_admin=True))
+    db.session.add(FeaturedStatement(conversation_id=conv.id, polis_statement_id=9,
+                                     confirmed_by_admin=False))   # not confirmed
+    db.session.commit()
+
+    page = admin_client.get(f'/admin/conversations/{conv.id}').get_data(as_text=True)
+    assert _tile_value(page, 'featured selected') == '3'
+    assert 'recommended' in page                  # advisory note rendered
+
+
+# ── Argument-mapping phase ──────────────────────────────────────────────────────
+
+def test_argument_mapping_counts_pro_con_contributors_raters(admin_client, conv):
+    conv.phase_argument_mapping = True
+    fs = FeaturedStatement(conversation_id=conv.id, polis_statement_id=1,
+                           confirmed_by_admin=True)
+    db.session.add(fs)
+    db.session.commit()
+
+    p1, p2 = _participant(101, 'contrib1'), _participant(102, 'contrib2')
+    pro1 = Argument(featured_statement_id=fs.id, proposer_id=p1.id, body='pro a', side='pro')
+    pro2 = Argument(featured_statement_id=fs.id, proposer_id=p2.id, body='pro b', side='pro')
+    con1 = Argument(featured_statement_id=fs.id, proposer_id=p1.id, body='con a', side='con')
+    seed = Argument(featured_statement_id=fs.id, proposer_id=None, body='seed', side='pro')
+    hidden = Argument(featured_statement_id=fs.id, proposer_id=p2.id, body='bad', side='con',
+                      hidden=True)
+    db.session.add_all([pro1, pro2, con1, seed, hidden])
+    db.session.commit()
+
+    rater = _participant(103, 'rater1')
+    db.session.add(ArgumentVote(argument_id=pro1.id, participant_id=rater.id))
+    db.session.add(ArgumentVote(argument_id=con1.id, participant_id=rater.id))
+    db.session.commit()
+
+    page = admin_client.get(f'/admin/conversations/{conv.id}').get_data(as_text=True)
+    # Seeds (NULL proposer) and hidden args are excluded from the counts.
+    assert _tile_value(page, 'pro arguments') == '2'
+    assert _tile_value(page, 'con arguments') == '1'
+    assert _tile_value(page, 'contributors') == '2'      # p1, p2 — distinct
+    assert _tile_value(page, 'rating arguments') == '1'  # one distinct rater
+
+
+# ── Informed-voting phase ───────────────────────────────────────────────────────
+
+def test_informed_voting_shows_round2_stats(admin_client, conv):
+    conv.phase_informed_voting = True
+    conv.phase6_polis_conversation_id = 'p6conv1234'
+    fs = FeaturedStatement(conversation_id=conv.id, polis_statement_id=1,
+                           confirmed_by_admin=True, phase6_polis_statement_id=0)
+    db.session.add(fs)
+    db.session.commit()
+
+    def stats_for(zinvite):
+        if zinvite == 'p6conv1234':
+            return {'n_participants': 7, 'n_votes': 21, 'avg_votes': 3.0,
+                    'median_votes': 3.0, 'n_statements': 1, 'n_seed': 1}
+        return {'n_participants': 12, 'n_votes': 80, 'avg_votes': 6.0,
+                'median_votes': 6.0, 'n_statements': 10, 'n_seed': 2}
+
+    server = MagicMock()
+    server.get_polis_stats.side_effect = stats_for
+    with patch('app._polis_server_client', return_value=server):
+        page = admin_client.get(f'/admin/conversations/{conv.id}').get_data(as_text=True)
+
+    assert _tile_value(page, 'statements seeded') == '1/1'
+    assert _tile_value(page, 'voted this round') == '7'
+    assert _tile_value(page, 'informed votes') == '21'
+    assert _tile_value(page, 'round 1 participants') == '12'
+
+
+# ── Loud warning when Polis PG is configured but down ───────────────────────────
+
+def test_warning_when_pg_configured_but_unavailable(app, admin_client, conv):
+    app.config['POLIS_DATABASE_URL'] = 'postgresql://unused/db'
+    server = MagicMock()
+    server.get_polis_stats.return_value = None        # PG unreachable
+    with patch('app._polis_server_client', return_value=server):
+        page = admin_client.get(f'/admin/conversations/{conv.id}').get_data(as_text=True)
+    assert 'phase-stats-warning' in page
+    assert 'Live statistics unavailable' in page
+
+
+def test_no_warning_when_pg_not_configured(admin_client, conv):
+    # POLIS_DATABASE_URL is unset in the test app — None stats are expected, not an error.
+    server = MagicMock()
+    server.get_polis_stats.return_value = None
+    with patch('app._polis_server_client', return_value=server):
+        page = admin_client.get(f'/admin/conversations/{conv.id}').get_data(as_text=True)
+    assert 'phase-stats-warning' not in page

--- a/v2/tests/test_phase_stats.py
+++ b/v2/tests/test_phase_stats.py
@@ -175,6 +175,32 @@ def test_informed_voting_warns_when_phase6_fetch_fails(app, admin_client, conv):
     assert _tile_value(page, 'voted this round') is None
 
 
+def test_no_round2_warning_when_informed_voting_not_displayed_stage(app, admin_client, conv):
+    # Non-linear state: both informed-voting and public-results flags are on, so the
+    # *displayed* stage is public_results (furthest-along). No round-2 tiles render, so a
+    # failed phase-6 fetch must NOT trip the warning — it tracks the shown stage, not the
+    # raw flag (#165). Guards the false-positive the flag-based condition would have raised.
+    app.config['POLIS_DATABASE_URL'] = 'postgresql://unused/db'
+    conv.phase_informed_voting = True
+    conv.phase_public_results = True
+    conv.phase6_polis_conversation_id = 'p6conv1234'
+    db.session.commit()
+
+    def stats_for(zinvite):
+        if zinvite == 'p6conv1234':
+            return None                              # round-2 PG unreachable (but not shown)
+        return {'n_participants': 12, 'n_votes': 80, 'avg_votes': 6.0,
+                'median_votes': 6.0, 'n_statements': 10, 'n_seed': 2}
+
+    server = MagicMock()
+    server.get_polis_stats.side_effect = stats_for
+    with patch('app._polis_server_client', return_value=server):
+        page = admin_client.get(f'/admin/conversations/{conv.id}').get_data(as_text=True)
+
+    # Round-1 stats are healthy and shown; the irrelevant phase-6 failure stays silent.
+    assert 'phase-stats-warning' not in page
+
+
 # ── Loud warning when Polis PG is configured but down ───────────────────────────
 
 def test_warning_when_pg_configured_but_unavailable(app, admin_client, conv):

--- a/v2/tests/test_phase_stats.py
+++ b/v2/tests/test_phase_stats.py
@@ -91,6 +91,34 @@ def test_argument_mapping_counts_pro_con_contributors_raters(admin_client, conv)
     assert _tile_value(page, 'rating arguments') == '1'  # one distinct rater
 
 
+def test_argument_mapping_raters_exclude_hidden_only_voters(admin_client, conv):
+    # A participant who rated *only* a hidden argument must not inflate the rater count —
+    # n_raters applies the same Argument.hidden filter as the other tiles (#165 should-fix).
+    conv.phase_argument_mapping = True
+    fs = FeaturedStatement(conversation_id=conv.id, polis_statement_id=1,
+                           confirmed_by_admin=True)
+    db.session.add(fs)
+    db.session.commit()
+
+    author = _participant(201, 'author')
+    visible = Argument(featured_statement_id=fs.id, proposer_id=author.id,
+                       body='visible', side='pro')
+    hidden = Argument(featured_statement_id=fs.id, proposer_id=author.id,
+                      body='moderated', side='con', hidden=True)
+    db.session.add_all([visible, hidden])
+    db.session.commit()
+
+    visible_rater = _participant(202, 'visible_rater')
+    hidden_rater = _participant(203, 'hidden_rater')
+    db.session.add(ArgumentVote(argument_id=visible.id, participant_id=visible_rater.id))
+    db.session.add(ArgumentVote(argument_id=hidden.id, participant_id=hidden_rater.id))
+    db.session.commit()
+
+    page = admin_client.get(f'/admin/conversations/{conv.id}').get_data(as_text=True)
+    # Only the visible-arg rater counts; the hidden-only rater is excluded.
+    assert _tile_value(page, 'rating arguments') == '1'
+
+
 # ── Informed-voting phase ───────────────────────────────────────────────────────
 
 def test_informed_voting_shows_round2_stats(admin_client, conv):
@@ -117,6 +145,34 @@ def test_informed_voting_shows_round2_stats(admin_client, conv):
     assert _tile_value(page, 'voted this round') == '7'
     assert _tile_value(page, 'informed votes') == '21'
     assert _tile_value(page, 'round 1 participants') == '12'
+
+
+def test_informed_voting_warns_when_phase6_fetch_fails(app, admin_client, conv):
+    # Round-1 stats succeed but the phase-6 (round-2) fetch returns None. The warning
+    # must still fire — otherwise the round-2 tiles vanish silently (#165 must-fix).
+    app.config['POLIS_DATABASE_URL'] = 'postgresql://unused/db'
+    conv.phase_informed_voting = True
+    conv.phase6_polis_conversation_id = 'p6conv1234'
+    fs = FeaturedStatement(conversation_id=conv.id, polis_statement_id=1,
+                           confirmed_by_admin=True, phase6_polis_statement_id=0)
+    db.session.add(fs)
+    db.session.commit()
+
+    def stats_for(zinvite):
+        if zinvite == 'p6conv1234':
+            return None                              # round-2 PG unreachable
+        return {'n_participants': 12, 'n_votes': 80, 'avg_votes': 6.0,
+                'median_votes': 6.0, 'n_statements': 10, 'n_seed': 2}
+
+    server = MagicMock()
+    server.get_polis_stats.side_effect = stats_for
+    with patch('app._polis_server_client', return_value=server):
+        page = admin_client.get(f'/admin/conversations/{conv.id}').get_data(as_text=True)
+
+    assert 'phase-stats-warning' in page
+    assert 'Live statistics unavailable' in page
+    # Round-2 tiles are absent (no phase6_stats); the warning explains why.
+    assert _tile_value(page, 'voted this round') is None
 
 
 # ── Loud warning when Polis PG is configured but down ───────────────────────────


### PR DESCRIPTION
## Summary

Closes #165.

The admin conversation window's phase-hero stat block showed a fixed participants / votes / statements readout. This replaces it with tiles **scoped to the current phase**, so they sit above the guided "Move on" box and double as readiness signals (#156).

| Phase | Tiles |
|---|---|
| **Explore** | participants, votes cast, statements (n seed), avg & median votes/person |
| **Featured selection** | featured selected (+ "recommended" note), candidate statements, participants |
| **Arguments / Cleanup** | featured count, pro/con argument counts (human + visible — seeds & hidden excluded), distinct contributors, raters |
| **Informed vote** | statements seeded (n/total), round-2 participants & votes (from the Phase 6 Polis conversation), round-1 participants for comparison |
| **Report** | headline totals |

Flask-derived tiles (featured, arguments) come from our own DB, so they render even when Polis PG is unavailable.

## Loud warning on a real PG failure

The two Polis-PG states are distinguished deliberately:

- **`POLIS_DATABASE_URL` set but the stats DB is unreachable** (`get_polis_stats` → `None`) → a prominent always-visible amber banner in the hero. A new `.phase-stats-warning` class is used because `.box-adv-note` is hidden outside advanced mode.
- **PG intentionally not wired** (local/dev) → stays silent; `None` is expected there.

## Changes

- `v2/app.py`: `_phase_stats()` + `_featured_counts()` / `_argument_stats()` helpers; route fetches Phase 6 round stats and computes `polis_stats_unavailable`.
- `v2/templates/admin_conversation.html`: per-phase tile loop + warning banner (replaces the hardcoded 3-tile block and its TODO).
- `v2/static/redesign.css`: `.phase-stats-warning` + `.phase-stat-note`.
- `v2/tests/test_phase_stats.py`: now 7 tests.
- `v2/log_changelog.md`: build-log entry.

Also included: a roadmap sync commit (`docs(roadmap)`) reconciling `plan_roadmap.md` with recently merged work.

## Review fixes (post-merge)

`main` was merged in (clean, no conflicts) and two rounds of [pr-check](https://claude.ai/code/session_01KoMsYNSKT4nxWqiLdb6yBf) review fixes were applied:

- **Phase-6 outage warning** now fires when the round-2 stats fetch fails during informed voting (was silent), and is gated on the *displayed* stage (`_current_stage_index`) rather than the raw `phase_informed_voting` flag — so it can't false-positive in non-linear phase states where round-2 tiles aren't shown.
- **`n_raters`** now applies the same `Argument.hidden.is_(False)` filter as the sibling tiles (raters of moderated arguments no longer inflate the count).
- **Accessibility:** stat tiles are native `<dl>/<dt>/<dd>` (programmatic value↔label association, no ARIA); the warning banner uses `role="status"` (correct for a present-at-load banner, vs the previous `role="alert"`); warning text darkened to clear AA contrast on the tinted panel.
- **Banner wording** no longer asserts "could not be reached" — `get_polis_stats` also returns `None` for an unregistered/invalid conversation id, so the copy now covers both causes.

## Testing

- `test_phase_stats.py` — **7 passed**: per-phase tile correctness (featured-selection, argument-mapping incl. seed/hidden exclusion + hidden-only-rater exclusion, informed-vote with mocked Phase 6 stats), warning shown/not-shown by PG-configured state, phase-6-outage warning, and the non-linear false-positive guard.
- **Full suite: 325 passed**, no regressions.
- Not done: visual/browser check of tile layout and a screen-reader pass on the `<dl>` tiles + banner; the PG-down case is simulated via a mocked `get_polis_stats` returning `None` (the documented failure contract), not a killed Postgres. A light human staging pass is recommended for these.

## Scope notes

- Scoped to `admin_conversation_detail`; the separate `admin_featured` page (which also blanks silently on PG failure) is untouched.
- Recommended-featured count reuses the existing `_RECOMMENDED_FEATURED` constant — per-conversation config is #160's job.

https://claude.ai/code/session_01KoMsYNSKT4nxWqiLdb6yBf

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoMsYNSKT4nxWqiLdb6yBf)_