### PR TITLE
feat(admin): show all active phases in the phase-control box

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -551,13 +551,21 @@ def _argument_stats(conv):
     }
 
 
-def _phase_tiles(conv, key, polis_stats, phase6_stats=None):
+def _phase_tiles(conv, key, polis_stats, phase6_stats=None,
+                 get_featured_counts=None, get_argument_stats=None):
     """Stat tiles for a single phase `key` (#165). Each tile is {value, label, unit?, note?}.
 
     Polis-derived tiles (vote/participant counts) are omitted when polis_stats is
     None — the template shows a loud warning instead. Flask-derived tiles (featured
     statements, arguments) always render, since they don't depend on Polis PG.
+
+    `get_featured_counts` / `get_argument_stats` are optional accessors so a multi-phase
+    caller can memoize those DB aggregates across phases (several active phases reuse the
+    same featured/argument counts); they default to a fresh per-call query.
     """
+    get_featured_counts = get_featured_counts or (lambda: _featured_counts(conv))
+    get_argument_stats  = get_argument_stats  or (lambda: _argument_stats(conv))
+
     def polis_basic():
         if not polis_stats:
             return []
@@ -577,7 +585,7 @@ def _phase_tiles(conv, key, polis_stats, phase6_stats=None):
             tiles.append({'value': polis_stats['median_votes'], 'label': 'median votes / person'})
 
     elif key == 'featured_selection':
-        confirmed, _ = _featured_counts(conv)
+        confirmed, _ = get_featured_counts()
         tiles.append({'value': confirmed, 'label': 'featured selected',
                       'note': '{} recommended'.format(_RECOMMENDED_FEATURED)})
         if polis_stats:
@@ -585,8 +593,8 @@ def _phase_tiles(conv, key, polis_stats, phase6_stats=None):
             tiles.append({'value': polis_stats['n_participants'], 'label': 'participants'})
 
     elif key in ('argument_mapping', 'cleanup'):
-        confirmed, _ = _featured_counts(conv)
-        a = _argument_stats(conv)
+        confirmed, _ = get_featured_counts()
+        a = get_argument_stats()
         tiles.append({'value': confirmed,          'label': 'featured statements'})
         tiles.append({'value': a['n_pro'],         'label': 'pro arguments'})
         tiles.append({'value': a['n_con'],         'label': 'con arguments'})
@@ -595,7 +603,7 @@ def _phase_tiles(conv, key, polis_stats, phase6_stats=None):
             tiles.append({'value': a['n_raters'],  'label': 'rating arguments'})
 
     elif key == 'informed_voting':
