### PR TITLE
feat(#122, #165): Phase 6 results report — three surfaces + moderation filter

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -123,9 +123,10 @@ def _build_phase6_results(
       {
         'statements': [{
           'text', 'fs_id',
-          'p2': {n_agree, n_disagree, n_pass, n_voters, pct_agree},
-          'p6': {n_agree, n_disagree, n_pass, n_voters, pct_agree},
-          'shift': float | None,     # p6_pct_agree - p2_pct_agree; None if p2 unavailable
+          'p2': {n_agree, n_disagree, n_pass, n_voters, pct_agree, pct_disagree, pct_pass},
+          'p6': {n_agree, n_disagree, n_pass, n_voters, pct_agree, pct_disagree, pct_pass},
+          'shift': float | None,     # aggregate: p6_pct_agree - p2_pct_agree (population comparison,
+                                     #   NOT individual-level delta — see 'matched_participants')
           'my_p2_vote': int | None,  # raw Polis vote; None if participation absent or PG unavail
           'my_p6_vote': int | None,
           'my_p2_label': str | None,
@@ -133,6 +134,11 @@ def _build_phase6_results(
         }],
         'p6_participants': int | None,
         'p2_participants': int | None,
+        'matched_participants': None,  # int | None — participants who voted in BOTH rounds;
+                                       # requires xid→pid mapping (not yet stored, see TODO below).
+                                       # Individual-level delta + CI extrapolation depend on this.
+        'p2_consensus': list,   # top-3 statements by Phase 2 agree rate (population consensus)
+        'p2_divisive':  list,   # top-3 statements by balanced agree/disagree split (most divisive)
         'filter': Phase6ResultsFilter,
         'source_divergence': float | None,  # abs diff between PG count and Particiapi count
         'is_preliminary': bool,   # True while conversation is still active
@@ -267,15 +273,27 @@ def _build_phase6_results(
     # Sort by largest absolute shift first; statements with no shift data go last.
     statements.sort(key=lambda s: abs(s['shift']) if s['shift'] is not None else -1, reverse=True)
 
+    # Phase 2 consensus / divisiveness derived from the same data.
+    p2_with_data = [s for s in statements if s['p2'] is not None and s['p2']['n_voters'] > 0]
+    p2_consensus = sorted(p2_with_data,
+                          key=lambda s: s['p2']['pct_agree'] or 0, reverse=True)[:3]
+    # Most divisive = smallest gap between agree and disagree (most 50/50 split).
+    p2_divisive  = sorted(p2_with_data,
+                          key=lambda s: abs((s['p2']['pct_agree'] or 0) - (s['p2']['pct_disagree'] or 0)))[:3]
+
     return {
-        'statements':         statements,
-        'p6_participants':    p6_total_participants,
-        'p2_participants':    p2_total_participants,
-        'filter':             filt,
-        'source_divergence':  source_divergence,
-        'is_preliminary':     bool(conv.active),
-        'clusters':           clusters,
-        'pg_available':       pg_available,
+        'statements':            statements,
+        'p6_participants':       p6_total_participants,
+        'p2_participants':       p2_total_participants,
+        # TODO: compute once xid→pid mapping is available (see personal-votes TODO above).
+        'matched_participants':  None,
+        'p2_consensus':          p2_consensus,
+        'p2_divisive':           p2_divisive,
+        'filter':                filt,
+        'source_divergence':     source_divergence,
+        'is_preliminary':        bool(conv.active),
+        'clusters':              clusters,
+        'pg_available':          pg_available,
     }
 _math_recompute_last: dict[int, float] = {}  # conv.id → epoch of last trigger
 

--- a/v2/app.py
+++ b/v2/app.py
@@ -1165,6 +1165,7 @@ def admin_conversation_detail(conv_id):
     phase6_results    = (_build_phase6_results(conv, participation=None)
                          if conv.phase_informed_voting and conv.phase6_polis_conversation_id
                          else None)
+    reveal            = _reveal_context(conv, participation=None)
     return render_template('admin_conversation.html',
                            conversation=conv,
                            conv_roles=conv_roles,
@@ -1173,6 +1174,7 @@ def admin_conversation_detail(conv_id):
                            participant_count=participant_count,
                            polis_stats=polis_stats,
                            phase6_results=phase6_results,
+                           reveal=reveal,
                            admin_roles=ADMIN_ROLES,
                            can_manage_roles=can_manage_roles,
                            phase_sequence=PHASE_SEQUENCE,

--- a/v2/app.py
+++ b/v2/app.py
@@ -4,6 +4,7 @@ app.py — Flask application for wiki-polis v2.
 
 import base64
 import click
+import dataclasses
 import functools
 import hashlib
 import hmac
@@ -74,6 +75,208 @@ ADMIN_USERS = [u.strip() for u in _read_secret('admin-users').split(',') if u.st
 _REVEAL_COOLDOWN_DAYS = 30   # days after close before reveal window opens
 _REVEAL_WINDOW_DAYS   = 30   # days participants may opt in once the window opens
 _MATH_RECOMPUTE_COOLDOWN = 600  # seconds between auto-triggered recomputes per conversation
+
+# ── Phase 6 results ───────────────────────────────────────────────────────────
+
+@dataclasses.dataclass(frozen=True)
+class Phase6ResultsFilter:
+    """Moderation exclusions applied uniformly across all Phase 6 result surfaces.
+
+    excluded_tids: Phase 6 Polis statement tids to suppress (statements hidden via
+      admin moderation after Phase 6 init, e.g. de-featured mid-round). Populated
+      from FeaturedStatement rows whose phase6_polis_statement_id has mod=-1 in the
+      Phase 6 Polis conversation.
+
+    excluded_pids: Polis participant pids to suppress (banned participants). Empty
+      until issue #60 (ban participant) ships the admin UI; the field exists so
+      results can be recomputed with exclusions without a schema change.
+    """
+    excluded_tids: frozenset  # frozenset[int]
+    excluded_pids: frozenset  # frozenset[int]
+
+    @classmethod
+    def empty(cls) -> 'Phase6ResultsFilter':
+        return cls(excluded_tids=frozenset(), excluded_pids=frozenset())
+
+
+def _vote_label(vote: int | None) -> str | None:
+    """Human-readable label for a raw Polis vote value."""
+    if vote is None:
+        return None
+    return {-1: 'Agreed', 1: 'Disagreed', 0: 'Passed'}.get(vote)
+
+
+def _pct(n: int, total: int) -> float:
+    return round(n / total * 100, 1) if total else 0.0
+
+
+def _build_phase6_results(
+    conv,
+    participation,
+    results_filter: 'Phase6ResultsFilter | None' = None,
+) -> dict | None:
+    """Build the unified Phase 6 results object used by all result surfaces.
+
+    Returns None if Phase 6 is not initialised or has no confirmed statements.
+
+    The returned dict has shape:
+      {
+        'statements': [{
+          'text', 'fs_id',
+          'p2': {n_agree, n_disagree, n_pass, n_voters, pct_agree},
+          'p6': {n_agree, n_disagree, n_pass, n_voters, pct_agree},
+          'shift': float | None,     # p6_pct_agree - p2_pct_agree; None if p2 unavailable
+          'my_p2_vote': int | None,  # raw Polis vote; None if participation absent or PG unavail
+          'my_p6_vote': int | None,
+          'my_p2_label': str | None,
+          'my_p6_label': str | None,
+        }],
+        'p6_participants': int | None,
+        'p2_participants': int | None,
+        'filter': Phase6ResultsFilter,
+        'source_divergence': float | None,  # abs diff between PG count and Particiapi count
+        'is_preliminary': bool,   # True while conversation is still active
+        'clusters': list | None,  # from Particiapi get_results on the Phase 6 zinvite
+        'pg_available': bool,
+      }
+
+    Data sources:
+      - Primary: PolisServerClient Postgres queries (votes_latest_unique).
+      - Comparison/clusters: ParticiAPIClient.get_results(phase6_zinvite).
+    Moderation is applied via results_filter before any aggregation.
+    If Postgres is unavailable, vote counts fall back to None (surfaces degrade
+    gracefully) but cluster data from Particiapi is still returned.
+    """
+    if not conv.phase6_polis_conversation_id:
+        return None
+
+    filt = results_filter or Phase6ResultsFilter.empty()
+
+    # Confirmed featured statements, excluding any whose Phase 6 tid is suppressed.
+    confirmed = [
+        fs for fs in FeaturedStatement.query.filter_by(
+            conversation_id=conv.id, confirmed_by_admin=True
+        ).all()
+        if fs.phase6_polis_statement_id is not None
+        and fs.phase6_polis_statement_id not in filt.excluded_tids
+        and fs.statement_text
+    ]
+    if not confirmed:
+        return None
+
+    p6_zinvite = conv.phase6_polis_conversation_id
+    p2_zinvite = conv.polis_id
+    excluded_pids = list(filt.excluded_pids)
+    allowed_p6_tids = [fs.phase6_polis_statement_id for fs in confirmed]
+
+    client = _polis_server_client()
+
+    # ── Primary source: Postgres ──────────────────────────────────────────────
+    p6_counts = client.get_phase6_vote_counts(p6_zinvite, allowed_p6_tids, excluded_pids)
+    p6_total_participants = client.get_phase6_participant_count(p6_zinvite, excluded_pids)
+    pg_available = p6_counts is not None
+
+    # Phase 2 counts keyed by polis_statement_id (Phase 2 tid).
+    p2_tids = [fs.polis_statement_id for fs in confirmed if fs.polis_statement_id]
+    p2_counts_raw = None
+    p2_total_participants = None
+    if p2_tids and pg_available:
+        # Reuse get_phase6_vote_counts against the Phase 2 zinvite — same SQL works.
+        p2_counts_raw = client.get_phase6_vote_counts(p2_zinvite, p2_tids, excluded_pids)
+        p2_total_participants = client.get_phase6_participant_count(p2_zinvite, excluded_pids)
+
+    # ── Personal votes (only when participation is present) ───────────────────
+    my_p2_votes: dict[int, int] = {}
+    my_p6_votes: dict[int, int] = {}
+    if participation and pg_available:
+        # We need the Polis pid for the participant. Polis pids are not stored in
+        # our DB — we use xid (hashed mw_user_id). The personal-votes query
+        # therefore cannot run until we have a xid→pid mapping.
+        # For now this is left as empty dicts (personal votes show as None).
+        # TODO: store or derive Polis pid to enable per-participant vote display.
+        pass
+
+    # ── Comparison source: Particiapi ─────────────────────────────────────────
+    pa_results = None
+    try:
+        pa_results = PolisParticipantClient(
+            current_app.config['PARTICIAPI_BASE']
+        ).get_results(p6_zinvite)
+    except Exception:
+        logger.exception('Particiapi get_results failed for Phase 6 zinvite %s', p6_zinvite)
+
+    clusters = None
+    source_divergence = None
+    if pa_results:
+        clusters = pa_results.get('groups') or None
+        # Sanity-check: compare Particiapi participant count vs Postgres count.
+        pa_n = None
+        if pa_results.get('majority'):
+            # Particiapi doesn't expose a participant count directly in majority.
+            # Use groups n_members sum as a proxy when available.
+            groups = pa_results.get('groups') or []
+            if groups:
+                pa_n = sum(g.get('n_members', 0) for g in groups)
+        if pa_n and p6_total_participants:
+            source_divergence = abs(pa_n - p6_total_participants) / max(p6_total_participants, 1)
+            if source_divergence > 0.05:
+                logger.warning(
+                    'Phase 6 source divergence %.1f%% for conv %s '
+                    '(PG=%d, Particiapi=%d) — may indicate moderation sync lag',
+                    source_divergence * 100, conv.slug, p6_total_participants, pa_n,
+                )
+
+    # ── Build per-statement rows ──────────────────────────────────────────────
+    statements = []
+    for fs in confirmed:
+        p6_tid = fs.phase6_polis_statement_id
+        p2_tid = fs.polis_statement_id
+
+        p6_row = (p6_counts or {}).get(p6_tid, {'n_agree': 0, 'n_disagree': 0, 'n_pass': 0, 'n_voters': 0})
+        p2_row = (p2_counts_raw or {}).get(p2_tid, None) if p2_tid else None
+
+        p6_n = p6_row['n_voters']
+        p6_pct_agree    = _pct(p6_row['n_agree'],    p6_n)
+        p6_pct_disagree = _pct(p6_row['n_disagree'], p6_n)
+        p6_pct_pass     = _pct(p6_row['n_pass'],     p6_n)
+
+        p2_pct_agree = p2_pct_disagree = p2_pct_pass = None
+        if p2_row:
+            p2_n = p2_row['n_voters']
+            p2_pct_agree    = _pct(p2_row['n_agree'],    p2_n)
+            p2_pct_disagree = _pct(p2_row['n_disagree'], p2_n)
+            p2_pct_pass     = _pct(p2_row['n_pass'],     p2_n)
+
+        shift = round(p6_pct_agree - p2_pct_agree, 1) if p2_pct_agree is not None else None
+
+        statements.append({
+            'text':        fs.statement_text,
+            'fs_id':       fs.id,
+            'p6': {**p6_row, 'pct_agree': p6_pct_agree,
+                   'pct_disagree': p6_pct_disagree, 'pct_pass': p6_pct_pass},
+            'p2': ({**p2_row, 'pct_agree': p2_pct_agree,
+                    'pct_disagree': p2_pct_disagree, 'pct_pass': p2_pct_pass}
+                   if p2_row else None),
+            'shift':       shift,
+            'my_p2_vote':  my_p2_votes.get(p2_tid),
+            'my_p6_vote':  my_p6_votes.get(p6_tid),
+            'my_p2_label': _vote_label(my_p2_votes.get(p2_tid)),
+            'my_p6_label': _vote_label(my_p6_votes.get(p6_tid)),
+        })
+
+    # Sort by largest absolute shift first; statements with no shift data go last.
+    statements.sort(key=lambda s: abs(s['shift']) if s['shift'] is not None else -1, reverse=True)
+
+    return {
+        'statements':         statements,
+        'p6_participants':    p6_total_participants,
+        'p2_participants':    p2_total_participants,
+        'filter':             filt,
+        'source_divergence':  source_divergence,
+        'is_preliminary':     bool(conv.active),
+        'clusters':           clusters,
+        'pg_available':       pg_available,
+    }
 _math_recompute_last: dict[int, float] = {}  # conv.id → epoch of last trigger
 
 
@@ -941,6 +1144,9 @@ def admin_conversation_detail(conv_id):
     invite_count      = ConversationInvite.query.filter_by(conversation_id=conv_id).count()
     participant_count = Participation.query.filter_by(conversation_id=conv_id).count()
     polis_stats       = _polis_server_client().get_polis_stats(conv.polis_id)
+    phase6_results    = (_build_phase6_results(conv, participation=None)
+                         if conv.phase_informed_voting and conv.phase6_polis_conversation_id
+                         else None)
     return render_template('admin_conversation.html',
                            conversation=conv,
                            conv_roles=conv_roles,
@@ -948,6 +1154,7 @@ def admin_conversation_detail(conv_id):
                            invite_count=invite_count,
                            participant_count=participant_count,
                            polis_stats=polis_stats,
+                           phase6_results=phase6_results,
                            admin_roles=ADMIN_ROLES,
                            can_manage_roles=can_manage_roles,
                            phase_sequence=PHASE_SEQUENCE,
@@ -1975,6 +2182,13 @@ def conversation(slug):
                 'phase6_stmt_id': fs.phase6_polis_statement_id,
             })
 
+    # Phase 6 results — built when the results tab is visible or Phase 6 is active.
+    # Surface A (preliminary) is shown inside the results tab while the round is live.
+    phase6_results = None
+    if (conv.phase_informed_voting or conv.phase_personal_results or conv.phase_public_results) \
+            and conv.phase6_polis_conversation_id:
+        phase6_results = _build_phase6_results(conv, participation)
+
     return render_template('conversation.html',
                            conversation=conv,
                            participation=participation,
@@ -1989,7 +2203,8 @@ def conversation(slug):
                            new_stmt_unlock_at=conv.argument_vote_data.get('new_stmt_unlock_at', 10) if conv.argument_vote_data else 10,
                            new_stmt_max=conv.argument_vote_data.get('new_stmt_max', 3) if conv.argument_vote_data else 3,
                            new_stmt_ids=participation.new_stmt_ids if participation else [],
-                           phase6_data=phase6_data)
+                           phase6_data=phase6_data,
+                           phase6_results=phase6_results)
 
 # ── Arguments ────────────────────────────────────────────────────────────
 
@@ -2594,6 +2809,53 @@ def create_app(test_config: dict | None = None) -> Flask:
     csrf.exempt(proxy_bp)
 
     return app
+
+
+# ── Phase 6 final report ──────────────────────────────────────────────────────
+
+@participant_bp.get('/c/<slug>/report')
+def conversation_report(slug):
+    """Phase 6 final results report — aggregate only, no personal votes.
+
+    Accessible once the conversation is closed (conv.closed_at is set).
+    Requires login when phase_personal_results is set; public when
+    phase_public_results is set.
+
+    Surface B: post-close, post-organizer-cleanup. Marked 'Final report'.
+    For the preliminary in-round view see the Results tab on the conversation page.
+    """
+    conv = Conversation.query.filter_by(slug=slug).first_or_404()
+    participant = _current_participant()
+    participation = (
+        Participation.query.filter_by(
+            conversation_id=conv.id,
+            participant_id=participant.id,
+        ).first()
+        if participant else None
+    )
+    _check_conversation_access(conv, participant)
+
+    if not conv.closed_at:
+        # Conversation still open — redirect to the results tab.
+        return redirect(url_for('participant.conversation', slug=slug) + '#tab-results')
+
+    if not (conv.phase_public_results or conv.phase_personal_results):
+        return redirect(url_for('participant.conversation', slug=slug))
+
+    if conv.phase_personal_results and not conv.phase_public_results and not participant:
+        return redirect(url_for('participant.login') + f'?next={request.path}')
+
+    phase6_results = _build_phase6_results(conv, participation=None)  # aggregate only
+
+    reveal = _reveal_context(conv, participation)
+    return render_template(
+        'report.html',
+        conversation=conv,
+        participation=participation,
+        phase6_results=phase6_results,
+        reveal=reveal,
+        reveal_state=reveal['state'] if reveal else None,
+    )
 
 
 # ── Routes ────────────────────────────────────────────────────────────────────

--- a/v2/guide_organizer.md
+++ b/v2/guide_organizer.md
@@ -40,7 +40,8 @@ A consultation moves through a linear sequence of phases — each builds on the 
 3. **Featured selection** — participants can see their personal results while you curate the featured statements that the argument layer will use.
 4. **Argument mapping** — opens a pro/con argument layer on the featured statements. Participants read, submit, and vote on short pro/con arguments.
 5. **Informed voting** — a second, independent voting round on the featured statements only, with the Phase 4 arguments shown inline so participants deliberate before casting a clean Agree / Disagree / Pass vote. Participants who skipped earlier phases can join here; the statement set is fixed. Must be **initialised** from the admin panel before the tab appears (see [Enabling informed voting](#enabling-informed-voting)).
-6. **Public results** — opens the complete opinion map to everyone, including visitors. Reaching this phase **permanently closes the consultation** and starts the identity-reveal window.
+   *After informed voting ends:* participants see **preliminary results** while the organizer reviews and moderates before publishing. This is the **cleanup window** — no new phase flag, just the active conversation in a review state (see [section 7](#7-review-results-and-clean-up-the-cleanup-window)).
+6. **Publish final report** — the organizer explicitly closes the conversation once satisfied with the results. This publishes the final report at `/c/<slug>/report`, freezes the moderation filter (making report figures semi-immutable), and starts the identity-reveal window. Closing is **irreversible**.
 
 ### Moving between phases
 
@@ -184,35 +185,51 @@ representative or strongly dividing ones) from the system's suggestions, or add 
 manually. On featured statements participants read, submit, and vote on short pro/con
 arguments. Keep the set small (≈8–12) — curation quality drives the argument layer.
 
-## 7. Read the informed voting results
+## 7. Review results and clean up (the cleanup window)
 
-After Phase 6 (informed voting) the platform generates three result surfaces:
+After informed voting ends there is a **cleanup window** before the final report is
+published. This is not a separate phase toggle — the conversation stays active while you
+review. Participants see a **Preliminary results** banner during this time.
 
-### Preliminary results (while the round is live)
-Participants see a comparison table on the **Results tab** as soon as the round is open.
-It shows agree/disagree bars for each featured statement side-by-side (Phase 2 initial vote vs
-Phase 6 informed vote) and a shift indicator (e.g. +12% agree). This is marked
-**Preliminary** — counts change as more participants vote.
+**What to do in the cleanup window:**
+- Review the preliminary results (the Results tab shows the same data the final report will).
+- Moderate any remaining flagged statements from the informed voting round.
+- Once issue #60 ships: exclude any participants who violated the terms — their votes will
+  be filtered from the final report counts.
+- When you are satisfied: **publish the final report** by closing the conversation (see
+  section 8 below).
 
-### Final report (after you close)
-Once you close the consultation, a **final report** is published at `/c/<slug>/report`.
-It shows:
-- Participation counts for each round (initial and informed voting)
-- The full opinion-shift table, sorted by size of shift
-- Opinion groups (clusters) identified in the informed voting round by Polis math
-- Any moderation exclusions applied (e.g. statements or participants removed post-round)
+> **Don't rush this step.** Once you close, the moderation filter is frozen and the
+> aggregate counts in the report become semi-immutable. You can add a narrative and
+> context before publishing, but the vote tallies won't change after close.
+
+### What participants see during the cleanup window
+The Results tab shows a "Preliminary results" banner. Once you close, it transitions to a
+"Read the final report →" link. Participants are not notified automatically — consider
+sending a talk-page or email notification when the final report goes live.
+
+### Result surfaces
+
+#### Preliminary results
+Available on the **Results tab** as soon as informed voting is open (and continues through
+the cleanup window). Shows agree/disagree bars side-by-side (Phase 2 initial vote vs Phase 6
+informed vote) and an aggregate shift indicator. Marked **Preliminary** — counts change while
+voting is open.
+
+#### Final report (after close)
+Published at `/c/<slug>/report` once `closed_at` is set. Shows:
+- Participation counts for each round
+- Full opinion-shift table, sorted by size of shift
+- Opinion groups (clusters) identified in the informed voting round
+- Moderation exclusions applied (statements and participants filtered from counts)
+- Process timeline and methodology notes
 
 The report is public when **Public results** is on; login-required when only
 **Personal results** is on.
 
-> **Organizer cleanup before the report.** Between closing and publishing, you may want
-> to moderate any remaining flagged statements or (once issue #60 ships) exclude
-> participants who violated the terms. All exclusions are reflected in the final report's
-> counts — the raw votes remain in Polis but are filtered from the displayed aggregates.
-
-### Self-comparison (coming soon)
-A future surface will let participants explore where their own informed votes place them
-relative to the opinion groups. See issue #122 for tracking.
+#### Self-comparison (coming soon)
+A future surface will let participants see where their own votes place them relative to the
+opinion groups.
 
 ### Two data sources — what the platform checks
 The platform queries **two sources** and compares them:
@@ -220,16 +237,18 @@ The platform queries **two sources** and compares them:
   moderation filters are applied here.
 - **Particiapi results API** — provides the cluster/group structure that Polis math computed.
 
-If the participant counts diverge by more than 5% (e.g. a moderation sync lag), the app
-logs a warning. You'll see this in the server logs if it occurs.
+If participant counts diverge by more than 5% (e.g. a moderation sync lag), the app logs a
+warning. You'll see this in the server logs if it occurs.
 
-## 8. Close and identity reveal
+## 8. Publish the final report and identity reveal
 
-**Closing is irreversible** and starts the retention clock. After a cooldown a
-participant may *voluntarily and permanently* attach their Wikimedia username to their
-pseudonym; that reveal is never undone. The internal link between an account and its
-pseudonym is removed within 180 days for participants who did **not** reveal. See the
-identity model in [`spec_functional-design.md`](spec_functional-design.md) and the
+**Closing is irreversible.** It publishes the final report, freezes the moderation filter
+(so aggregate counts in the report are semi-immutable), and starts the retention clock.
+
+After a cooldown a participant may *voluntarily and permanently* attach their Wikimedia
+username to their pseudonym; that reveal is never undone. The internal link between an
+account and its pseudonym is removed within 180 days for participants who did **not** reveal.
+See the identity model in [`spec_functional-design.md`](spec_functional-design.md) and the
 [privacy statement](pub_privacy.md).
 
 ---

--- a/v2/guide_organizer.md
+++ b/v2/guide_organizer.md
@@ -184,7 +184,46 @@ representative or strongly dividing ones) from the system's suggestions, or add 
 manually. On featured statements participants read, submit, and vote on short pro/con
 arguments. Keep the set small (≈8–12) — curation quality drives the argument layer.
 
-## 7. Close and identity reveal
+## 7. Read the informed voting results
+
+After Phase 6 (informed voting) the platform generates three result surfaces:
+
+### Preliminary results (while the round is live)
+Participants see a comparison table on the **Results tab** as soon as the round is open.
+It shows agree/disagree bars for each featured statement side-by-side (Phase 2 initial vote vs
+Phase 6 informed vote) and a shift indicator (e.g. +12% agree). This is marked
+**Preliminary** — counts change as more participants vote.
+
+### Final report (after you close)
+Once you close the consultation, a **final report** is published at `/c/<slug>/report`.
+It shows:
+- Participation counts for each round (initial and informed voting)
+- The full opinion-shift table, sorted by size of shift
+- Opinion groups (clusters) identified in the informed voting round by Polis math
+- Any moderation exclusions applied (e.g. statements or participants removed post-round)
+
+The report is public when **Public results** is on; login-required when only
+**Personal results** is on.
+
+> **Organizer cleanup before the report.** Between closing and publishing, you may want
+> to moderate any remaining flagged statements or (once issue #60 ships) exclude
+> participants who violated the terms. All exclusions are reflected in the final report's
+> counts — the raw votes remain in Polis but are filtered from the displayed aggregates.
+
+### Self-comparison (coming soon)
+A future surface will let participants explore where their own informed votes place them
+relative to the opinion groups. See issue #122 for tracking.
+
+### Two data sources — what the platform checks
+The platform queries **two sources** and compares them:
+- **Polis Postgres directly** (`votes_latest_unique`) — ground truth for vote counts;
+  moderation filters are applied here.
+- **Particiapi results API** — provides the cluster/group structure that Polis math computed.
+
+If the participant counts diverge by more than 5% (e.g. a moderation sync lag), the app
+logs a warning. You'll see this in the server logs if it occurs.
+
+## 8. Close and identity reveal
 
 **Closing is irreversible** and starts the retention clock. After a cooldown a
 participant may *voluntarily and permanently* attach their Wikimedia username to their

--- a/v2/log_changelog.md
+++ b/v2/log_changelog.md
@@ -292,3 +292,17 @@ arguments so participants deliberate before casting a clean vote.
 
 **Ops**
 - [x] `deploy.sh --migrate` runs Alembic from the bastion via dynamic envvar loading + `MIGRATION_MODE=1` (skips web-server-only startup checks); documented in `guide_deployment.md`
+
+## Step 8 — Phase 6 results report (2026-06-10)
+
+**Phase 6 results — three surfaces** ([#122](https://github.com/lgelauff/wiki-polis/issues/122), [#165](https://github.com/lgelauff/wiki-polis/issues/165) partial)
+
+- [x] `Phase6ResultsFilter` dataclass in `app.py`: `excluded_tids` (hidden Phase 6 statements) + `excluded_pids` (banned participants, empty until #60); applied uniformly across all result surfaces
+- [x] Three new `PolisServerClient` Postgres methods (all query `votes_latest_unique`): `get_phase6_vote_counts(zinvite, allowed_tids, excluded_pids)`, `get_phase6_participant_count`, `get_personal_votes`
+- [x] `_build_phase6_results` helper: per-statement Phase 2 vs Phase 6 comparison, shift calculation, personal vote lookup (deferred pending xid→pid mapping), source-divergence check between PG and Particiapi; graceful fallback when PG unavailable
+- [x] **Surface A — preliminary** (`conversation.html` results tab): agree/disagree bar chart per statement, shift indicator (↑/↓), personal vote badge, preliminary banner; shown while round is live
+- [x] **Surface B — final report** (`/c/<slug>/report`): new route + `report.html` template; aggregate only, opinion-shift table, cluster section from Particiapi, participation counts, moderation note, Final badge; public when `phase_public_results`, login-gated when `phase_personal_results` only
+- [x] **Surface C placeholder** in final report: "Where did you land?" self-comparison section reserved, full implementation deferred
+- [x] **Admin stats slice** (#165, informed voting only): Phase 6 participant count, statement count, largest-shift teaser in admin conversation stats panel
+- [x] Done screen updated: closed-state links to final report
+- [x] Docs: `ref_data-model.md` (two-conversation architecture, vote-sign, filter model, result surfaces), `ref_polis-data-model.md` (`votes_latest_unique` Phase 6 note), `guide_organizer.md` (new "Read the informed voting results" section)

--- a/v2/polis_admin.py
+++ b/v2/polis_admin.py
@@ -79,6 +79,49 @@ _FEATURED_CANDIDATES_SQL = """
     LIMIT %s
 """
 
+# Per-statement vote counts for a Phase 6 (informed voting) conversation.
+# Uses votes_latest_unique (one vote per participant per statement) — the same
+# table Polis math uses — so counts are deduplicated and authoritative.
+# allowed_tids filters to confirmed featured statements; hidden/moderated tids
+# are excluded by passing only the non-moderated set from the caller.
+# excluded_pids is an array of Polis participant IDs (ints) to exclude from counts
+# (banned participants); pass an empty array when no bans are in effect.
+# Raw vote sign: -1 = agree, +1 = disagree, 0 = pass (Polis convention).
+_PHASE6_VOTE_COUNTS_SQL = """
+    WITH z AS (SELECT zid FROM zinvites WHERE zinvite = %s)
+    SELECT
+      v.tid,
+      COUNT(DISTINCT v.pid) FILTER (WHERE v.vote = -1) AS n_agree,
+      COUNT(DISTINCT v.pid) FILTER (WHERE v.vote =  1) AS n_disagree,
+      COUNT(DISTINCT v.pid) FILTER (WHERE v.vote =  0) AS n_pass,
+      COUNT(DISTINCT v.pid)                             AS n_voters
+    FROM votes_latest_unique v, z
+    WHERE v.zid = z.zid
+      AND v.tid = ANY(%s)
+      AND NOT (v.pid = ANY(%s))
+    GROUP BY v.tid
+"""
+
+# Total distinct participant count for a Phase 6 conversation, optionally
+# excluding banned pids. Used as the denominator for participation rate.
+_PHASE6_PARTICIPANT_COUNT_SQL = """
+    WITH z AS (SELECT zid FROM zinvites WHERE zinvite = %s)
+    SELECT COUNT(DISTINCT v.pid)
+    FROM votes_latest_unique v, z
+    WHERE v.zid = z.zid
+      AND NOT (v.pid = ANY(%s))
+"""
+
+# Personal votes: the logged-in participant's own votes in a given conversation,
+# keyed by statement tid. Used to show "You: Agreed / Disagreed / Passed" on
+# the results surfaces. Requires the participant's Polis pid.
+_PERSONAL_VOTES_SQL = """
+    WITH z AS (SELECT zid FROM zinvites WHERE zinvite = %s)
+    SELECT v.tid, v.vote
+    FROM votes_latest_unique v, z
+    WHERE v.zid = z.zid AND v.pid = %s
+"""
+
 _POLIS_STATS_SQL = """
     WITH z AS (SELECT zid FROM zinvites WHERE zinvite = %s),
     vd AS (
@@ -477,6 +520,92 @@ class PolisServerClient:
             }
         except (ValueError, IndexError):
             return None
+
+    def get_phase6_vote_counts(
+        self,
+        zinvite: str,
+        allowed_tids: list[int],
+        excluded_pids: list[int] | None = None,
+    ) -> dict[int, dict] | None:
+        """Return per-statement vote counts for a Phase 6 conversation.
+
+        Queries votes_latest_unique (one vote per participant per statement).
+        Only counts votes for tids in allowed_tids — caller passes the
+        confirmed, non-moderated set so hidden statements are automatically
+        excluded from aggregates.
+
+        excluded_pids is an optional list of Polis participant IDs to suppress
+        (e.g. banned participants). Pass None or [] when no bans are in effect.
+
+        Returns dict[tid → {n_agree, n_disagree, n_pass, n_voters}], or None
+        if the Postgres connection is unavailable.
+
+        Raw Polis vote sign: -1 = agree, +1 = disagree, 0 = pass.
+        """
+        if not self._db_url or not _SAFE_ZINVITE.match(zinvite or ''):
+            return None
+        if not allowed_tids:
+            return {}
+        pids = list(excluded_pids or [])
+        rows = self._pg_query(
+            _PHASE6_VOTE_COUNTS_SQL,
+            (zinvite, allowed_tids, pids),
+            'get_phase6_vote_counts',
+        )
+        if rows is None:
+            return None
+        return {
+            int(r[0]): {
+                'n_agree':    int(r[1]),
+                'n_disagree': int(r[2]),
+                'n_pass':     int(r[3]),
+                'n_voters':   int(r[4]),
+            }
+            for r in rows
+        }
+
+    def get_phase6_participant_count(
+        self,
+        zinvite: str,
+        excluded_pids: list[int] | None = None,
+    ) -> int | None:
+        """Return the number of distinct participants in a Phase 6 conversation.
+
+        Excludes any pids in excluded_pids (banned participants).
+        Returns None if Postgres is unavailable.
+        """
+        if not self._db_url or not _SAFE_ZINVITE.match(zinvite or ''):
+            return None
+        pids = list(excluded_pids or [])
+        rows = self._pg_query(
+            _PHASE6_PARTICIPANT_COUNT_SQL,
+            (zinvite, pids),
+            'get_phase6_participant_count',
+        )
+        if rows is None:
+            return None
+        return int(rows[0][0]) if rows else 0
+
+    def get_personal_votes(
+        self,
+        zinvite: str,
+        polis_pid: int,
+    ) -> dict[int, int] | None:
+        """Return the participant's own votes in a conversation keyed by tid.
+
+        Returns dict[tid → vote] where vote is -1 (agree), +1 (disagree), or
+        0 (pass). Returns None if Postgres is unavailable.
+        """
+        if not self._db_url or not _SAFE_ZINVITE.match(zinvite or ''):
+            return None
+        rows = self._pg_query(
+            _PERSONAL_VOTES_SQL,
+            (zinvite, polis_pid),
+            'get_personal_votes',
+        )
+        if rows is None:
+            return None
+        return {int(r[0]): int(r[1]) for r in rows}
 
     def queue_math_recompute(self, zinvite: str) -> bool:
         """Insert a worker_tasks row to trigger a polismath recompute for one conversation.

--- a/v2/ref_data-model.md
+++ b/v2/ref_data-model.md
@@ -63,10 +63,23 @@ enum(`moderator`) · `granted_at` · `granted_by` FK→participants (**SET NULL*
 `(participant_id, conversation_id, role)`.
 
 ### `featured_statements`
-`id` PK · `conversation_id` FK (CASCADE) · `polis_statement_id` int · `statement_text`
-(nullable; cached from Particiapi for when the API is down) · `suggested_by_system`
-bool=F · `confirmed_by_admin` bool=F · `created_at`. Unique
-`(conversation_id, polis_statement_id)`.
+`id` PK · `conversation_id` FK (CASCADE) · `polis_statement_id` int (Phase 2 tid in the
+main Polis conversation) · `phase6_polis_statement_id` int nullable (Phase 6 tid in the
+dedicated informed-voting Polis conversation; set by `admin_phase6_init`/`_sync_phase6_featured`
+and cleared to NULL when the statement is hidden in Phase 6) · `statement_text`
+(nullable; cached from Particiapi) · `suggested_by_system` bool=F · `confirmed_by_admin`
+bool=F · `created_at`. Unique `(conversation_id, polis_statement_id)`.
+
+**Phase 6 two-conversation architecture.** Each `Conversation` holds two separate Polis
+conversation IDs: `polis_id` (Phase 2, all statements) and `phase6_polis_conversation_id`
+(Phase 6, only confirmed featured statements as seeds). These are independent Polis
+conversations with distinct zinvites and vote sets. Joining them for comparison uses the
+`FeaturedStatement` as the bridge: `polis_statement_id` is the Phase 2 tid,
+`phase6_polis_statement_id` is the Phase 6 tid for the same logical statement.
+
+**Vote-sign convention (both conversations).** Raw Polis DB: `-1 = Agree, 1 = Disagree,
+0 = Pass`. The participant-facing CSV export negates this (agree = +1). wiki-polis always
+reads from `votes_latest_unique` using the raw sign. See `ref_polis-data-model.md`.
 
 ### `arguments`
 `id` PK · `featured_statement_id` FK (CASCADE) · `proposer_id` FK→participants
@@ -115,5 +128,15 @@ proposer_id)`, `argument_votes(argument_id, participant_id)`,
   workflow is still needed to remove internal account↔pseudonym links for non-revealed
   participations by the retention commitment.
 
-> The proposal's `phase6_*` fields (from [`prop_phase-model.md`](prop_phase-model.md)) are
-> **not** in `db.py` — they exist only in the proposal.
+**Phase 6 results moderation.** `Phase6ResultsFilter` (defined in `app.py`) carries two
+exclusion sets applied uniformly across all result surfaces:
+- `excluded_tids` — Phase 6 Polis tids suppressed post-init (de-featured statements whose
+  `phase6_polis_statement_id` was moderated to `mod = -1`).
+- `excluded_pids` — Polis participant pids suppressed (banned participants; empty until
+  issue #60 ships the admin ban UI). The field exists so results can be recomputed with
+  exclusions without a schema change.
+
+**Result surfaces.** Three surfaces are built from the same `_build_phase6_results` helper:
+1. **Surface A — preliminary** (results tab in `conversation.html` while round is live).
+2. **Surface B — final report** (`/c/<slug>/report`, public after close).
+3. **Surface C — self-comparison** (placeholder in the final report; full implementation deferred).

--- a/v2/ref_polis-data-model.md
+++ b/v2/ref_polis-data-model.md
@@ -93,6 +93,13 @@ One row per statement. `txt` is the statement text.
 - `votes_latest_unique` is the **authoritative current vote** — a `RULE` upserts it on every `votes` insert. Query this for current state.
 - `vote` value: **-1 = Agree, 1 = Disagree, 0 = Pass/Unsure** (opposite of the data export sign).
 
+**Phase 6 vote queries use `votes_latest_unique`, not `votes`.** The Phase 6 informed
+voting round lives in a separate Polis conversation (`phase6_polis_conversation_id`). All
+wiki-polis result queries (`get_phase6_vote_counts`, `get_phase6_participant_count`,
+`get_personal_votes`) query `votes_latest_unique` to get one-vote-per-participant-per-statement,
+consistent with what Polis math uses. Filtering to confirmed featured statement tids and
+optionally excluding banned pids happens in the SQL `WHERE` clause — never post-hoc in Python.
+
 ### `participants` (keyed by `(zid, pid)`)
 
 One row per (user, conversation). Tracks `vote_count`, `last_interaction`.

--- a/v2/spec_functional-design.md
+++ b/v2/spec_functional-design.md
@@ -298,7 +298,7 @@ Admins do not need a separate moderation UI for hiding individual statements or 
 
 ## Phase control
 
-A conversation moves through a linear sequence of six phases, each backed by a boolean flag on the conversation:
+A conversation moves through a linear sequence of phases, each backed by a boolean flag on the conversation:
 
 | Order | Phase | Flag | What it enables |
 |---|---|---|---|
@@ -307,11 +307,16 @@ A conversation moves through a linear sequence of six phases, each backed by a b
 | 3 | Featured selection | `phase_personal_results` | participants see personal results while the organizer curates featured statements |
 | 4 | Argument mapping | `phase_argument_mapping` | pro/con argument layer on featured statements |
 | 5 | Informed voting | `phase_informed_voting` (+ `phase6_polis_conversation_id`) | second clean vote round on featured statements; requires a one-time **initialise** |
-| 6 | Public results | `phase_public_results` | full aggregate map public to everyone; **auto-closes** the conversation |
+| — | *Cleanup window* | *(no flag — inferred state)* | organizer reviews results before publishing; participants see preliminary results; see [#163] |
+| 6 | Public results | `phase_public_results` | full aggregate map public to everyone |
+
+The **cleanup window** is the period after informed voting ends and before the organizer publishes the final report by closing the conversation (`closed_at` set). No separate flag is needed: the state is inferred from `conv.active AND NOT conv.phase_informed_voting` (or informed voting still on but organizer is reviewing). Participants see a "Preliminary results" banner during this window; the final report at `/c/<slug>/report` is only published once `closed_at` is set. At that moment the `Phase6ResultsFilter` (excluded statements and participants) is snapshotted so the published figures are semi-immutable — see [#163] for implementation.
+
+**Closing is irreversible** and starts the identity-reveal clock. It does not happen automatically — the organizer explicitly publishes the final report as a deliberate action.
 
 Two control surfaces:
 
-- **Simple / guided ("Move on").** Advances one step forward through the sequence. Renders a consequence summary plus a **readiness checklist** (per-phase preconditions); the submit button is gated client-side until every item is confirmed, and the server re-validates on POST. Machine-checked preconditions (currently only "≥1 confirmed featured statement" before argument mapping) show a met / not-met badge. A closed conversation jumps straight to public results.
+- **Simple / guided ("Move on").** Advances one step forward through the sequence. Renders a consequence summary plus a **readiness checklist** (per-phase preconditions); the submit button is gated client-side until every item is confirmed, and the server re-validates on POST. Machine-checked preconditions (currently only "≥1 confirmed featured statement" before argument mapping) show a met / not-met badge.
 - **Advanced toggles (global admin only).** Each phase flag as an independent on/off control, including backward moves and non-linear states. Opens automatically when the conversation is already in a non-linear state.
 
 Conversation moderators (non-admins) see phase controls read-only. Pause/Resume and Close are separate conversation-status actions (see above), not phases.

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -2940,6 +2940,229 @@ a { color: var(--pass); }
 }
 
 /* ─────────────────────────────────────────────────────────────────────────────
+   Phase 6 results table — shared by conversation.html results tab (Surface A)
+   and report.html (Surface B).
+   ───────────────────────────────────────────────────────────────────────────── */
+
+.p6-results-block {
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--hairline);
+}
+
+.p6-results-header {
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.p6-results-badge {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+.p6-results-badge--preliminary {
+  color: var(--spot);
+  background: rgba(180,83,9,.08);
+  border: 1px solid rgba(180,83,9,.18);
+}
+
+/* Results comparison table */
+.p6-results-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: .875rem;
+  margin-top: .5rem;
+}
+.p6-results-table th {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding: 6px 8px 8px;
+  text-align: left;
+  border-bottom: 1px solid var(--hairline);
+}
+.p6-results-table td {
+  padding: 10px 8px;
+  vertical-align: top;
+  border-bottom: 1px solid var(--hairline-soft, var(--hairline));
+}
+.p6-results-row:last-child td { border-bottom: none; }
+
+.p6-col-stmt  { width: 40%; min-width: 160px; line-height: 1.4; }
+.p6-col-phase { width: 22%; min-width: 120px; }
+.p6-col-shift { width: 10%; min-width: 56px;  white-space: nowrap; }
+.p6-col-mine  { width: 10%; min-width: 70px;  }
+
+/* Stacked agree/disagree bar */
+.p6-vote-bar {
+  display: flex;
+  height: 8px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--surface2);
+  margin-bottom: 3px;
+}
+.p6-bar-agree    { background: var(--agree);    transition: width .2s; }
+.p6-bar-disagree { background: var(--disagree); transition: width .2s; }
+
+.p6-bar-label {
+  font-size: 11px;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+/* Shift indicator */
+.p6-shift {
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+}
+.p6-shift--up   { color: var(--agree); }
+.p6-shift--down { color: var(--disagree); }
+
+/* Personal vote badge */
+.p6-my-vote {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 4px;
+  background: var(--surface2);
+  color: var(--muted);
+}
+.p6-my-vote--agreed    { color: var(--agree);    background: rgba(31,138,91,.09); }
+.p6-my-vote--disagreed { color: var(--disagree); background: rgba(196,74,74,.09); }
+.p6-my-vote--passed    { color: var(--pass);     background: rgba(61,109,186,.09); }
+
+/* Mobile: collapse phase columns */
+@media (max-width: 640px) {
+  .p6-col-stmt  { width: auto; }
+  .p6-col-phase { width: 90px; min-width: 90px; }
+  .p6-col-shift { width: 48px; min-width: 48px; }
+  .p6-col-mine  { display: none; }
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Final report page (report.html)
+   ───────────────────────────────────────────────────────────────────────────── */
+
+.report-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--hairline);
+}
+
+.report-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--ink);
+  letter-spacing: -.02em;
+  line-height: 1.25;
+  margin: 0 0 .25rem;
+}
+
+.report-subtitle {
+  font-size: .875rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.report-badge {
+  flex-shrink: 0;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .07em;
+  text-transform: uppercase;
+  padding: 3px 10px;
+  border-radius: 4px;
+  color: var(--agree);
+  background: rgba(31,138,91,.09);
+  border: 1px solid rgba(31,138,91,.2);
+}
+
+.report-section {
+  margin-bottom: 2.5rem;
+}
+
+.report-section-heading {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ink);
+  margin: 0 0 .75rem;
+  display: flex;
+  align-items: baseline;
+  gap: .5rem;
+  flex-wrap: wrap;
+}
+
+.report-section-sub {
+  font-size: .8125rem;
+  font-weight: 400;
+  color: var(--muted);
+}
+
+.report-stats-row {
+  display: flex;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.report-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.report-stat-value {
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: var(--ink);
+  letter-spacing: -.03em;
+  line-height: 1;
+}
+
+.report-stat-label {
+  font-size: .75rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  font-family: var(--mono);
+  letter-spacing: .05em;
+}
+
+.report-moderation-note {
+  font-size: 12px;
+  margin-top: .75rem;
+}
+
+.report-table th,
+.report-table td { padding: 10px 10px; }
+
+.report-section--explore {
+  background: var(--surface2);
+  border: 1px solid var(--hairline);
+  border-radius: 10px;
+  padding: 18px 20px;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
    Arguments tab redesign — at-* components
    Additive; does not override existing arg-* rules.
    ───────────────────────────────────────────────────────────────────────────── */

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -3162,6 +3162,66 @@ a { color: var(--pass); }
   padding: 18px 20px;
 }
 
+/* Report — new scaffold elements */
+.report-placeholder {
+  font-size: 13px;
+  color: var(--muted);
+  font-style: italic;
+  background: var(--surface2);
+  border: 1px dashed var(--hairline);
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin-bottom: .75rem;
+}
+.report-placeholder-inline {
+  font-size: 12px;
+  color: var(--muted);
+  font-style: italic;
+}
+.report-section-sub-heading {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+  margin: 1rem 0 .4rem;
+}
+.report-stat--placeholder { opacity: .45; }
+.report-col-note {
+  font-size: 10px;
+  font-weight: 400;
+  color: var(--muted);
+  display: block;
+}
+.report-anchor { color: var(--muted); font-size: inherit; }
+.report-anchor:hover { color: var(--link); }
+
+/* Process timeline */
+.report-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: .5rem;
+}
+.report-timeline-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 13px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--hairline);
+}
+.report-timeline-item--placeholder { opacity: .5; }
+.report-timeline-label { color: var(--fg); }
+.report-timeline-value { color: var(--muted); text-align: right; }
+
+/* Statement rows used in initial opinions section */
+.report-stmt-row {
+  margin-bottom: 1rem;
+}
+.report-stmt-text {
+  font-size: 14px;
+  margin: 0 0 .35rem;
+}
+
 /* ─────────────────────────────────────────────────────────────────────────────
    Arguments tab redesign — at-* components
    Additive; does not override existing arg-* rules.

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -90,8 +90,6 @@
         </div>
         <p class="phase-now-desc">{{ phase_sequence[current_stage_index].effect }}</p>
 
-        {# The few numbers we already fetch. TODO(#165/#42): per-phase statistics
-           (e.g. featured-with-arguments, awaiting moderation) replace these. #}
         {% if polis_stats %}
         <div class="phase-stats">
           <div><div class="phase-stat-value">{{ polis_stats.n_participants }}</div>
@@ -100,6 +98,45 @@
                <div class="phase-stat-label">votes cast</div></div>
           <div><div class="phase-stat-value">{{ polis_stats.n_statements }}</div>
                <div class="phase-stat-label">statements ({{ polis_stats.n_seed }} seed)</div></div>
+        </div>
+        {% endif %}
+
+        {# Phase 6 (informed voting) stats — shown when the round is active. #}
+        {% if phase6_results %}
+        <div class="phase-stats phase-stats--p6" style="margin-top:.75rem;padding-top:.75rem;border-top:1px solid var(--hairline)">
+          <div>
+            <div class="phase-stat-label" style="margin-bottom:3px">Informed voting</div>
+            {% if phase6_results.p6_participants is not none %}
+            <div><div class="phase-stat-value">{{ phase6_results.p6_participants }}</div>
+                 <div class="phase-stat-label">participants in round 6</div></div>
+            {% else %}
+            <div class="muted" style="font-size:12px">participant count unavailable</div>
+            {% endif %}
+          </div>
+          {% if phase6_results.statements %}
+          <div>
+            <div class="phase-stat-value">{{ phase6_results.statements | length }}</div>
+            <div class="phase-stat-label">statements voted on</div>
+          </div>
+          {# Teaser: statement with largest opinion shift #}
+          {% set biggest = phase6_results.statements | selectattr('shift', 'ne', none) | list | first %}
+          {% if biggest %}
+          <div style="grid-column:1/-1;margin-top:.25rem">
+            <div class="phase-stat-label" style="margin-bottom:3px">Largest shift</div>
+            <span style="font-size:13px">"{{ biggest.text | truncate(60, True, '…') }}"</span>
+            <span class="p6-shift {% if biggest.shift > 0 %}p6-shift--up{% elif biggest.shift < 0 %}p6-shift--down{% endif %}" style="margin-left:.4rem">
+              {% if biggest.shift > 0 %}+{% endif %}{{ biggest.shift }}%
+            </span>
+          </div>
+          {% endif %}
+          {% endif %}
+          {% if phase6_results.filter.excluded_tids or phase6_results.filter.excluded_pids %}
+          <div style="grid-column:1/-1;font-size:11px;color:var(--muted)">
+            Moderation:
+            {% if phase6_results.filter.excluded_tids %}{{ phase6_results.filter.excluded_tids | length }} stmt excluded{% endif %}
+            {% if phase6_results.filter.excluded_pids %}· {{ phase6_results.filter.excluded_pids | length }} participant excluded{% endif %}
+          </div>
+          {% endif %}
         </div>
         {% endif %}
       </div>

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -457,7 +457,11 @@
       {% if not conversation.active %}
       <div class="danger-row">
         <div class="danger-row-main">
-          <div class="danger-row-title">Permanently closed</div>
+          <div class="danger-row-title">Permanently closed
+            {% if conversation.phase_public_results or conversation.phase_personal_results %}
+            · <a href="{{ url_for('participant.conversation_report', slug=conversation.slug) }}" style="font-weight:400;font-size:13px">View final report <span aria-hidden="true">→</span></a>
+            {% endif %}
+          </div>
           <div class="danger-row-desc">
             {% if reveal and reveal.state == 'cooldown' %}
               Closed {{ conversation.closed_at.strftime('%-d %b %Y') }}.

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -458,7 +458,21 @@
       <div class="danger-row">
         <div class="danger-row-main">
           <div class="danger-row-title">Permanently closed</div>
-          <div class="danger-row-desc">The 30-day identity-reveal window has started and cannot be reset.</div>
+          <div class="danger-row-desc">
+            {% if reveal and reveal.state == 'cooldown' %}
+              Closed {{ conversation.closed_at.strftime('%-d %b %Y') }}.
+              The identity-reveal window opens on {{ reveal.opens_at.strftime('%-d %b %Y') }}
+              ({{ reveal.days_until_open }} day{{ 's' if reveal.days_until_open != 1 }} away) — nothing to do until then.
+            {% elif reveal and reveal.state == 'open' %}
+              Closed {{ conversation.closed_at.strftime('%-d %b %Y') }}.
+              The identity-reveal window is open until {{ reveal.closes_at.strftime('%-d %b %Y') }}.
+            {% elif reveal and reveal.state == 'closed' %}
+              Closed {{ conversation.closed_at.strftime('%-d %b %Y') }}.
+              The identity-reveal window has closed; records are permanently pseudonymous.
+            {% else %}
+              Closed{% if conversation.closed_at %} {{ conversation.closed_at.strftime('%-d %b %Y') }}{% endif %}. Cannot be reopened.
+            {% endif %}
+          </div>
         </div>
       </div>
       {% else %}

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -62,6 +62,11 @@
     {% else %}
     <p class="muted">This consultation is closed.</p>
     {% endif %}
+    {% if conversation.phase_public_results or conversation.phase_personal_results %}
+    <p style="margin-top:1rem;font-size:14px">
+      <a href="{{ url_for('participant.conversation_report', slug=conversation.slug) }}">Read the final report <span aria-hidden="true">→</span></a>
+    </p>
+    {% endif %}
   </div>
 
   {% elif conversation.paused %}

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -400,6 +400,78 @@
         <p class="muted">Results haven't been published yet. Check back soon.</p>
       {% endif %}
 
+      {# ── Phase 6 informed voting results (Surface A — preliminary) ──────── #}
+      {% if phase6_results and phase6_results.statements %}
+      <div class="results-block p6-results-block">
+        <div class="p6-results-header">
+          <p class="results-label">Informed voting results</p>
+          {% if phase6_results.is_preliminary %}
+          <span class="p6-results-badge p6-results-badge--preliminary">Preliminary</span>
+          {% endif %}
+          {% if phase6_results.p6_participants %}
+          <span class="muted" style="font-size:12px">{{ phase6_results.p6_participants }} participant{{ 's' if phase6_results.p6_participants != 1 }}</span>
+          {% endif %}
+        </div>
+        {% if not phase6_results.pg_available %}
+        <p class="muted" style="font-size:13px">Detailed vote counts are not available right now.</p>
+        {% else %}
+        <table class="p6-results-table" aria-label="Informed voting results by statement">
+          <thead>
+            <tr>
+              <th class="p6-col-stmt">Statement</th>
+              <th class="p6-col-phase" title="Phase 2 — initial voting">Initial vote</th>
+              <th class="p6-col-phase" title="Phase 6 — informed voting">Informed vote</th>
+              <th class="p6-col-shift" title="Change in agree rate">Shift</th>
+              {% if participation %}<th class="p6-col-mine">Yours</th>{% endif %}
+            </tr>
+          </thead>
+          <tbody>
+          {% for s in phase6_results.statements %}
+          <tr class="p6-results-row">
+            <td class="p6-col-stmt">{{ s.text }}</td>
+            <td class="p6-col-phase">
+              {% if s.p2 %}
+              <div class="p6-vote-bar" title="Agree {{ s.p2.pct_agree }}% · Disagree {{ s.p2.pct_disagree }}%">
+                <div class="p6-bar-agree" style="width:{{ s.p2.pct_agree }}%"></div>
+                <div class="p6-bar-disagree" style="width:{{ s.p2.pct_disagree }}%"></div>
+              </div>
+              <span class="p6-bar-label">{{ s.p2.pct_agree }}% agree</span>
+              {% else %}<span class="muted">—</span>{% endif %}
+            </td>
+            <td class="p6-col-phase">
+              <div class="p6-vote-bar" title="Agree {{ s.p6.pct_agree }}% · Disagree {{ s.p6.pct_disagree }}%">
+                <div class="p6-bar-agree" style="width:{{ s.p6.pct_agree }}%"></div>
+                <div class="p6-bar-disagree" style="width:{{ s.p6.pct_disagree }}%"></div>
+              </div>
+              <span class="p6-bar-label">{{ s.p6.pct_agree }}% agree</span>
+            </td>
+            <td class="p6-col-shift">
+              {% if s.shift is not none %}
+              <span class="p6-shift {% if s.shift > 0 %}p6-shift--up{% elif s.shift < 0 %}p6-shift--down{% endif %}">
+                {% if s.shift > 0 %}+{% endif %}{{ s.shift }}%
+              </span>
+              {% else %}<span class="muted">—</span>{% endif %}
+            </td>
+            {% if participation %}
+            <td class="p6-col-mine">
+              {% if s.my_p6_label %}
+              <span class="p6-my-vote p6-my-vote--{{ s.my_p6_label|lower }}">{{ s.my_p6_label }}</span>
+              {% else %}<span class="muted">—</span>{% endif %}
+            </td>
+            {% endif %}
+          </tr>
+          {% endfor %}
+          </tbody>
+        </table>
+        {% endif %}
+        {% if not conversation.active %}
+        <p style="margin-top:1rem;font-size:13px">
+          <a href="{{ url_for('participant.conversation_report', slug=conversation.slug) }}">Read the full results report <span aria-hidden="true">→</span></a>
+        </p>
+        {% endif %}
+      </div>
+      {% endif %}{# end phase6_results #}
+
     </div>
   </div>
   {% endif %}{# end 'results' in tabs #}
@@ -897,7 +969,7 @@
     {% elif conversation.active %}
     <p class="p6-done-text">The results report will be published here once this consultation closes.</p>
     {% else %}
-    <p class="p6-done-text">This consultation is now closed.</p>
+    <p class="p6-done-text">This consultation is now closed. <a href="{{ url_for('participant.conversation_report', slug=conversation.slug) }}">Read the final report <span aria-hidden="true">→</span></a></p>
     {% endif %}
     {% if reveal_state is none or reveal_state == 'pending' %}
     <p class="p6-done-reveal">Your votes are recorded under pseudonym <strong>{{ participation.pseudonym }}</strong>. Once this consultation closes, you will have a limited window to optionally link your Wikimedia username. You cannot make that decision yet.</p>

--- a/v2/templates/report.html
+++ b/v2/templates/report.html
@@ -1,0 +1,196 @@
+{% extends "base.html" %}
+
+{% block header_crumb %}
+<span class="header-crumb">
+  <span class="header-crumb-sep">/</span>
+  <span>{{ conversation.title | truncate(40, True, '…') }}</span>
+  <span class="header-crumb-sep">/</span>
+  <span>report</span>
+</span>
+{% endblock %}
+
+{% block content %}
+<div class="container" style="max-width:800px">
+
+  <p style="margin-bottom:1.25rem">
+    <a href="{{ url_for('participant.conversation', slug=conversation.slug) }}"
+       style="font-size:13px;color:var(--muted);text-decoration:none">
+      <span aria-hidden="true">←</span> {{ conversation.title }}
+    </a>
+  </p>
+
+  {# ── Header ──────────────────────────────────────────────────────────────── #}
+  <div class="report-header">
+    <div>
+      <h1 class="report-title">{{ conversation.title }}</h1>
+      <p class="report-subtitle">
+        Final results report
+        {% if conversation.closed_at %}
+        · closed {{ conversation.closed_at.strftime('%-d %b %Y') }}
+        {% endif %}
+      </p>
+    </div>
+    <span class="report-badge">Final</span>
+  </div>
+
+  {% if phase6_results %}
+
+  {# ── Participation summary ────────────────────────────────────────────────── #}
+  <div class="report-section">
+    <h2 class="report-section-heading">Participation</h2>
+    <div class="report-stats-row">
+      {% if phase6_results.p2_participants %}
+      <div class="report-stat">
+        <span class="report-stat-value">{{ phase6_results.p2_participants }}</span>
+        <span class="report-stat-label">Initial voting</span>
+      </div>
+      {% endif %}
+      {% if phase6_results.p6_participants %}
+      <div class="report-stat">
+        <span class="report-stat-value">{{ phase6_results.p6_participants }}</span>
+        <span class="report-stat-label">Informed voting</span>
+      </div>
+      {% endif %}
+    </div>
+    {% if phase6_results.filter.excluded_tids or phase6_results.filter.excluded_pids %}
+    <p class="report-moderation-note muted">
+      Moderation applied:
+      {% if phase6_results.filter.excluded_tids %}
+      {{ phase6_results.filter.excluded_tids | length }} statement{{ 's' if phase6_results.filter.excluded_tids | length != 1 }} excluded
+      {% endif %}
+      {% if phase6_results.filter.excluded_pids %}
+      · {{ phase6_results.filter.excluded_pids | length }} participant{{ 's' if phase6_results.filter.excluded_pids | length != 1 }} excluded
+      {% endif %}
+    </p>
+    {% endif %}
+    {% if not phase6_results.pg_available %}
+    <p class="muted" style="font-size:13px;margin-top:.5rem">
+      Detailed vote counts are not available — the results database is unreachable.
+    </p>
+    {% endif %}
+  </div>
+
+  {# ── Opinion shift table ─────────────────────────────────────────────────── #}
+  {% if phase6_results.statements and phase6_results.pg_available %}
+  <div class="report-section">
+    <h2 class="report-section-heading">
+      Opinion shift
+      <span class="report-section-sub">Did argument exposure change views?</span>
+    </h2>
+    <p class="muted" style="font-size:13px;margin-bottom:1rem">
+      Each row compares the initial vote (Phase 2, before seeing arguments) with the
+      informed vote (Phase 6, after argument mapping). Shift = change in agree rate.
+      Sorted by size of shift.
+    </p>
+    <table class="p6-results-table report-table" aria-label="Opinion shift per statement">
+      <thead>
+        <tr>
+          <th class="p6-col-stmt">Statement</th>
+          <th class="p6-col-phase">Initial</th>
+          <th class="p6-col-phase">Informed</th>
+          <th class="p6-col-shift">Shift</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for s in phase6_results.statements %}
+      <tr class="p6-results-row">
+        <td class="p6-col-stmt">{{ s.text }}</td>
+        <td class="p6-col-phase">
+          {% if s.p2 %}
+          <div class="p6-vote-bar" title="Agree {{ s.p2.pct_agree }}% · Disagree {{ s.p2.pct_disagree }}%">
+            <div class="p6-bar-agree" style="width:{{ s.p2.pct_agree }}%"></div>
+            <div class="p6-bar-disagree" style="width:{{ s.p2.pct_disagree }}%"></div>
+          </div>
+          <span class="p6-bar-label">{{ s.p2.pct_agree }}% agree · {{ s.p2.n_voters }} votes</span>
+          {% else %}<span class="muted">—</span>{% endif %}
+        </td>
+        <td class="p6-col-phase">
+          <div class="p6-vote-bar" title="Agree {{ s.p6.pct_agree }}% · Disagree {{ s.p6.pct_disagree }}%">
+            <div class="p6-bar-agree" style="width:{{ s.p6.pct_agree }}%"></div>
+            <div class="p6-bar-disagree" style="width:{{ s.p6.pct_disagree }}%"></div>
+          </div>
+          <span class="p6-bar-label">{{ s.p6.pct_agree }}% agree · {{ s.p6.n_voters }} votes</span>
+        </td>
+        <td class="p6-col-shift">
+          {% if s.shift is not none %}
+          <span class="p6-shift {% if s.shift > 0 %}p6-shift--up{% elif s.shift < 0 %}p6-shift--down{% endif %}">
+            {% if s.shift > 0 %}+{% endif %}{{ s.shift }}%
+          </span>
+          {% else %}<span class="muted">—</span>{% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% endif %}
+
+  {# ── Opinion groups (clusters from Particiapi) ───────────────────────────── #}
+  {% if phase6_results.clusters %}
+  <div class="report-section">
+    <h2 class="report-section-heading">
+      Opinion groups
+      <span class="report-section-sub">{{ phase6_results.clusters | length }} group{{ 's' if phase6_results.clusters | length != 1 }} identified in the informed voting round</span>
+    </h2>
+    <p class="muted" style="font-size:13px;margin-bottom:1rem">
+      Groups represent clusters of participants with similar voting patterns.
+      Statements listed here were most characteristic of each group.
+    </p>
+    {% for group in phase6_results.clusters %}
+    <div class="results-block" style="margin-bottom:1rem">
+      <p class="results-group-heading">
+        Group {{ loop.index }}
+        {% if group.n_members %}<span class="muted" style="font-weight:400;font-size:12px">· {{ group.n_members }} participant{{ 's' if group.n_members != 1 }}</span>{% endif %}
+      </p>
+      {% for r in group.agree %}
+      <div class="results-row">
+        <span class="results-badge results-agree">agree</span>
+        <span class="results-text">"{{ r.statement_text }}"</span>
+        {% if r.value %}<span class="results-pct">{{ (r.value * 100)|int }}%</span>{% endif %}
+      </div>
+      {% endfor %}
+      {% for r in group.disagree %}
+      <div class="results-row">
+        <span class="results-badge results-disagree">disagree</span>
+        <span class="results-text">"{{ r.statement_text }}"</span>
+        {% if r.value %}<span class="results-pct">{{ (r.value * 100)|int }}%</span>{% endif %}
+      </div>
+      {% endfor %}
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {# ── Self-comparison placeholder (Surface C) ─────────────────────────────── #}
+  {% if participation and phase6_results.clusters %}
+  <div class="report-section report-section--explore">
+    <h2 class="report-section-heading">Where did you land?</h2>
+    <p class="muted" style="font-size:13px">
+      Personalised group comparison — coming soon. This will show how your informed votes
+      compare to each opinion group and where your views sit in the overall distribution.
+    </p>
+  </div>
+  {% endif %}
+
+  {% else %}
+  <div class="landing-section">
+    <p class="muted">Informed voting results are not available for this consultation yet.</p>
+  </div>
+  {% endif %}
+
+  {# ── Identity reveal callout ──────────────────────────────────────────────── #}
+  {% if reveal_state == 'open' and participation %}
+  <div class="reveal-callout" style="margin-top:2rem">
+    <p class="reveal-callout-text">
+      The identity reveal window is open. Your participation is recorded under
+      pseudonym <strong>{{ participation.pseudonym }}</strong>.
+    </p>
+    <a class="reveal-callout-link"
+       href="{{ url_for('participant.reveal_identity', slug=conversation.slug) }}">
+      Optionally link your Wikimedia username <span aria-hidden="true">→</span>
+    </a>
+  </div>
+  {% endif %}
+
+</div>
+{% endblock %}

--- a/v2/templates/report.html
+++ b/v2/templates/report.html
@@ -36,18 +36,14 @@
   {# ── Introduction ─────────────────────────────────────────────────────────── #}
   <div class="report-section">
     <h2 class="report-section-heading">Introduction</h2>
-    {# PLACEHOLDER: organizer-written introduction text.
-       This section should describe: the topic, why this consultation was run,
-       who organised it, and what will be done with the results.
-       Add a `conversation.report_intro` field and render it here. #}
+    {# PLACEHOLDER: organizer-written report introduction.
+       Add a `conversation.report_intro` field (separate from intro_text, which is
+       the participant-facing submission prompt) and render it here. #}
     <p class="report-placeholder">
       <em>Organizer introduction not yet added. This section should explain
       what the consultation was about, who organised it, and how the results
       will be used.</em>
     </p>
-    {% if conversation.intro_text %}
-    <div class="report-intro-text">{{ conversation.intro_text | safe }}</div>
-    {% endif %}
   </div>
 
   {# ── Process timeline ────────────────────────────────────────────────────── #}

--- a/v2/templates/report.html
+++ b/v2/templates/report.html
@@ -33,24 +33,79 @@
     <span class="report-badge">Final</span>
   </div>
 
+  {# ── Introduction ─────────────────────────────────────────────────────────── #}
+  <div class="report-section">
+    <h2 class="report-section-heading">Introduction</h2>
+    {# PLACEHOLDER: organizer-written introduction text.
+       This section should describe: the topic, why this consultation was run,
+       who organised it, and what will be done with the results.
+       Add a `conversation.report_intro` field and render it here. #}
+    <p class="report-placeholder">
+      <em>Organizer introduction not yet added. This section should explain
+      what the consultation was about, who organised it, and how the results
+      will be used.</em>
+    </p>
+    {% if conversation.intro_text %}
+    <div class="report-intro-text">{{ conversation.intro_text | safe }}</div>
+    {% endif %}
+  </div>
+
+  {# ── Process timeline ────────────────────────────────────────────────────── #}
+  <div class="report-section">
+    <h2 class="report-section-heading">Process</h2>
+    <div class="report-timeline">
+      <div class="report-timeline-item">
+        <span class="report-timeline-label">Consultation opened</span>
+        <span class="report-timeline-value">{{ conversation.created_at.strftime('%-d %b %Y') }}</span>
+      </div>
+      {# PLACEHOLDER: per-phase open timestamps are not yet stored in the DB.
+         Add phase_*_opened_at columns to record when each toggle was first enabled. #}
+      <div class="report-timeline-item report-timeline-item--placeholder">
+        <span class="report-timeline-label">Submission phase</span>
+        <span class="report-timeline-value report-placeholder-inline">dates not stored yet</span>
+      </div>
+      <div class="report-timeline-item report-timeline-item--placeholder">
+        <span class="report-timeline-label">Argument mapping</span>
+        <span class="report-timeline-value report-placeholder-inline">dates not stored yet</span>
+      </div>
+      <div class="report-timeline-item report-timeline-item--placeholder">
+        <span class="report-timeline-label">Informed voting</span>
+        <span class="report-timeline-value report-placeholder-inline">dates not stored yet</span>
+      </div>
+      {% if conversation.closed_at %}
+      <div class="report-timeline-item">
+        <span class="report-timeline-label">Consultation closed</span>
+        <span class="report-timeline-value">{{ conversation.closed_at.strftime('%-d %b %Y') }}</span>
+      </div>
+      {% endif %}
+    </div>
+  </div>
+
   {% if phase6_results %}
 
-  {# ── Participation summary ────────────────────────────────────────────────── #}
+  {# ── Participation ────────────────────────────────────────────────────────── #}
   <div class="report-section">
     <h2 class="report-section-heading">Participation</h2>
     <div class="report-stats-row">
       {% if phase6_results.p2_participants %}
       <div class="report-stat">
         <span class="report-stat-value">{{ phase6_results.p2_participants }}</span>
-        <span class="report-stat-label">Initial voting</span>
+        <span class="report-stat-label">Initial voting (Phase 2)</span>
       </div>
       {% endif %}
       {% if phase6_results.p6_participants %}
       <div class="report-stat">
         <span class="report-stat-value">{{ phase6_results.p6_participants }}</span>
-        <span class="report-stat-label">Informed voting</span>
+        <span class="report-stat-label">Informed voting (Phase 6)</span>
       </div>
       {% endif %}
+      {# PLACEHOLDER: matched_participants — participants who voted in both rounds.
+         Requires xid→pid cross-round linkage (not yet stored). Needed for individual
+         delta calculation and extrapolation. #}
+      <div class="report-stat report-stat--placeholder">
+        <span class="report-stat-value">—</span>
+        <span class="report-stat-label">Voted in both rounds</span>
+      </div>
     </div>
     {% if phase6_results.filter.excluded_tids or phase6_results.filter.excluded_pids %}
     <p class="report-moderation-note muted">
@@ -70,7 +125,84 @@
     {% endif %}
   </div>
 
-  {# ── Opinion shift table ─────────────────────────────────────────────────── #}
+  {# ── Statement inventory ──────────────────────────────────────────────────── #}
+  <div class="report-section">
+    <h2 class="report-section-heading">Statements</h2>
+    {# PLACEHOLDER: full statement inventory — total submitted, seed vs participant-proposed,
+       moderation outcomes (accepted / rejected / pending).
+       Requires: Particiapi query for full statement list + moderation status.
+       We currently only store confirmed featured statements.
+       Add a `get_all_statements(zinvite)` call and render counts here. #}
+    <p class="report-placeholder">
+      <em>Statement inventory not yet available. This section will show: total
+      statements submitted, how many were seed statements vs participant-proposed,
+      and moderation outcomes.</em>
+    </p>
+    <p class="muted" style="font-size:13px">
+      Featured statements used in informed voting: {{ phase6_results.statements | length }}
+    </p>
+  </div>
+
+  {# ── Initial opinions (Phase 2) ───────────────────────────────────────────── #}
+  {% if phase6_results.p2_consensus or phase6_results.p2_divisive %}
+  <div class="report-section">
+    <h2 class="report-section-heading">
+      Initial opinions
+      <span class="report-section-sub">Phase 2 — before argument mapping</span>
+    </h2>
+    <p class="muted" style="font-size:13px;margin-bottom:1rem">
+      Based on votes cast during the initial submission phase, before participants
+      saw any arguments.
+    </p>
+
+    {% if phase6_results.p2_consensus %}
+    <h3 class="report-section-sub-heading">Highest agreement</h3>
+    {% for s in phase6_results.p2_consensus %}
+    <div class="report-stmt-row">
+      <p class="report-stmt-text">{{ s.text }}</p>
+      <div class="p6-vote-bar" title="Agree {{ s.p2.pct_agree }}% · Disagree {{ s.p2.pct_disagree }}%">
+        <div class="p6-bar-agree" style="width:{{ s.p2.pct_agree }}%"></div>
+        <div class="p6-bar-disagree" style="width:{{ s.p2.pct_disagree }}%"></div>
+      </div>
+      <span class="p6-bar-label">{{ s.p2.pct_agree }}% agree · {{ s.p2.n_voters }} votes</span>
+    </div>
+    {% endfor %}
+    {% endif %}
+
+    {% if phase6_results.p2_divisive %}
+    <h3 class="report-section-sub-heading" style="margin-top:1.25rem">Most divisive</h3>
+    <p class="muted" style="font-size:13px;margin-bottom:.75rem">
+      Statements with the most evenly split agree/disagree response.
+    </p>
+    {% for s in phase6_results.p2_divisive %}
+    <div class="report-stmt-row">
+      <p class="report-stmt-text">{{ s.text }}</p>
+      <div class="p6-vote-bar" title="Agree {{ s.p2.pct_agree }}% · Disagree {{ s.p2.pct_disagree }}%">
+        <div class="p6-bar-agree" style="width:{{ s.p2.pct_agree }}%"></div>
+        <div class="p6-bar-disagree" style="width:{{ s.p2.pct_disagree }}%"></div>
+      </div>
+      <span class="p6-bar-label">{{ s.p2.pct_agree }}% agree · {{ s.p2.n_voters }} votes</span>
+    </div>
+    {% endfor %}
+    {% endif %}
+  </div>
+  {% endif %}
+
+  {# ── Argument mapping ─────────────────────────────────────────────────────── #}
+  <div class="report-section">
+    <h2 class="report-section-heading">Argument mapping</h2>
+    {# PLACEHOLDER: argument mapping summary.
+       Feasible soon: argument counts are in our DB (Arguments table).
+       Add to the report route: argument count per statement, most-upvoted arguments,
+       participation in the argument voting phase. #}
+    <p class="report-placeholder">
+      <em>Argument mapping summary not yet available. This section will show:
+      arguments submitted per statement, most-upvoted pro/con arguments, and
+      participation in argument voting.</em>
+    </p>
+  </div>
+
+  {# ── Aggregate opinion shift ──────────────────────────────────────────────── #}
   {% if phase6_results.statements and phase6_results.pg_available %}
   <div class="report-section">
     <h2 class="report-section-heading">
@@ -78,17 +210,20 @@
       <span class="report-section-sub">Did argument exposure change views?</span>
     </h2>
     <p class="muted" style="font-size:13px;margin-bottom:1rem">
-      Each row compares the initial vote (Phase 2, before seeing arguments) with the
-      informed vote (Phase 6, after argument mapping). Shift = change in agree rate.
+      Each row compares the initial vote (Phase 2, before arguments) with the
+      informed vote (Phase 6, after argument mapping). <strong>Shift</strong> is
+      the change in population-level agree rate — a cross-round comparison of
+      separate populations, not a matched individual delta
+      (see <a href="#methodology" class="report-anchor">Methodology</a> below).
       Sorted by size of shift.
     </p>
-    <table class="p6-results-table report-table" aria-label="Opinion shift per statement">
+    <table class="p6-results-table report-table" aria-label="Aggregate opinion shift per statement">
       <thead>
         <tr>
           <th class="p6-col-stmt">Statement</th>
           <th class="p6-col-phase">Initial</th>
           <th class="p6-col-phase">Informed</th>
-          <th class="p6-col-shift">Shift</th>
+          <th class="p6-col-shift">Shift <span class="report-col-note">(aggregate)</span></th>
         </tr>
       </thead>
       <tbody>
@@ -125,6 +260,34 @@
   </div>
   {% endif %}
 
+  {# ── Matched participant delta ─────────────────────────────────────────────── #}
+  <div class="report-section">
+    <h2 class="report-section-heading">Matched participant analysis</h2>
+    {# PLACEHOLDER: individual-level delta for participants who voted in both rounds,
+       and extrapolation to the full Phase 2 population with confidence intervals.
+
+       This requires:
+       1. xid→pid cross-round linkage (not yet stored — see personal-votes TODO in app.py)
+       2. Per-participant before/after vote pairs for each statement
+       3. A CI method for extrapolating from the matched subset to the full Phase 2 cohort
+          — REQUIRES LITERATURE REVIEW. Candidate approaches:
+          - Wilcoxon signed-rank on matched pairs (non-parametric, appropriate for ordinal votes)
+          - Bootstrap CI on matched delta with correction for non-matched fraction
+          - Difference-in-differences with covariates if demographic data is available
+       See literature/REVIEW.md in polis-study for relevant references. #}
+    <p class="report-placeholder">
+      <em>Matched participant analysis not yet available. This section will show
+      the individual-level opinion change for participants who voted in both rounds,
+      and a population-level extrapolation with confidence intervals.</em>
+    </p>
+    <p class="muted" style="font-size:13px">
+      Note: delta is only directly observable for participants who cast a vote in
+      both Phase 2 and Phase 6. Extrapolation to the full initial-voting cohort
+      requires statistical adjustment; confidence intervals for this extrapolation
+      are under development (pending methodology review).
+    </p>
+  </div>
+
   {# ── Opinion groups (clusters from Particiapi) ───────────────────────────── #}
   {% if phase6_results.clusters %}
   <div class="report-section">
@@ -133,8 +296,9 @@
       <span class="report-section-sub">{{ phase6_results.clusters | length }} group{{ 's' if phase6_results.clusters | length != 1 }} identified in the informed voting round</span>
     </h2>
     <p class="muted" style="font-size:13px;margin-bottom:1rem">
-      Groups represent clusters of participants with similar voting patterns.
-      Statements listed here were most characteristic of each group.
+      Groups represent clusters of participants with similar voting patterns,
+      identified by PCA + k-means on the informed voting matrix. Statements
+      listed here were most characteristic of each group.
     </p>
     {% for group in phase6_results.clusters %}
     <div class="results-block" style="margin-bottom:1rem">
@@ -171,6 +335,64 @@
     </p>
   </div>
   {% endif %}
+
+  {# ── Methodology ─────────────────────────────────────────────────────────── #}
+  <div class="report-section" id="methodology">
+    <h2 class="report-section-heading">Methodology</h2>
+
+    <h3 class="report-section-sub-heading">Data sources</h3>
+    <p class="muted" style="font-size:13px;margin-bottom:1rem">
+      Vote counts are drawn from the Polis Postgres database
+      (<code>votes_latest_unique</code> view), which holds one vote per
+      participant per statement. Opinion groups (clusters) are computed by the
+      Polis math service and retrieved via the Particiapi results API. Where the
+      two participant counts diverge by more than 5%, a warning is logged.
+      Moderation exclusions (hidden statements, banned participants) are applied
+      before any aggregation.
+    </p>
+
+    <h3 class="report-section-sub-heading">Aggregate opinion shift</h3>
+    <p class="muted" style="font-size:13px;margin-bottom:1rem">
+      The shift column in the opinion-shift table is computed as
+      <em>Phase 6 agree% − Phase 2 agree%</em>. This is a cross-round
+      <strong>population comparison</strong>, not a paired before/after
+      measurement: Phase 2 and Phase 6 participants are overlapping but not
+      identical sets. A positive shift means the informed-voting cohort agreed
+      at a higher rate, but this may partly reflect differences in who
+      participated rather than genuine attitude change.
+    </p>
+
+    <h3 class="report-section-sub-heading">Individual delta and extrapolation</h3>
+    {# PLACEHOLDER: CI methodology — requires literature review.
+       Candidate references from polis-study/literature/REVIEW.md:
+       - small2021polis for the Polis matrix model
+       - navarrete2024understanding for divisiveness metrics methodology
+       - Deliberative poll literature (Fishkin) for pre/post matched-panel methods
+       Likely approach: Wilcoxon signed-rank on matched pairs; bootstrap for CI;
+       inverse-probability weighting or difference-in-differences for extrapolation.
+       Literature review needed before finalising. #}
+    <p class="muted" style="font-size:13px;margin-bottom:1rem">
+      Individual-level delta — the change in a specific participant's vote
+      between rounds — is only observable for participants who voted in both
+      Phase 2 and Phase 6. Extrapolating from this matched subset to the full
+      initial-voting population requires statistical adjustment for the
+      non-random selection of who returned for Phase 6.
+    </p>
+    <p class="report-placeholder" style="font-size:13px">
+      <em>Confidence interval methodology for the extrapolated delta is pending
+      literature review. This section will describe the statistical method used
+      once the approach is finalised.</em>
+    </p>
+
+    <h3 class="report-section-sub-heading">Clustering</h3>
+    <p class="muted" style="font-size:13px">
+      Opinion groups are produced by the Polis algorithm: PCA reduces the
+      participant × statement vote matrix to two dimensions, then k-means
+      clustering groups participants by voting similarity. The number of groups
+      is chosen by silhouette score. Consensus and representative statements for
+      each group are selected by the Polis math service.
+    </p>
+  </div>
 
   {% else %}
   <div class="landing-section">


### PR DESCRIPTION
Closes #122. Partial #165 (informed voting stats slice only).

## Summary

- **Data layer** — three new `PolisServerClient` Postgres methods querying `votes_latest_unique`: `get_phase6_vote_counts` (per-statement agree/disagree/pass, filtered to allowed tids and excluded pids), `get_phase6_participant_count`, `get_personal_votes`
- **`Phase6ResultsFilter`** dataclass: `excluded_tids` (hidden Phase 6 statements) + `excluded_pids` (banned participants, empty until #60); applied uniformly across all surfaces
- **`_build_phase6_results`** helper: Phase 2 vs Phase 6 per-statement comparison, shift calculation, source-divergence check between PG and Particiapi, graceful fallback when PG unavailable
- **Surface A — preliminary** (results tab, `conversation.html`): agree/disagree bars, shift indicator, personal vote badge, Preliminary banner while round is live
- **Surface B — final report** (`/c/<slug>/report`): new route + `report.html`; aggregate only, opinion-shift table sorted by shift, clusters from Particiapi, participation counts, moderation note, Final badge; links from done screen and results tab
- **Surface C placeholder** in final report: "Where did you land?" reserved, full self-comparison deferred
- **Admin stats slice** (#165 partial): Phase 6 participant count, statement count, largest-shift teaser in admin conversation stats panel
- **Docs**: `ref_data-model.md` (two-conversation architecture, vote-sign, filter model), `ref_polis-data-model.md` (`votes_latest_unique` Phase 6 note), `guide_organizer.md` (new results section)

## Deferred / known gaps
- Personal votes (my_p2_vote / my_p6_vote) always None — requires xid→pid mapping not yet stored; field exists, TODO comment in code
- Surface C self-comparison — placeholder only; full implementation is a follow-up
- Banned-participant exclusion UI (#60) — `excluded_pids` field is wired, UI not yet built

## Test plan
- [x] 317 pytest pass, no migration
- [ ] Staging: open a conversation with Phase 6 active and verify results tab renders; navigate to `/c/<slug>/report` on a closed conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)