-        confirmed, _ = _featured_counts(conv)
+        confirmed, _ = get_featured_counts()
         seeded = (FeaturedStatement.query
                   .filter(FeaturedStatement.conversation_id == conv.id,
                           FeaturedStatement.confirmed_by_admin.is_(True),
@@ -621,11 +629,29 @@ def _phase_stat_groups(conv, polis_stats, phase6_stats=None):
     control box shows a group per phase — its name plus the tiles relevant to it —
     rather than only the furthest-along phase. Groups with no tiles are kept here and
     skipped by the template.
+
+    The featured/argument DB aggregates are memoized across phases here: in advanced
+    mode several active phases (e.g. argument_mapping + cleanup + informed_voting) each
+    want the featured count, and they'd otherwise re-run the same COUNT/aggregate query
+    per phase on every admin page load.
     """
+    cache = {}
+
+    def featured_counts():
+        if 'featured' not in cache:
+            cache['featured'] = _featured_counts(conv)
+        return cache['featured']
+
+    def argument_stats():
+        if 'arguments' not in cache:
+            cache['arguments'] = _argument_stats(conv)
+        return cache['arguments']
+
     return [
         {'key':   PHASE_SEQUENCE[i]['key'],
          'label': PHASE_SEQUENCE[i]['label'],
-         'tiles': _phase_tiles(conv, PHASE_SEQUENCE[i]['key'], polis_stats, phase6_stats)}
+         'tiles': _phase_tiles(conv, PHASE_SEQUENCE[i]['key'], polis_stats, phase6_stats,
+                               featured_counts, argument_stats)}
         for i in _active_stage_indices(conv)
     ]
 
@@ -1301,7 +1327,6 @@ def admin_conversation_detail(conv_id):
         polis_stats is None
         or (conv.phase_informed_voting and conv.phase6_polis_conversation_id
             and phase6_stats is None))
-    active_phase_labels = [PHASE_SEQUENCE[i]['label'] for i in _active_stage_indices(conv)]
     phase6_results    = (_build_phase6_results(conv, participation=None)
                          if conv.phase_informed_voting and conv.phase6_polis_conversation_id
                          else None)
@@ -1314,7 +1339,6 @@ def admin_conversation_detail(conv_id):
                            participant_count=participant_count,
                            polis_stats=polis_stats,
                            phase_stat_groups=_phase_stat_groups(conv, polis_stats, phase6_stats),
-                           active_phase_labels=active_phase_labels,
                            polis_stats_unavailable=polis_stats_unavailable,
                            phase6_results=phase6_results,
                            reveal=reveal,
@@ -1322,6 +1346,7 @@ def admin_conversation_detail(conv_id):
                            can_manage_roles=can_manage_roles,
                            phase_sequence=PHASE_SEQUENCE,
                            current_stage_index=_current_stage_index(conv),
+                           active_stage_indices=_active_stage_indices(conv),
                            linear_phase_state=_is_linear_phase_state(conv),
                            advance_target_index=_advance_target_index(conv),
                            transition=_transition_context(conv))

--- a/v2/app.py
+++ b/v2/app.py
@@ -147,6 +147,15 @@ def _current_stage_index(conv) -> int:
     return idx
 
 
+def _active_stage_indices(conv) -> list[int]:
+    """Every stage index whose flag is on, in sequence order; [0] (preparation) if
+    none are. In simple/linear mode this is a single index; in advanced mode multiple
+    phases can be active at once and each is surfaced in the phase-control box."""
+    active = [i for i, s in enumerate(PHASE_SEQUENCE)
+              if s['flag'] and getattr(conv, s['flag'])]
+    return active or [0]
+
+
 def _is_linear_phase_state(conv) -> bool:
     """True if at most one phase flag is on — the simple-mode invariant."""
     return sum(1 for f in _PHASE_FLAGS if getattr(conv, f)) <= 1
@@ -321,9 +330,8 @@ def _argument_stats(conv):
     }
 
 
-def _phase_stats(conv, polis_stats, phase6_stats=None):
-    """Tiles for the phase-hero readout, scoped to the conversation's current phase
-    (#165). Each tile is {value, label, unit?, note?}.
+def _phase_tiles(conv, key, polis_stats, phase6_stats=None):
+    """Stat tiles for a single phase `key` (#165). Each tile is {value, label, unit?, note?}.
 
     Polis-derived tiles (vote/participant counts) are omitted when polis_stats is
     None — the template shows a loud warning instead. Flask-derived tiles (featured
@@ -339,7 +347,6 @@ def _phase_stats(conv, polis_stats, phase6_stats=None):
              'label': 'statements ({} seed)'.format(polis_stats['n_seed'])},
         ]
 
-    key   = PHASE_SEQUENCE[_current_stage_index(conv)]['key']
     tiles = []
 
     if key == 'submission':
@@ -384,6 +391,22 @@ def _phase_stats(conv, polis_stats, phase6_stats=None):
         tiles = polis_basic()
 
     return tiles
+
+
+def _phase_stat_groups(conv, polis_stats, phase6_stats=None):
+    """One stat group per *active* phase, in sequence order; each is
+    {key, label, tiles}. In simple/linear mode this is a single group (the template
+    renders it flat). In advanced mode several phases can be on at once, so the
+    control box shows a group per phase — its name plus the tiles relevant to it —
+    rather than only the furthest-along phase. Groups with no tiles are kept here and
+    skipped by the template.
+    """
+    return [
+        {'key':   PHASE_SEQUENCE[i]['key'],
+         'label': PHASE_SEQUENCE[i]['label'],
+         'tiles': _phase_tiles(conv, PHASE_SEQUENCE[i]['key'], polis_stats, phase6_stats)}
+        for i in _active_stage_indices(conv)
+    ]
 
 
 csrf    = CSRFProtect()
@@ -1042,23 +1065,22 @@ def admin_conversation_detail(conv_id):
     participant_count = Participation.query.filter_by(conversation_id=conv_id).count()
     client            = _polis_server_client()
     polis_stats       = client.get_polis_stats(conv.polis_id)
-    # Round-2 tiles render only when the *displayed* stage is informed voting (the
-    # furthest-along flag), which can differ from the raw phase_informed_voting flag in
-    # non-linear states. Key the phase-6 fetch and its warning off the same stage, so the
-    # banner can't fire for round-2 tiles that were never shown (#165).
-    in_informed_voting = PHASE_SEQUENCE[_current_stage_index(conv)]['key'] == 'informed_voting'
+    # Informed-voting round-2 tiles render whenever that phase is active (its flag is
+    # on) — including alongside other phases in advanced mode — so fetch the phase-6
+    # stats and gate the warning on the flag itself.
     phase6_stats      = (client.get_polis_stats(conv.phase6_polis_conversation_id)
-                         if in_informed_voting and conv.phase6_polis_conversation_id
+                         if conv.phase_informed_voting and conv.phase6_polis_conversation_id
                          else None)
     # Loud warning only when Polis PG is configured but unreachable — never when it is
     # deliberately not wired (local/dev), where None is expected. Unavailable if the
-    # round-1 fetch failed, or — in informed voting — the round-2 (phase-6) fetch failed
-    # (without that a phase-6 outage would drop the round-2 tiles silently).
+    # round-1 fetch failed, or — when informed voting is active — the round-2 (phase-6)
+    # fetch failed (without that a phase-6 outage would drop the round-2 tiles silently).
     polis_pg_configured     = bool(current_app.config.get('POLIS_DATABASE_URL'))
     polis_stats_unavailable = polis_pg_configured and (
         polis_stats is None
-        or (in_informed_voting and conv.phase6_polis_conversation_id
+        or (conv.phase_informed_voting and conv.phase6_polis_conversation_id
             and phase6_stats is None))
+    active_phase_labels = [PHASE_SEQUENCE[i]['label'] for i in _active_stage_indices(conv)]
     return render_template('admin_conversation.html',
                            conversation=conv,
                            conv_roles=conv_roles,
@@ -1066,7 +1088,8 @@ def admin_conversation_detail(conv_id):
                            invite_count=invite_count,
                            participant_count=participant_count,
                            polis_stats=polis_stats,
-                           phase_stats=_phase_stats(conv, polis_stats, phase6_stats),
+                           phase_stat_groups=_phase_stat_groups(conv, polis_stats, phase6_stats),
+                           active_phase_labels=active_phase_labels,
                            polis_stats_unavailable=polis_stats_unavailable,
                            admin_roles=ADMIN_ROLES,
                            can_manage_roles=can_manage_roles,

--- a/v2/log_changelog.md
+++ b/v2/log_changelog.md
@@ -322,3 +322,24 @@ the guided "Move on" box and double as readiness signals (#156).
   readers read one phrase, not a stream of loose numbers); warning banner uses `role="status"`
   (not the render-time-inappropriate `role="alert"`); warning text darkened to clear AA
   contrast on the tinted panel
+
+## Multi-phase statistics in the phase-control box (follow-up to #165)
+
+In advanced mode an organizer can have several phase flags on at once. The phase-control
+box previously collapsed that to the single furthest-along phase — showing one phase name
+and only that phase's stats. It now reflects **every active phase**.
+
+- [x] `_active_stage_indices(conv)` returns all on-flag stage indices (was: only the
+  furthest via `_current_stage_index`)
+- [x] `_phase_stats` split into `_phase_tiles(conv, key, …)` (per-phase tile builder) +
+  `_phase_stat_groups(conv, …)` which returns one `{key, label, tiles}` group per active
+  phase — addressing the long if/elif altitude nit from the #183 review
+- [x] Phase-hero header: simple mode unchanged ("You are in phase N of M"); non-linear mode
+  shows "Multiple phases active" + the active phase names joined
+- [x] Stats render a labelled group per active phase; a single active phase still renders
+  flat (no heading), identical to before
+- [x] Phase-6 fetch + outage warning go back to gating on the `phase_informed_voting` flag
+  (the round-2 tiles now render whenever that phase is active, not only when furthest), which
+  supersedes the #183 narrowing coherently
+- [x] Tests: group-per-active-phase rendering, single-phase stays flat, and the multi-phase
+  phase-6-outage warning

--- a/v2/log_changelog.md
+++ b/v2/log_changelog.md
@@ -344,6 +344,26 @@ and only that phase's stats. It now reflects **every active phase**.
 - [x] Tests: group-per-active-phase rendering, single-phase stays flat, and the multi-phase
   phase-6-outage warning
 
+**Review follow-up (#189):** reconcile the three "which phases are active" surfaces so the
+box never contradicts itself in advanced mode.
+
+- [x] Journey stepper now reflects multi-active state: in non-linear mode every active phase
+  is marked *current* and none shown as *done* (was: driven by the single furthest-along
+  stage, contradicting the "Multiple phases active" hero). `active_stage_indices` passed to
+  the template.
+- [x] Group labelling keys off the hero state (`not linear_phase_state`), not the tile count:
+  a lone tiled group is still labelled when the header names ≥2 phases, so the reader can
+  tell whose numbers they are.
+- [x] The "...shown below" copy is reworded and omitted when no active phase currently has
+  data (e.g. Polis-only phases while PG is down) — no dangling promise over an empty area.
+- [x] a11y: each grouped `<dl>` is `aria-labelledby` its phase label, so a screen reader
+  announces the group name rather than a flat number stream across phase boundaries.
+- [x] Featured/argument DB aggregates memoized across phases in `_phase_stat_groups` (was:
+  re-queried per active phase); dropped the duplicate `active_phase_labels` (header labels
+  derive from the group list).
+- [x] Tests: lone-tiled-group still labelled, all-Polis-only omits the copy, stepper marks
+  every active step current.
+
 ## Step 8 — Phase 6 results report (2026-06-10)
 
 **Phase 6 results — three surfaces** ([#122](https://github.com/lgelauff/wiki-polis/issues/122), [#165](https://github.com/lgelauff/wiki-polis/issues/165) partial)

--- a/v2/static/redesign.css
+++ b/v2/static/redesign.css
@@ -287,6 +287,17 @@
   border-top: 1px solid var(--hairline-soft);
 }
 .phase-stats dd { margin: 0; }  /* drop the UA dd indent — tiles stack value over label */
+/* Per-phase group heading + tighter spacing when several phases are active at once
+   in advanced mode (the single-phase case renders flat, without these). */
+.phase-stats-group-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-top: 18px;
+}
+.phase-stats--grouped { margin: 8px 0 0; padding-top: 0; border-top: none; }
 .phase-stat-value {
   font-size: 24px;
   font-weight: 700;

--- a/v2/static/redesign.css
+++ b/v2/static/redesign.css
@@ -298,6 +298,13 @@
   margin-top: 18px;
 }
 .phase-stats--grouped { margin: 8px 0 0; padding-top: 0; border-top: none; }
+/* Divider between consecutive phase groups (advanced mode): a group label that follows a
+   previous group's stats gets a hairline rule above it. The first group has no preceding
+   stats, so no leading bar. */
+.phase-stats--grouped + .phase-stats-group-label {
+  border-top: 1px solid var(--hairline-soft);
+  padding-top: 18px;
+}
 .phase-stat-value {
   font-size: 24px;
   font-weight: 700;

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -56,14 +56,22 @@
          Arguments and Informed vote). Renders from PHASE_SEQUENCE. #}
       <ol class="journey phase-stepper" aria-label="Consultation phase progress">
         {% for stage in phase_sequence %}
+        {# Linear (simple) mode: one current step, earlier steps done ✓ — driven by the
+           furthest-along stage. Non-linear (advanced) mode: several phases are open at
+           once, so mark *every* active step current and never show a phase as "done",
+           keeping the stepper consistent with the "Multiple phases active" hero below
+           rather than contradicting it. #}
+        {%- set is_current = (loop.index0 == current_stage_index) if linear_phase_state
+                             else (loop.index0 in active_stage_indices) %}
+        {%- set is_done = (loop.index0 < current_stage_index) if linear_phase_state else false %}
         <li class="journey-step
-                   {%- if loop.index0 == current_stage_index %} journey-step--current
-                   {%- elif loop.index0 < current_stage_index %} journey-step--done{% endif %}"
-            {% if loop.index0 == current_stage_index %}aria-current="step"{% endif %}>
-          <span class="journey-dot">{% if loop.index0 < current_stage_index %}✓{% else %}{{ loop.index }}{% endif %}</span>
+                   {%- if is_current %} journey-step--current
+                   {%- elif is_done %} journey-step--done{% endif %}"
+            {% if is_current %}aria-current="step"{% endif %}>
+          <span class="journey-dot">{% if is_done %}✓{% else %}{{ loop.index }}{% endif %}</span>
           <span class="journey-label">{{ stage.label }}</span>
-          {% if loop.index0 == current_stage_index %}<span class="sr-only">(current phase)</span>
-          {% elif loop.index0 < current_stage_index %}<span class="sr-only">(completed)</span>
+          {% if is_current %}<span class="sr-only">(current phase)</span>
+          {% elif is_done %}<span class="sr-only">(completed)</span>
           {% else %}<span class="sr-only">(upcoming)</span>{% endif %}
         </li>
         {% endfor %}
@@ -82,6 +90,10 @@
 
       {# Current-phase body #}
       <div class="phase-hero-body">
+        {# Active phases that actually have data to show right now. Distinct from the set of
+           active phases (a Polis-only phase yields no tiles while PG is down), so the header
+           copy and the per-phase render below both key off this single list. #}
+        {% set shown_groups = phase_stat_groups | selectattr('tiles') | list %}
         {% if linear_phase_state %}
         <div class="phase-now-head">
           <span class="phase-now-kicker">You are in phase {{ current_stage_index + 1 }} of {{ phase_sequence | length }}</span>
@@ -97,9 +109,10 @@
           <span class="phase-now-kicker">Multiple phases active</span>
         </div>
         <div class="phase-now-head" style="margin-top:2px">
-          <span class="phase-now-name">{{ active_phase_labels | join(' + ') }}</span>
+          <span class="phase-now-name">{{ phase_stat_groups | map(attribute='label') | join(' + ') }}</span>
         </div>
-        <p class="phase-now-desc">Several phases are open at once (advanced mode). Statistics for each are shown below.</p>
+        {# Reword + omit the "shown below" promise unless a group will actually render. #}
+        <p class="phase-now-desc">Several phases are open at once (advanced mode).{% if shown_groups %} Statistics for the phases with available data are shown below.{% endif %}</p>
         {% endif %}
 
         {# Phase-specific statistics (#165). One group per active phase; in advanced mode
@@ -114,15 +127,19 @@
             conversation may not yet be registered in Polis. Check the server logs.</span>
         </div>
         {% endif %}
-        {# `multi` = more than one active phase actually has tiles; only then do we label
-           each group (a single group renders flat, unchanged from simple mode). #}
-        {% set multi = (phase_stat_groups | selectattr('tiles') | list | length) > 1 %}
-        {% for g in phase_stat_groups if g.tiles %}
-        {% if multi %}<div class="phase-stats-group-label">{{ g.label }}</div>{% endif %}
+        {# Label each group whenever the box is in non-linear (advanced) mode — i.e. whenever
+           the hero names more than one phase — so the reader can always tell which phase the
+           numbers belong to, even when only one of the named phases currently has data. A
+           single active phase (simple mode) still renders flat, unchanged. #}
+        {% for g in shown_groups %}
+        {% if not linear_phase_state %}<div id="psg-{{ loop.index }}" class="phase-stats-group-label">{{ g.label }}</div>{% endif %}
         {# A <dl> ties each value to its label programmatically: a screen reader reads each
            tile as "<value> <label>" rather than a stream of disconnected numbers. Native
-           dt/dd needs no ARIA — the visible text is the accessible text (#165). #}
-        <dl class="phase-stats{% if multi %} phase-stats--grouped{% endif %}">
+           dt/dd needs no ARIA. In grouped mode aria-labelledby points the list at its phase
+           label, so the group name is announced as the list's name — without it a SR hears a
+           flat number stream across phase boundaries (#165 a11y follow-up). #}
+        <dl class="phase-stats{% if not linear_phase_state %} phase-stats--grouped{% endif %}"
+            {% if not linear_phase_state %}aria-labelledby="psg-{{ loop.index }}"{% endif %}>
           {% for t in g.tiles %}
           <div>
             <dt class="phase-stat-value">{{ t.value }}{% if t.unit %}<span class="unit">{{ t.unit }}</span>{% endif %}</dt>

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -82,6 +82,7 @@
 
       {# Current-phase body #}
       <div class="phase-hero-body">
+        {% if linear_phase_state %}
         <div class="phase-now-head">
           <span class="phase-now-kicker">You are in phase {{ current_stage_index + 1 }} of {{ phase_sequence | length }}</span>
         </div>
@@ -89,11 +90,22 @@
           <span class="phase-now-name">{{ phase_sequence[current_stage_index].label }}</span>
         </div>
         <p class="phase-now-desc">{{ phase_sequence[current_stage_index].effect }}</p>
+        {% else %}
+        {# Advanced/non-linear: several phase flags are on at once — name them all rather
+           than only the furthest-along one. #}
+        <div class="phase-now-head">
+          <span class="phase-now-kicker">Multiple phases active</span>
+        </div>
+        <div class="phase-now-head" style="margin-top:2px">
+          <span class="phase-now-name">{{ active_phase_labels | join(' + ') }}</span>
+        </div>
+        <p class="phase-now-desc">Several phases are open at once (advanced mode). Statistics for each are shown below.</p>
+        {% endif %}
 
-        {# Phase-specific statistics (#165). Tiles are scoped to the current phase and
-           built server-side by _phase_stats(). Flask-derived numbers (featured,
-           arguments) render even when Polis PG is down; the warning below fires only
-           when PG is configured but unreachable. #}
+        {# Phase-specific statistics (#165). One group per active phase; in advanced mode
+           several render at once, each headed by its phase name. Flask-derived numbers
+           (featured, arguments) render even when Polis PG is down; the warning below fires
+           only when PG is configured but unreachable. #}
         {% if polis_stats_unavailable %}
         <div class="phase-stats-warning" role="status">
           <span aria-hidden="true">⚠️</span>
@@ -102,19 +114,23 @@
             conversation may not yet be registered in Polis. Check the server logs.</span>
         </div>
         {% endif %}
-        {% if phase_stats %}
+        {# `multi` = more than one active phase actually has tiles; only then do we label
+           each group (a single group renders flat, unchanged from simple mode). #}
+        {% set multi = (phase_stat_groups | selectattr('tiles') | list | length) > 1 %}
+        {% for g in phase_stat_groups if g.tiles %}
+        {% if multi %}<div class="phase-stats-group-label">{{ g.label }}</div>{% endif %}
         {# A <dl> ties each value to its label programmatically: a screen reader reads each
            tile as "<value> <label>" rather than a stream of disconnected numbers. Native
            dt/dd needs no ARIA — the visible text is the accessible text (#165). #}
-        <dl class="phase-stats">
-          {% for t in phase_stats %}
+        <dl class="phase-stats{% if multi %} phase-stats--grouped{% endif %}">
+          {% for t in g.tiles %}
           <div>
             <dt class="phase-stat-value">{{ t.value }}{% if t.unit %}<span class="unit">{{ t.unit }}</span>{% endif %}</dt>
             <dd class="phase-stat-label">{{ t.label }}{% if t.note %}<div class="phase-stat-note">{{ t.note }}</div>{% endif %}</dd>
           </div>
           {% endfor %}
         </dl>
-        {% endif %}
+        {% endfor %}
       </div>
 
       {# Pause / Resume — directly under the phase bar (governs the running

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -347,10 +347,10 @@
                {% if conversation.phase_argument_mapping %}checked{% endif %}> Argument mapping</label>
         <label><input type="checkbox" name="phase_cleanup" value="1"
                {% if conversation.phase_cleanup %}checked{% endif %}> Cleanup</label>
-        <label><input type="checkbox" name="phase_public_results" value="1"
-               {% if conversation.phase_public_results %}checked{% endif %}> Public results</label>
         <label><input type="checkbox" name="phase_informed_voting" value="1"
                {% if conversation.phase_informed_voting %}checked{% endif %}> Informed voting</label>
+        <label><input type="checkbox" name="phase_public_results" value="1"
+               {% if conversation.phase_public_results %}checked{% endif %}> Public results</label>
         <button type="submit" class="btn-small phases-save">Save phases</button>
       </form>
 

--- a/v2/tests/test_phase_stats.py
+++ b/v2/tests/test_phase_stats.py
@@ -175,20 +175,27 @@ def test_informed_voting_warns_when_phase6_fetch_fails(app, admin_client, conv):
     assert _tile_value(page, 'voted this round') is None
 
 
-def test_no_round2_warning_when_informed_voting_not_displayed_stage(app, admin_client, conv):
-    # Non-linear state: both informed-voting and public-results flags are on, so the
-    # *displayed* stage is public_results (furthest-along). No round-2 tiles render, so a
-    # failed phase-6 fetch must NOT trip the warning — it tracks the shown stage, not the
-    # raw flag (#165). Guards the false-positive the flag-based condition would have raised.
-    app.config['POLIS_DATABASE_URL'] = 'postgresql://unused/db'
+# ── Multiple phases active at once (advanced mode) ──────────────────────────────
+
+def test_multi_phase_renders_a_group_per_active_phase(admin_client, conv):
+    # Two phase flags on → the box names every active phase and renders a labelled
+    # stat group per phase, each with its own tiles (not just the furthest-along one).
+    conv.phase_argument_mapping = True
     conv.phase_informed_voting = True
-    conv.phase_public_results = True
     conv.phase6_polis_conversation_id = 'p6conv1234'
+    fs = FeaturedStatement(conversation_id=conv.id, polis_statement_id=1,
+                           confirmed_by_admin=True, phase6_polis_statement_id=0)
+    db.session.add(fs)
+    db.session.commit()
+    author = _participant(301, 'c1')
+    db.session.add(Argument(featured_statement_id=fs.id, proposer_id=author.id,
+                            body='pro a', side='pro'))
     db.session.commit()
 
     def stats_for(zinvite):
         if zinvite == 'p6conv1234':
-            return None                              # round-2 PG unreachable (but not shown)
+            return {'n_participants': 7, 'n_votes': 21, 'avg_votes': 3.0,
+                    'median_votes': 3.0, 'n_statements': 1, 'n_seed': 1}
         return {'n_participants': 12, 'n_votes': 80, 'avg_votes': 6.0,
                 'median_votes': 6.0, 'n_statements': 10, 'n_seed': 2}
 
@@ -197,8 +204,49 @@ def test_no_round2_warning_when_informed_voting_not_displayed_stage(app, admin_c
     with patch('app._polis_server_client', return_value=server):
         page = admin_client.get(f'/admin/conversations/{conv.id}').get_data(as_text=True)
 
-    # Round-1 stats are healthy and shown; the irrelevant phase-6 failure stays silent.
-    assert 'phase-stats-warning' not in page
+    assert 'Multiple phases active' in page
+    # A labelled group for each active phase, in sequence order.
+    assert 'phase-stats-group-label">Arguments' in page
+    assert 'phase-stats-group-label">Informed vote' in page
+    # Tiles from both groups render.
+    assert _tile_value(page, 'pro arguments') == '1'
+    assert _tile_value(page, 'statements seeded') == '1/1'
+    assert _tile_value(page, 'voted this round') == '7'
+
+
+def test_single_phase_renders_flat_without_group_label(admin_client, conv):
+    # One active phase → flat readout, no per-phase heading (simple-mode look preserved).
+    conv.phase_argument_mapping = True
+    db.session.commit()
+    page = admin_client.get(f'/admin/conversations/{conv.id}').get_data(as_text=True)
+    assert 'phase-stats-group-label' not in page
+    assert 'Multiple phases active' not in page
+
+
+def test_multi_phase_informed_voting_warns_on_phase6_outage(app, admin_client, conv):
+    # Advanced/non-linear: informed-voting + public-results both on. The informed-voting
+    # group renders, so a failed phase-6 fetch DOES drop its round-2 tiles — the warning
+    # must fire (the round-2 tiles are genuinely shown when the flag is on).
+    app.config['POLIS_DATABASE_URL'] = 'postgresql://unused/db'
+    conv.phase_informed_voting = True
+    conv.phase_public_results = True
+    conv.phase6_polis_conversation_id = 'p6conv1234'
+    db.session.commit()
+
+    def stats_for(zinvite):
+        if zinvite == 'p6conv1234':
+            return None                              # round-2 PG unreachable
+        return {'n_participants': 12, 'n_votes': 80, 'avg_votes': 6.0,
+                'median_votes': 6.0, 'n_statements': 10, 'n_seed': 2}
+
+    server = MagicMock()
+    server.get_polis_stats.side_effect = stats_for
+    with patch('app._polis_server_client', return_value=server):
+        page = admin_client.get(f'/admin/conversations/{conv.id}').get_data(as_text=True)
+
+    assert 'phase-stats-warning' in page
+    assert 'Live statistics unavailable' in page
+    assert 'Multiple phases active' in page
 
 
 # ── Loud warning when Polis PG is configured but down ───────────────────────────

--- a/v2/tests/test_phase_stats.py
+++ b/v2/tests/test_phase_stats.py
@@ -249,6 +249,55 @@ def test_multi_phase_informed_voting_warns_on_phase6_outage(app, admin_client, c
     assert 'Multiple phases active' in page
 
 
+def test_multi_phase_lone_tiled_group_is_still_labelled(admin_client, conv):
+    # Non-linear with two phases named, but only one currently has data: Explore is
+    # Polis-only (no tiles while PG is down) and Arguments has Flask-derived tiles. The
+    # single rendered group must still carry its phase label — otherwise the header names
+    # two phases over one anonymous block and the reader can't tell whose numbers these are.
+    conv.phase_submission = True            # Explore — polis_basic() → [] (no polis stats)
+    conv.phase_argument_mapping = True      # Arguments — Flask tiles always render
+    db.session.commit()
+
+    page = admin_client.get(f'/admin/conversations/{conv.id}').get_data(as_text=True)
+    assert 'Multiple phases active' in page
+    assert 'Explore + Arguments' in page                  # header names both active phases
+    # The lone tiled group is labelled and the <dl> is associated with it for screen readers.
+    assert 'phase-stats-group-label">Arguments' in page
+    assert 'aria-labelledby="psg-1"' in page
+    # Explore yields no tiles, so it gets no group block of its own.
+    assert 'phase-stats-group-label">Explore' not in page
+    assert 'Statistics for the phases with available data are shown below' in page
+
+
+def test_multi_phase_all_polis_only_omits_shown_below_copy(admin_client, conv):
+    # Two Polis-only phases active with no Polis stats (PG unconfigured → no warning):
+    # neither yields tiles. The header still names them, but the "...shown below" promise
+    # must be dropped rather than left dangling over an empty stats area.
+    conv.phase_submission = True            # Explore — polis-only
+    conv.phase_public_results = True        # Report  — polis-only
+    db.session.commit()
+
+    page = admin_client.get(f'/admin/conversations/{conv.id}').get_data(as_text=True)
+    assert 'Multiple phases active' in page
+    assert 'Explore + Report' in page
+    assert 'Statistics for the phases with available data are shown below' not in page
+    assert 'phase-stats-group-label' not in page          # no group renders
+    assert 'phase-stats-warning' not in page              # PG unconfigured — None is expected
+
+
+def test_multi_phase_stepper_marks_every_active_step_current(admin_client, conv):
+    # The journey stepper must agree with the hero: in non-linear mode every active phase
+    # is "current" and none is shown as "done", rather than marking earlier still-open
+    # phases complete off the single furthest-along stage.
+    conv.phase_submission = True            # index 1
+    conv.phase_argument_mapping = True      # index 3 (non-contiguous)
+    db.session.commit()
+
+    page = admin_client.get(f'/admin/conversations/{conv.id}').get_data(as_text=True)
+    assert page.count('journey-step--current') == 2       # both active steps marked current
+    assert 'journey-step--done' not in page               # nothing collapsed to "done"
+
+
 # ── Loud warning when Polis PG is configured but down ───────────────────────────
 
 def test_warning_when_pg_configured_but_unavailable(app, admin_client, conv):


### PR DESCRIPTION
## What

Builds on the phase-specific admin statistics from #183 (now merged). In non-linear phase states several phase flags can be on at once, but the phase-control box only surfaced stats for a single "current" (furthest-along) stage. This shows stat tiles for **every active phase**.

- `_active_stage_indices(conv)` returns all on-flag stage indices (was: only the furthest).
- `_phase_stats` refactored into `_phase_tiles(conv, key, …)` + `_phase_stat_groups(conv, …)` (one `{key, label, tiles}` group per active phase) — resolves the long if/elif altitude nit from the #183 review.
- Phase-hero header: simple mode unchanged ("You are in phase N of M"); non-linear mode shows "Multiple phases active" + the active phase names.
- Stats render a labelled group per active phase; a single active phase still renders flat (unchanged from before).
- Phase-6 fetch + outage warning gate on the `phase_informed_voting` flag (round-2 tiles render whenever that phase is active, not only when furthest).

> #183 has merged, so this PR auto-retargeted to `main`. I re-merged `main` into the branch and re-reconciled against #184's Phase-6 results work (`phase6_results`/`reveal` + the informed-voting results teaser are preserved alongside the new multi-phase groups).

## Testing

- Full suite: **326 pass**, only the known pre-existing `test_empty_results…` flake fails (fails on a clean `main` too; unrelated).
- Added tests: group-per-active-phase rendering, single-phase stays flat, multi-phase phase-6-outage warning.

https://claude.ai/code/session_01KoMsYNSKT4nxWqiLdb6yBf