### PR TITLE
feat(#190): homepage navigation — phase legend, mode toggle, per-tile phase rail

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -3200,11 +3200,13 @@ def _register_routes(app: Flask) -> None:
                      .order_by(Conversation.created_at.desc())
                      .all())
 
+        mod_ids: set = set()
         moderating = []
         if participant:
             if _is_global_admin(participant):
                 moderating = (Conversation.query
                               .order_by(Conversation.created_at.desc()).all())
+                mod_ids = {c.id for c in moderating}
             else:
                 roles = AdminRole.query.filter(
                     AdminRole.participant_id == participant.id,
@@ -3213,6 +3215,9 @@ def _register_routes(app: Flask) -> None:
                     mod_ids = {r.conversation_id for r in roles}
                     moderating = Conversation.query.filter(
                         Conversation.id.in_(mod_ids)).all()
+
+        # Exclude moderated conversations from Browse — they already appear in "You moderate"
+        available = [c for c in available if c.id not in mod_ids]
 
         # keyed by conversation_id, scoped to current user only
         # assumes at most one Participation per (user, conversation) — last row wins if duplicates exist

--- a/v2/app.py
+++ b/v2/app.py
@@ -368,13 +368,21 @@ def _current_stage_index(conv) -> int:
     return idx
 
 
-def _active_stage_indices(conv) -> list[int]:
-    """Every stage index whose flag is on, in sequence order; [0] (preparation) if
-    none are. In simple/linear mode this is a single index; in advanced mode multiple
-    phases can be active at once and each is surfaced in the phase-control box."""
-    active = [i for i, s in enumerate(PHASE_SEQUENCE)
-              if s['flag'] and getattr(conv, s['flag'])]
-    return active or [0]
+def _active_phases(conv) -> set:
+    """Return the set of currently-active phase keys for a conversation.
+
+    Uses PHASE_SEQUENCE flag names as keys. Also adds 'cleanup_window' (inferred:
+    informed_voting on, not yet closed) and 'closed'. Multiple keys are possible
+    when the conversation is in advanced/non-linear mode.
+    """
+    phases = {s['key'] for s in PHASE_SEQUENCE if s['flag'] and getattr(conv, s['flag'])}
+    if not phases and not conv.closed_at:
+        phases.add('preparation')
+    if conv.phase_informed_voting and not conv.closed_at:
+        phases.add('cleanup_window')   # inferred: after IV, before publish
+    if conv.closed_at:
+        phases.add('closed')
+    return phases
 
 
 def _is_linear_phase_state(conv) -> bool:
@@ -3209,12 +3217,39 @@ def _register_routes(app: Flask) -> None:
         # keyed by conversation_id, scoped to current user only
         # assumes at most one Participation per (user, conversation) — last row wins if duplicates exist
         pseudonym_map = {p.conversation_id: p for p in joined_parts}
+
+        # Per-conversation action signals for the home page tiles.
+        all_home_convs = active_joined + archived_joined + list(available)
+
+        # Bulk-fetch statements remaining via Polis Postgres (xid → pid via xids table).
+        # Only meaningful for submission-phase conversations; falls back to None on error.
+        xid = session.get('xid')
+        submission_convs = [c for c in all_home_convs if c.phase_submission and c.active]
+        zinvites = [c.polis_id for c in submission_convs if c.polis_id]
+        remaining_by_zinvite: dict = {}
+        if zinvites and xid:
+            result = _polis_server_client().get_statements_remaining_bulk(zinvites, xid)
+            if result:
+                remaining_by_zinvite = result
+        signals_map: dict = {}
+        for conv in all_home_convs:
+            part = pseudonym_map.get(conv.id)
+            reveal = _reveal_context(conv, part) if conv.closed_at else None
+            remaining = remaining_by_zinvite.get(
+                conv.polis_id) if conv.polis_id else None
+            signals_map[conv.id] = {
+                'phases':               _active_phases(conv),
+                'statements_remaining': remaining,
+                'reveal':               reveal,
+            }
+
         return render_template('home.html',
                                active_joined=active_joined,
                                archived_joined=archived_joined,
                                available=available,
                                moderating=moderating,
                                pseudonym_map=pseudonym_map,
+                               signals_map=signals_map,
                                dev_test_users=dev_test_users)
 
 

--- a/v2/app.py
+++ b/v2/app.py
@@ -660,7 +660,7 @@ def _phase_stat_groups(conv, polis_stats, phase6_stats=None):
          'label': PHASE_SEQUENCE[i]['label'],
          'tiles': _phase_tiles(conv, PHASE_SEQUENCE[i]['key'], polis_stats, phase6_stats,
                                featured_counts, argument_stats)}
-        for i in _active_stage_indices(conv)
+        for i in [j for j, s in enumerate(PHASE_SEQUENCE) if s['key'] in _active_phases(conv)]
     ]
 
 
@@ -1354,7 +1354,8 @@ def admin_conversation_detail(conv_id):
                            can_manage_roles=can_manage_roles,
                            phase_sequence=PHASE_SEQUENCE,
                            current_stage_index=_current_stage_index(conv),
-                           active_stage_indices=_active_stage_indices(conv),
+                           active_stage_indices=[i for i, s in enumerate(PHASE_SEQUENCE)
+                                                  if s['key'] in _active_phases(conv)],
                            linear_phase_state=_is_linear_phase_state(conv),
                            advance_target_index=_advance_target_index(conv),
                            transition=_transition_context(conv))

--- a/v2/polis_admin.py
+++ b/v2/polis_admin.py
@@ -112,6 +112,48 @@ _PHASE6_PARTICIPANT_COUNT_SQL = """
       AND NOT (v.pid = ANY(%s))
 """
 
+# Statements remaining to vote on, across multiple conversations, for one participant.
+# Identified by xid (our SHA-256 of mw_user_id — stored in xids.xid).
+# Returns one row per zinvite: total approved statements and how many the participant
+# has already cast a non-pass vote on (pass counts as "voted" for progress purposes).
+# zinvites is an ARRAY of text; only zinvites present in the xids table for this xid
+# are counted (i.e. conversations the participant has actually joined in Polis).
+_STATEMENTS_REMAINING_BULK_SQL = """
+    WITH zmap AS (
+        SELECT zi.zinvite, zi.zid
+        FROM zinvites zi
+        WHERE zi.zinvite = ANY(%s)
+    ),
+    pid_map AS (
+        SELECT p.zid, p.pid
+        FROM participants p
+        JOIN xids x ON x.uid = p.uid AND x.zid = p.zid
+        WHERE x.xid = %s
+          AND p.zid IN (SELECT zid FROM zmap)
+    ),
+    total_stmts AS (
+        SELECT zmap.zinvite, COUNT(c.tid)::int AS n_total
+        FROM comments c
+        JOIN zmap ON c.zid = zmap.zid
+        WHERE c.active = TRUE AND c.mod >= 0
+        GROUP BY zmap.zinvite
+    ),
+    voted_stmts AS (
+        SELECT zmap.zinvite, COUNT(DISTINCT v.tid)::int AS n_voted
+        FROM votes_latest_unique v
+        JOIN zmap ON v.zid = zmap.zid
+        JOIN pid_map pm ON pm.zid = v.zid AND pm.pid = v.pid
+        GROUP BY zmap.zinvite
+    )
+    SELECT
+        ts.zinvite,
+        ts.n_total,
+        COALESCE(vs.n_voted, 0) AS n_voted,
+        GREATEST(0, ts.n_total - COALESCE(vs.n_voted, 0)) AS n_remaining
+    FROM total_stmts ts
+    LEFT JOIN voted_stmts vs USING (zinvite)
+"""
+
 # Personal votes: the logged-in participant's own votes in a given conversation,
 # keyed by statement tid. Used to show "You: Agreed / Disagreed / Passed" on
 # the results surfaces. Requires the participant's Polis pid.
@@ -585,6 +627,34 @@ class PolisServerClient:
         if rows is None:
             return None
         return int(rows[0][0]) if rows else 0
+
+    def get_statements_remaining_bulk(
+        self,
+        zinvites: list[str],
+        xid: str,
+    ) -> dict[str, int] | None:
+        """Return statements remaining to vote on per conversation for one participant.
+
+        zinvites: list of Polis zinvites (conv.polis_id values).
+        xid: the participant's xid (sha256 of mw_user_id) — used to look up their
+             Polis pid via the xids table without storing pid separately.
+
+        Returns dict[zinvite → n_remaining], or None if Postgres is unavailable.
+        Conversations where the participant has no Polis record return 0.
+        """
+        if not self._db_url or not zinvites or not xid:
+            return None
+        safe = [z for z in zinvites if _SAFE_ZINVITE.match(z or '')]
+        if not safe:
+            return {}
+        rows = self._pg_query(
+            _STATEMENTS_REMAINING_BULK_SQL,
+            (safe, xid),
+            'get_statements_remaining_bulk',
+        )
+        if rows is None:
+            return None
+        return {r[0]: int(r[3]) for r in rows}
 
     def get_personal_votes(
         self,

--- a/v2/polis_admin.py
+++ b/v2/polis_admin.py
@@ -135,7 +135,7 @@ _STATEMENTS_REMAINING_BULK_SQL = """
         SELECT zmap.zinvite, COUNT(c.tid)::int AS n_total
         FROM comments c
         JOIN zmap ON c.zid = zmap.zid
-        WHERE c.active = TRUE AND c.mod >= 0
+        WHERE c.active = TRUE AND c.mod = 1
         GROUP BY zmap.zinvite
     ),
     voted_stmts AS (
@@ -143,6 +143,8 @@ _STATEMENTS_REMAINING_BULK_SQL = """
         FROM votes_latest_unique v
         JOIN zmap ON v.zid = zmap.zid
         JOIN pid_map pm ON pm.zid = v.zid AND pm.pid = v.pid
+        JOIN comments c ON c.zid = zmap.zid AND c.tid = v.tid
+          AND c.active = TRUE AND c.mod = 1
         GROUP BY zmap.zinvite
     )
     SELECT
@@ -640,7 +642,7 @@ class PolisServerClient:
              Polis pid via the xids table without storing pid separately.
 
         Returns dict[zinvite → n_remaining], or None if Postgres is unavailable.
-        Conversations where the participant has no Polis record return 0.
+        Conversations where the participant has no Polis record are absent from the dict.
         """
         if not self._db_url or not zinvites or not xid:
             return None

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -3765,6 +3765,12 @@ a { color: var(--pass); }
   color: #fff;
 }
 
+.home-mode-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-color: var(--accent);
+}
+
 /* ── Conv card: phase-rail variant ────────────────────────────────────────── */
 
 .conv-card--phase .conv-card-left { flex-direction: column; align-items: flex-start; gap: 6px; }

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -3550,38 +3550,32 @@ a { color: var(--pass); }
 .at-complete { margin-bottom: 8px; }
 .at-complete .interlude { margin-top: 1rem; }
 
-/* Collapsed-state chevron — floated to the right of at-head */
-.at-collapse-chevron {
-  align-self: center;
-  flex-shrink: 0;
-  font-size: 11px;
-  color: var(--muted);
-  margin-left: auto;
-  padding-left: 8px;
-}
-
-/* When collapsed: whole at-head is the click target */
-.at-panel--done .at-head {
+/* Revisit bar — collapsed panel summary shown after all-complete */
+.at-revisit-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 10px 14px;
+  background: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: 6px;
+  font-size: 13px;
+  color: #15734a;
+  text-align: left;
   cursor: pointer;
-  user-select: none;
-  border-bottom: none;
+  margin-top: 4px;
 }
-.at-panel--done .at-head:hover { background: var(--surface3); }
+.at-revisit-bar:hover { background: #dcfce7; }
+.at-revisit-bar svg  { flex-shrink: 0; color: #15734a; }
+.at-revisit-bar span:nth-child(2) { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.at-revisit-chevron  { flex-shrink: 0; font-size: 10px; }
 
-/* When collapsed: hide full statement text, steps; show one-line summary */
-.at-panel--done:not(.at-panel--expanded) .at-stmt,
-.at-panel--done:not(.at-panel--expanded) .at-steps { display: none; }
-.at-panel--done:not(.at-panel--expanded) .at-stmt-summary { display: block; }
-
-/* When expanded: show full statement, hide summary */
-.at-panel--done.at-panel--expanded .at-stmt-summary { display: none; }
-
-/* Always hide summary in normal (non-done) state */
-.at-stmt-summary { display: none; }
-
-/* Hide panel body when collapsed after completion; header stays visible */
+/* Hide panel body when collapsed after completion */
+.at-panel--done:not(.at-panel--expanded) .at-head,
 .at-panel--done:not(.at-panel--expanded) .at-cols,
 .at-panel--done:not(.at-panel--expanded) .at-nav { display: none; }
+.at-panel--done:not(.at-panel--expanded) { padding: 0; border: none; box-shadow: none; background: none; }
 
 /* Mobile */
 @media (max-width: 680px) {
@@ -3652,4 +3646,202 @@ a { color: var(--pass); }
 }
 @media (max-width: 560px) {
   .reveal-what { font-size: 11px; }
+}
+
+/* ── Homepage: dev banner ──────────────────────────────────────────────────── */
+
+.home-banner {
+  margin-bottom: 1.25rem;
+  padding: 10px 14px;
+  border: 1px solid var(--hairline);
+  border-radius: 8px;
+  background: var(--surface);
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+.home-banner a { color: var(--pass); }
+
+/* ── Homepage: phase journey legend ───────────────────────────────────────── */
+
+.phase-legend {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  margin-bottom: 1.5rem;
+  padding: 14px 18px;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: 10px;
+  overflow-x: auto;
+}
+
+.phase-legend-node {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.phase-legend-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: var(--surface2);
+  border: 1.5px solid var(--hairline);
+  color: var(--body);
+}
+
+.phase-legend-label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--muted);
+  text-align: center;
+  white-space: nowrap;
+  letter-spacing: 0.02em;
+}
+
+.phase-legend-connector {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 24px;
+  max-width: 56px;
+  padding-bottom: 18px; /* align with icon centre (icon 36px + label ~18px) */
+}
+
+.phase-legend-line {
+  flex: 1;
+  height: 1px;
+  background: var(--hairline);
+}
+
+.phase-legend-mid-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  border: 1.5px dashed var(--hairline);
+  flex-shrink: 0;
+  margin: 0 3px;
+}
+
+/* ── Homepage: mode toggle ─────────────────────────────────────────────────── */
+
+.home-mode-toggle {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 1.25rem;
+}
+
+.home-mode-btn {
+  padding: 6px 14px;
+  border: 1.5px solid var(--hairline);
+  border-radius: 20px;
+  background: var(--surface);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--muted);
+  cursor: pointer;
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
+}
+
+.home-mode-btn:hover {
+  border-color: var(--accent);
+  color: var(--ink);
+}
+
+.home-mode-btn--active {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #fff;
+}
+
+.home-mode-btn--active:hover {
+  background: var(--accent);
+  color: #fff;
+}
+
+/* ── Conv card: phase-rail variant ────────────────────────────────────────── */
+
+.conv-card--phase .conv-card-left { flex-direction: column; align-items: flex-start; gap: 6px; }
+.conv-card-left--col { flex-direction: column; align-items: flex-start; gap: 6px; }
+
+.conv-phase-rail {
+  display: flex;
+  align-items: center;
+  gap: 0;
+}
+
+.conv-phase-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1.5px solid var(--hairline);
+  background: transparent;
+  flex-shrink: 0;
+}
+
+.conv-phase-dot--past {
+  background: var(--hairline);
+  border-color: var(--hairline);
+}
+
+.conv-phase-dot--active {
+  background: var(--accent);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(61, 109, 186, 0.15);
+}
+
+.conv-phase-rail-line {
+  width: 18px;
+  height: 1px;
+  background: var(--hairline);
+  flex-shrink: 0;
+}
+
+.conv-phase-rail-line--done {
+  background: var(--muted);
+  opacity: 0.4;
+}
+
+/* ── Conv card: action chips ───────────────────────────────────────────────── */
+
+.conv-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.conv-chip {
+  display: inline-block;
+  padding: 2px 7px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 500;
+  background: var(--surface2);
+  border: 1px solid var(--hairline);
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.conv-chip--alert {
+  background: rgba(61, 109, 186, 0.07);
+  border-color: rgba(61, 109, 186, 0.3);
+  color: var(--pass);
+}
+
+/* ── Home empty state ──────────────────────────────────────────────────────── */
+
+.home-empty {
+  padding: 24px 0;
+}
+
+.conv-card-badge--muted {
+  background: var(--surface2);
+  color: var(--muted);
+  border-color: var(--hairline);
 }

--- a/v2/static/wiki-polis-flow.svg
+++ b/v2/static/wiki-polis-flow.svg
@@ -1,0 +1,75 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="600" viewBox="0 0 1200 600" role="img" aria-label="How a wiki-polis conversation works">
+<title>How a wiki-polis conversation works</title>
+<desc>Three phases — Explore the questions, Map the arguments, Express informed opinions — each producing data that converges into a more balanced policy draft.</desc>
+<rect x="0.5" y="0.5" width="1199" height="599" rx="18" fill="#fafaf9" stroke="#e5e5e6"></rect>
+<text x="48" y="62" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="30" font-weight="700" letter-spacing="-0.7" fill="#0c0c0e">How a wiki-polis conversation works</text>
+<text x="48" y="94" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="16" fill="#5f5f68">Not a decision exercise — a shared picture of where a community agrees, disagrees, and why.</text>
+<g transform="translate(48,124)">
+  <rect x="0" y="0" width="348" height="326" rx="14" fill="#ffffff" stroke="#e5e5e6"></rect>
+  <text x="22" y="40" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="19" font-weight="700" letter-spacing="-0.4" fill="#0c0c0e">Explore the questions</text>
+  <line x1="22" y1="72" x2="326" y2="72" stroke="#e5e5e6"></line>
+  <g transform="translate(79,84)"><rect x="26" y="14" width="138" height="46" rx="9" fill="#ffffff" stroke="#e5e5e6" stroke-width="1.5"></rect>
+<line x1="42" y1="31" x2="120" y2="31" stroke="#cfcdc6" stroke-width="3.2" stroke-linecap="round"></line>
+<line x1="42" y1="43" x2="96" y2="43" stroke="#cfcdc6" stroke-width="3.2" stroke-linecap="round"></line>
+<g transform="rotate(38 150 44)"><rect x="120" y="38" width="40" height="12" rx="2" fill="#3d6dba"></rect><rect x="116" y="38" width="8" height="12" fill="#b45309"></rect><path d="M160 38 L170 44 L160 50 Z" fill="#0c0c0e"></path></g>
+<g transform="translate(58 78)"><rect width="30" height="30" rx="7" fill="#15734a1f" stroke="#15734a" stroke-width="1.5"></rect><path d="M9 15 L13 19 L21 10" stroke="#15734a" stroke-width="2.6" fill="none" stroke-linecap="round" stroke-linejoin="round"></path></g>
+<g transform="translate(102 78)"><rect width="30" height="30" rx="7" fill="#b23a3a1a" stroke="#b23a3a" stroke-width="1.5"></rect><path d="M10 10 L20 20 M20 10 L10 20" stroke="#b23a3a" stroke-width="2.6" stroke-linecap="round"></path></g></g>
+  <text x="174" y="222" text-anchor="middle" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="12.5" font-style="italic" fill="#5f5f68">Vote yes / no — and edit or add statements</text>
+  <rect x="22" y="240" width="304" height="66" rx="10" fill="#eef3fb" stroke="#c9d6ef"></rect>
+  <text x="38" y="262" font-family="&#39;JetBrains Mono&#39;,monospace" font-size="10.5" font-weight="700" letter-spacing="1.3" fill="#3d6dba">WHAT WE LEARN</text>
+  <g transform="translate(38,270)"><circle cx="9" cy="11" r="3.2" fill="#3d6dba"></circle><circle cx="20" cy="7" r="3.2" fill="#3d6dba"></circle><circle cx="16" cy="19" r="3.2" fill="#3d6dba"></circle><circle cx="28" cy="15" r="3.2" fill="#3d6dba" opacity="0.55"></circle><circle cx="11" cy="25" r="3.2" fill="#3d6dba" opacity="0.55"></circle><circle cx="30" cy="26" r="3.2" fill="#3d6dba" opacity="0.55"></circle></g>
+  <text x="88" y="280" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="13" fill="#3f3f43">Clusters of statements that</text>
+  <text x="88" y="297" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="13" fill="#3f3f43">inform the topic</text></g>
+<g transform="translate(426,124)">
+  <rect x="0" y="0" width="348" height="326" rx="14" fill="#ffffff" stroke="#e5e5e6"></rect>
+  <text x="22" y="40" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="19" font-weight="700" letter-spacing="-0.4" fill="#0c0c0e">Map the arguments</text>
+  <line x1="22" y1="72" x2="326" y2="72" stroke="#e5e5e6"></line>
+  <g transform="translate(79,84)"><rect x="26" y="6" width="138" height="34" rx="8" fill="#ffffff" stroke="#e5e5e6" stroke-width="1.5"></rect>
+<line x1="40" y1="18" x2="118" y2="18" stroke="#cfcdc6" stroke-width="3.2" stroke-linecap="round"></line>
+<line x1="40" y1="28" x2="94" y2="28" stroke="#cfcdc6" stroke-width="3.2" stroke-linecap="round"></line>
+<rect x="30" y="52" width="118" height="24" rx="7" fill="#15734a0f" stroke="#15734a" stroke-width="1.5" stroke-dasharray="4 3"></rect>
+<path d="M40 64 h10 M45 59 v10" stroke="#15734a" stroke-width="2.4" stroke-linecap="round"></path>
+<g transform="rotate(34 150 64)"><rect x="120" y="59" width="30" height="9" rx="1.5" fill="#3d6dba"></rect><rect x="117" y="59" width="6" height="9" fill="#b45309"></rect><path d="M150 59 L158 63.5 L150 68 Z" fill="#0c0c0e"></path></g>
+<rect x="30" y="84" width="118" height="24" rx="7" fill="#f4f4f3" stroke="#5f5f68" stroke-width="1.5" stroke-dasharray="4 3"></rect>
+<path d="M40 96 h10" stroke="#5f5f68" stroke-width="2.4" stroke-linecap="round"></path>
+<g transform="rotate(34 150 96)"><rect x="120" y="91" width="30" height="9" rx="1.5" fill="#3d6dba"></rect><rect x="117" y="91" width="6" height="9" fill="#b45309"></rect><path d="M150 91 L158 95.5 L150 100 Z" fill="#0c0c0e"></path></g></g>
+  <text x="174" y="222" text-anchor="middle" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="12.5" font-style="italic" fill="#5f5f68">Write the pro &amp; con arguments that matter</text>
+  <rect x="22" y="240" width="304" height="66" rx="10" fill="#eef3fb" stroke="#c9d6ef"></rect>
+  <text x="38" y="262" font-family="&#39;JetBrains Mono&#39;,monospace" font-size="10.5" font-weight="700" letter-spacing="1.3" fill="#3d6dba">WHAT WE LEARN</text>
+  <g transform="translate(38,270)"><rect x="4" y="5" width="14" height="10" rx="2.5" fill="#15734a24" stroke="#15734a" stroke-width="1.3"></rect><path d="M8 10 h6 M11 7 v6" stroke="#15734a" stroke-width="1.6" stroke-linecap="round"></path><rect x="22" y="6" width="14" height="8" rx="2.5" fill="#15734a12"></rect><rect x="4" y="20" width="14" height="10" rx="2.5" fill="#f4f4f3" stroke="#5f5f68" stroke-width="1.3"></rect><path d="M8 25 h6" stroke="#5f5f68" stroke-width="1.6" stroke-linecap="round"></path><rect x="22" y="21" width="14" height="8" rx="2.5" fill="#f4f4f3"></rect></g>
+  <text x="88" y="280" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="13" fill="#3f3f43">A map of the arguments that</text>
+  <text x="88" y="297" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="13" fill="#3f3f43">matter, pro &amp; con</text></g>
+<g transform="translate(804,124)">
+  <rect x="0" y="0" width="348" height="326" rx="14" fill="#ffffff" stroke="#e5e5e6"></rect>
+  <text x="22" y="40" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="19" font-weight="700" letter-spacing="-0.4" fill="#0c0c0e">Express informed opinions</text>
+  <line x1="22" y1="72" x2="326" y2="72" stroke="#e5e5e6"></line>
+  <g transform="translate(79,84)"><rect x="26" y="4" width="138" height="30" rx="8" fill="#ffffff" stroke="#e5e5e6" stroke-width="1.5"></rect>
+<line x1="40" y1="14" x2="118" y2="14" stroke="#cfcdc6" stroke-width="3.2" stroke-linecap="round"></line>
+<line x1="40" y1="24" x2="94" y2="24" stroke="#cfcdc6" stroke-width="3.2" stroke-linecap="round"></line>
+<g transform="translate(34 44)"><rect width="56" height="20" rx="6" fill="#15734a1f" stroke="#15734a" stroke-width="1.3"></rect><path d="M12 10 h9 M16.5 5.5 v9" stroke="#15734a" stroke-width="2.2" stroke-linecap="round"></path><line x1="30" y1="10" x2="48" y2="10" stroke="#15734a" stroke-width="2.6" stroke-linecap="round" opacity="0.6"></line></g>
+<g transform="translate(100 44)"><rect width="56" height="20" rx="6" fill="#f4f4f3" stroke="#5f5f68" stroke-width="1.3"></rect><path d="M12 10 h9" stroke="#5f5f68" stroke-width="2.2" stroke-linecap="round"></path><line x1="30" y1="10" x2="48" y2="10" stroke="#5f5f68" stroke-width="2.6" stroke-linecap="round" opacity="0.6"></line></g>
+<g transform="translate(58 78)"><rect width="30" height="30" rx="7" fill="#15734a1f" stroke="#15734a" stroke-width="1.5"></rect><path d="M9 15 L13 19 L21 10" stroke="#15734a" stroke-width="2.6" fill="none" stroke-linecap="round" stroke-linejoin="round"></path></g>
+<g transform="translate(102 78)"><rect width="30" height="30" rx="7" fill="#b23a3a1a" stroke="#b23a3a" stroke-width="1.5"></rect><path d="M10 10 L20 20 M20 10 L10 20" stroke="#b23a3a" stroke-width="2.6" stroke-linecap="round"></path></g></g>
+  <text x="174" y="222" text-anchor="middle" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="12.5" font-style="italic" fill="#5f5f68">Vote again, with the key arguments shown</text>
+  <rect x="22" y="240" width="304" height="66" rx="10" fill="#eef3fb" stroke="#c9d6ef"></rect>
+  <text x="38" y="262" font-family="&#39;JetBrains Mono&#39;,monospace" font-size="10.5" font-weight="700" letter-spacing="1.3" fill="#3d6dba">WHAT WE LEARN</text>
+  <g transform="translate(38,270)"><rect x="5" y="16" width="8" height="14" rx="2" fill="#3d6dba"></rect><rect x="16" y="8" width="8" height="22" rx="2" fill="#3d6dba"></rect><rect x="27" y="20" width="8" height="10" rx="2" fill="#3d6dba" opacity="0.55"></rect></g>
+  <text x="88" y="280" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="13" fill="#3f3f43">How different parts of the</text>
+  <text x="88" y="297" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="13" fill="#3f3f43">community feel</text></g>
+<path d="M405 256 L417 269 L405 282" fill="none" stroke="#5f5f68" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"></path>
+<path d="M783 256 L795 269 L783 282" fill="none" stroke="#5f5f68" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"></path>
+<g stroke="#3d6dba" stroke-width="1.75" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M222 452 C222 478, 600 470, 600 488"></path>
+  <path d="M600 452 L600 488"></path>
+  <path d="M978 452 C978 478, 600 470, 600 488"></path>
+  <path d="M600 488 L600 500"></path>
+  <path d="M594 495 L600 501 L606 495"></path>
+</g>
+<circle cx="600" cy="488" r="2.6" fill="#3d6dba"></circle>
+<rect x="48" y="506" width="1104" height="64" rx="14" fill="#eef3fb" stroke="#c9d6ef"></rect>
+<rect x="68" y="520" width="36" height="36" rx="9" fill="#ffffff" stroke="#c9d6ef"></rect>
+<g transform="translate(75,527)" fill="none" stroke="#3d6dba" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><path d="M14 2v6h6"></path><path d="M9 14l2 2 4-4" stroke="#15734a"></path>
+</g>
+<text x="124" y="544" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="19" font-weight="700" letter-spacing="-0.4" fill="#0c0c0e">A more balanced policy draft</text>
+</svg>

--- a/v2/templates/home.html
+++ b/v2/templates/home.html
@@ -3,14 +3,14 @@
 
 {# ── Phase rail macro: 4 dots showing where this conversation is in the journey ─ #}
 {% macro phase_rail(phases) %}
-{%- set pos = 4 if 'closed' in phases else
-              (3 if ('cleanup_window' in phases or 'informed_voting' in phases) else
+{%- set pos = 4 if ('closed' in phases or 'public_results' in phases) else
+              (3 if ('cleanup_window' in phases or 'informed_voting' in phases or 'cleanup' in phases) else
                (2 if ('argument_mapping' in phases or 'featured_selection' in phases) else
                 (1 if 'submission' in phases else 0))) -%}
 <div class="conv-phase-rail" aria-hidden="true">
   <span class="conv-phase-dot{% if pos == 1 %} conv-phase-dot--active{% elif pos > 1 %} conv-phase-dot--past{% endif %}" title="Explore"></span>
   <span class="conv-phase-rail-line{% if pos > 1 %} conv-phase-rail-line--done{% endif %}"></span>
-  <span class="conv-phase-dot{% if pos == 2 %} conv-phase-dot--active{% elif pos > 2 %} conv-phase-dot--past{% endif %}" title="Arguments"></span>
+  <span class="conv-phase-dot{% if pos == 2 %} conv-phase-dot--active{% elif pos > 2 %} conv-phase-dot--past{% endif %}" title="Featured / Arguments"></span>
   <span class="conv-phase-rail-line{% if pos > 2 %} conv-phase-rail-line--done{% endif %}"></span>
   <span class="conv-phase-dot{% if pos == 3 %} conv-phase-dot--active{% elif pos > 3 %} conv-phase-dot--past{% endif %}" title="Informed vote"></span>
   <span class="conv-phase-rail-line{% if pos > 3 %} conv-phase-rail-line--done{% endif %}"></span>
@@ -20,13 +20,14 @@
 
 {# ── Action chips macro ─────────────────────────────────────────────────────── #}
 {% macro conv_chips(sig) %}
-{%- if sig and sig.statements_remaining is not none and sig.statements_remaining > 0 -%}
-<span class="conv-chip">{{ sig.statements_remaining }} to vote</span>
+{%- if sig and sig.get('statements_remaining') is not none and sig.get('statements_remaining') > 0 -%}
+<span class="conv-chip">{{ sig.get('statements_remaining') }} to vote</span>
 {%- endif -%}
-{%- if sig and sig.reveal and sig.reveal.state == 'open' -%}
-<span class="conv-chip conv-chip--alert">Reveal window: {{ sig.reveal.days_left }}d left</span>
-{%- elif sig and sig.reveal and sig.reveal.state == 'pending' -%}
-<span class="conv-chip">Reveal opens in {{ sig.reveal.days_left }}d</span>
+{%- if sig and sig.get('reveal') and sig.get('reveal').state == 'open' -%}
+{%- set dl = sig.get('reveal').days_left -%}
+<span class="conv-chip conv-chip--alert"><span aria-hidden="true">! </span>Reveal window: {{ 'today' if dl <= 0 else (dl|string + 'd left') }}</span>
+{%- elif sig and sig.get('reveal') and sig.get('reveal').state == 'pending' -%}
+<span class="conv-chip">Reveal opens in {{ sig.get('reveal').days_left }}d</span>
 {%- endif -%}
 {% endmacro %}
 
@@ -102,7 +103,7 @@
   <h1 class="sr-only">Your consultations</h1>
 
   {# ── Phase journey legend ──────────────────────────────────────────────── #}
-  <div class="phase-legend" aria-label="Consultation phases overview">
+  <div class="phase-legend" role="img" aria-label="Consultation phases: Explore, Arguments, Informed vote, Report">
     <div class="phase-legend-node">
       <span class="phase-legend-icon" aria-hidden="true">
         {# Explore: two horizontal bars + checkmark #}
@@ -112,7 +113,7 @@
           <polyline points="12,9 14,12.5 17,5.5"/>
         </svg>
       </span>
-      <span class="phase-legend-label">Explore</span>
+      <span class="phase-legend-label" aria-hidden="true">Explore</span>
     </div>
     <div class="phase-legend-connector" aria-hidden="true">
       <span class="phase-legend-line"></span>
@@ -130,7 +131,7 @@
           <path d="M14,6 L12,9.5 Q14,13 16,9.5 Z"/>
         </svg>
       </span>
-      <span class="phase-legend-label">Arguments</span>
+      <span class="phase-legend-label" aria-hidden="true">Arguments</span>
     </div>
     <div class="phase-legend-connector" aria-hidden="true">
       <span class="phase-legend-line"></span>
@@ -150,7 +151,7 @@
           <path d="M15,6 L14,8 Q15,10 16,8 Z"/>
         </svg>
       </span>
-      <span class="phase-legend-label">Informed vote</span>
+      <span class="phase-legend-label" aria-hidden="true">Informed vote</span>
     </div>
     <div class="phase-legend-connector" aria-hidden="true">
       <span class="phase-legend-line"></span>
@@ -167,16 +168,14 @@
           <line x1="6" y1="12" x2="10" y2="12"/>
         </svg>
       </span>
-      <span class="phase-legend-label">Report</span>
+      <span class="phase-legend-label" aria-hidden="true">Report</span>
     </div>
   </div>
 
   {# ── Mode toggle ───────────────────────────────────────────────────────── #}
-  {% set has_yours = active_joined or archived_joined %}
-  {% set has_browse = available %}
   <div class="home-mode-toggle" role="group" aria-label="View mode">
-    <button class="home-mode-btn" data-target="yours" type="button">Your conversations</button>
-    <button class="home-mode-btn" data-target="browse" type="button">Browse</button>
+    <button class="home-mode-btn" data-target="yours" type="button" aria-pressed="true">Your conversations</button>
+    <button class="home-mode-btn" data-target="browse" type="button" aria-pressed="false">Browse</button>
   </div>
 
   {# ── Your conversations ────────────────────────────────────────────────── #}
@@ -256,7 +255,7 @@
   </div>{# /home-yours #}
 
   {# ── Browse ────────────────────────────────────────────────────────────── #}
-  <div id="home-browse">
+  <div id="home-browse" hidden>
 
     {% if available %}
     <section aria-labelledby="sec-available">
@@ -329,19 +328,26 @@
 {% if username %}
 <script nonce="{{ csp_nonce }}">
 (function () {
-  var btns     = document.querySelectorAll('.home-mode-btn');
-  var yours    = document.getElementById('home-yours');
-  var browse   = document.getElementById('home-browse');
-  var stored   = localStorage.getItem('home-mode') || 'yours';
+  var MODES = ['yours', 'browse'];
+  var btns   = document.querySelectorAll('.home-mode-btn');
+  var yours  = document.getElementById('home-yours');
+  var browse = document.getElementById('home-browse');
+
+  function lsGet(key) { try { return localStorage.getItem(key); } catch (e) { return null; } }
+  function lsSet(key, val) { try { localStorage.setItem(key, val); } catch (e) {} }
+
+  var raw    = lsGet('home-mode');
+  var stored = MODES.includes(raw) ? raw : 'yours';
 
   function setMode(m) {
-    localStorage.setItem('home-mode', m);
+    if (m !== stored || !yours) lsSet('home-mode', m);
+    stored = m;
     btns.forEach(function (b) {
       b.classList.toggle('home-mode-btn--active', b.dataset.target === m);
       b.setAttribute('aria-pressed', b.dataset.target === m ? 'true' : 'false');
     });
-    yours.hidden  = m !== 'yours';
-    browse.hidden = m !== 'browse';
+    if (yours)  yours.hidden  = m !== 'yours';
+    if (browse) browse.hidden = m !== 'browse';
   }
 
   btns.forEach(function (b) {

--- a/v2/templates/home.html
+++ b/v2/templates/home.html
@@ -102,6 +102,11 @@
 
   <h1 class="sr-only">Your consultations</h1>
 
+  {# ── Flow diagram ─────────────────────────────────────────────────────── #}
+  <img src="{{ url_for('static', filename='wiki-polis-flow.svg') }}"
+       alt="How a wiki-polis conversation works"
+       style="width:100%;max-width:900px;display:block;margin:0 auto 1.5rem">
+
   {# ── Phase journey legend ──────────────────────────────────────────────── #}
   <div class="phase-legend" role="img" aria-label="Consultation phases: Explore, Arguments, Informed vote, Report">
     <div class="phase-legend-node">

--- a/v2/templates/home.html
+++ b/v2/templates/home.html
@@ -1,15 +1,46 @@
 {% extends "base.html" %}
 {% block content %}
 
+{# ── Phase rail macro: 4 dots showing where this conversation is in the journey ─ #}
+{% macro phase_rail(phases) %}
+{%- set pos = 4 if 'closed' in phases else
+              (3 if ('cleanup_window' in phases or 'informed_voting' in phases) else
+               (2 if ('argument_mapping' in phases or 'featured_selection' in phases) else
+                (1 if 'submission' in phases else 0))) -%}
+<div class="conv-phase-rail" aria-hidden="true">
+  <span class="conv-phase-dot{% if pos == 1 %} conv-phase-dot--active{% elif pos > 1 %} conv-phase-dot--past{% endif %}" title="Explore"></span>
+  <span class="conv-phase-rail-line{% if pos > 1 %} conv-phase-rail-line--done{% endif %}"></span>
+  <span class="conv-phase-dot{% if pos == 2 %} conv-phase-dot--active{% elif pos > 2 %} conv-phase-dot--past{% endif %}" title="Arguments"></span>
+  <span class="conv-phase-rail-line{% if pos > 2 %} conv-phase-rail-line--done{% endif %}"></span>
+  <span class="conv-phase-dot{% if pos == 3 %} conv-phase-dot--active{% elif pos > 3 %} conv-phase-dot--past{% endif %}" title="Informed vote"></span>
+  <span class="conv-phase-rail-line{% if pos > 3 %} conv-phase-rail-line--done{% endif %}"></span>
+  <span class="conv-phase-dot{% if pos == 4 %} conv-phase-dot--active{% endif %}" title="Report"></span>
+</div>
+{% endmacro %}
+
+{# ── Action chips macro ─────────────────────────────────────────────────────── #}
+{% macro conv_chips(sig) %}
+{%- if sig and sig.statements_remaining is not none and sig.statements_remaining > 0 -%}
+<span class="conv-chip">{{ sig.statements_remaining }} to vote</span>
+{%- endif -%}
+{%- if sig and sig.reveal and sig.reveal.state == 'open' -%}
+<span class="conv-chip conv-chip--alert">Reveal window: {{ sig.reveal.days_left }}d left</span>
+{%- elif sig and sig.reveal and sig.reveal.state == 'pending' -%}
+<span class="conv-chip">Reveal opens in {{ sig.reveal.days_left }}d</span>
+{%- endif -%}
+{% endmacro %}
+
 <div class="container home-container">
 
-  <div style="margin-bottom:1.25rem;padding:10px 14px;border:1px solid var(--hairline);border-radius:8px;background:var(--surface);font-size:13px;color:var(--muted);line-height:1.6">
+  <div class="home-banner">
     Prototype in active development — things may change.
     <a href="https://github.com/lgelauff/wiki-polis/issues/new"
-       target="_blank" rel="noopener" style="color:var(--pass)">Open an issue<span class="sr-only"> (opens in a new tab)</span></a> if you find a bug.
+       target="_blank" rel="noopener">Open an issue<span class="sr-only"> (opens in a new tab)</span></a> if you find a bug.
   </div>
 
 {% if not username %}
+
+  {# ── Unauthenticated landing ───────────────────────────────────────────── #}
 
   <div class="landing-section">
     <h1 style="font-size:26px;font-weight:600;letter-spacing:-0.02em;line-height:1.15;margin-bottom:12px">Where the community actually stands.</h1>
@@ -66,109 +97,208 @@
 
 {% else %}
 
+  {# ── Authenticated view ────────────────────────────────────────────────── #}
+
   <h1 class="sr-only">Your consultations</h1>
 
-  {% if active_joined %}
-  <section aria-labelledby="sec-active">
-    <div class="home-section">
-      <div class="home-section-header">
-        <h2 class="home-section-label" id="sec-active">Active</h2>
-        <span class="home-section-count" aria-hidden="true">{{ active_joined | length }} consultation{{ 's' if active_joined | length != 1 }}</span>
-      </div>
-      <ul class="conv-list">
-        {% for c in active_joined %}
-        {% set part = pseudonym_map.get(c.id) %}
-        <li>
-          <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card"
-             aria-label="{{ c.title }}{% if part and part.pseudonym %} — your pseudonym: {{ part.pseudonym }}{% endif %} — {{ 'temporarily paused' if c.paused else 'voting open' }} — continue">
-            <div class="conv-card-left">
-              <span class="conv-dot conv-dot--active" aria-hidden="true"></span>
-              <div class="conv-card-info">
+  {# ── Phase journey legend ──────────────────────────────────────────────── #}
+  <div class="phase-legend" aria-label="Consultation phases overview">
+    <div class="phase-legend-node">
+      <span class="phase-legend-icon" aria-hidden="true">
+        {# Explore: two horizontal bars + checkmark #}
+        <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="2" y1="7" x2="11" y2="7"/>
+          <line x1="2" y1="11" x2="11" y2="11"/>
+          <polyline points="12,9 14,12.5 17,5.5"/>
+        </svg>
+      </span>
+      <span class="phase-legend-label">Explore</span>
+    </div>
+    <div class="phase-legend-connector" aria-hidden="true">
+      <span class="phase-legend-line"></span>
+      <span class="phase-legend-mid-dot"></span>
+      <span class="phase-legend-line"></span>
+    </div>
+    <div class="phase-legend-node">
+      <span class="phase-legend-icon" aria-hidden="true">
+        {# Arguments: scales / balance #}
+        <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="9" y1="2" x2="9" y2="16"/>
+          <line x1="3" y1="16" x2="15" y2="16"/>
+          <line x1="4" y1="6" x2="14" y2="6"/>
+          <path d="M4,6 L2,9.5 Q4,13 6,9.5 Z"/>
+          <path d="M14,6 L12,9.5 Q14,13 16,9.5 Z"/>
+        </svg>
+      </span>
+      <span class="phase-legend-label">Arguments</span>
+    </div>
+    <div class="phase-legend-connector" aria-hidden="true">
+      <span class="phase-legend-line"></span>
+      <span class="phase-legend-mid-dot"></span>
+      <span class="phase-legend-line"></span>
+    </div>
+    <div class="phase-legend-node">
+      <span class="phase-legend-icon" aria-hidden="true">
+        {# Informed vote: two bars + small scales #}
+        <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="2" y1="7" x2="9" y2="7"/>
+          <line x1="2" y1="11" x2="9" y2="11"/>
+          <line x1="13" y1="3" x2="13" y2="15"/>
+          <line x1="10" y1="15" x2="16" y2="15"/>
+          <line x1="11" y1="6" x2="15" y2="6"/>
+          <path d="M11,6 L10,8 Q11,10 12,8 Z"/>
+          <path d="M15,6 L14,8 Q15,10 16,8 Z"/>
+        </svg>
+      </span>
+      <span class="phase-legend-label">Informed vote</span>
+    </div>
+    <div class="phase-legend-connector" aria-hidden="true">
+      <span class="phase-legend-line"></span>
+      <span class="phase-legend-mid-dot"></span>
+      <span class="phase-legend-line"></span>
+    </div>
+    <div class="phase-legend-node">
+      <span class="phase-legend-icon" aria-hidden="true">
+        {# Report: document with lines #}
+        <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <rect x="3" y="1" width="12" height="16" rx="1.5"/>
+          <line x1="6" y1="6" x2="12" y2="6"/>
+          <line x1="6" y1="9" x2="12" y2="9"/>
+          <line x1="6" y1="12" x2="10" y2="12"/>
+        </svg>
+      </span>
+      <span class="phase-legend-label">Report</span>
+    </div>
+  </div>
+
+  {# ── Mode toggle ───────────────────────────────────────────────────────── #}
+  {% set has_yours = active_joined or archived_joined %}
+  {% set has_browse = available %}
+  <div class="home-mode-toggle" role="group" aria-label="View mode">
+    <button class="home-mode-btn" data-target="yours" type="button">Your conversations</button>
+    <button class="home-mode-btn" data-target="browse" type="button">Browse</button>
+  </div>
+
+  {# ── Your conversations ────────────────────────────────────────────────── #}
+  <div id="home-yours">
+
+    {% if active_joined %}
+    <section aria-labelledby="sec-active">
+      <div class="home-section">
+        <div class="home-section-header">
+          <h2 class="home-section-label" id="sec-active">Active</h2>
+          <span class="home-section-count" aria-hidden="true">{{ active_joined | length }}</span>
+        </div>
+        <ul class="conv-list">
+          {% for c in active_joined %}
+          {% set part = pseudonym_map.get(c.id) %}
+          {% set sig  = signals_map.get(c.id, {}) %}
+          <li>
+            <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card conv-card--phase"
+               aria-label="{{ c.title }}{% if part and part.pseudonym %} — your pseudonym: {{ part.pseudonym }}{% endif %}{% if sig.statements_remaining %} — {{ sig.statements_remaining }} statements to vote{% endif %} — continue">
+              <div class="conv-card-left conv-card-left--col">
                 <div class="conv-card-title-row">
                   <h3 class="conv-card-title">{{ c.title }}</h3>
                   {% if part and part.pseudonym %}<span class="conv-card-badge" aria-hidden="true">{{ part.pseudonym }}</span>{% endif %}
                 </div>
-                <div class="conv-card-sub">
-                  {%- if c.paused -%}temporarily paused{%- else -%}voting open{%- endif -%}
-                </div>
+                {{ phase_rail(sig.phases if sig.phases is defined else set()) }}
+                {% set chips = conv_chips(sig) %}
+                {% if chips.strip() %}<div class="conv-chips">{{ chips }}</div>{% endif %}
               </div>
-            </div>
-            <span class="conv-card-action" aria-hidden="true">CONTINUE →</span>
-          </a>
-        </li>
-        {% endfor %}
-      </ul>
-    </div>
-  </section>
-  {% endif %}
-
-  {% if available %}
-  <section aria-labelledby="sec-available">
-    <div class="home-section">
-      <div class="home-section-header">
-        <h2 class="home-section-label" id="sec-available">Open to you</h2>
-        <span class="home-section-count" aria-hidden="true">{{ available | length }} consultation{{ 's' if available | length != 1 }}</span>
+              <span class="conv-card-action" aria-hidden="true">CONTINUE →</span>
+            </a>
+          </li>
+          {% endfor %}
+        </ul>
       </div>
-      <ul class="conv-list">
-        {% for c in available %}
-        <li>
-          <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card"
-             aria-label="{{ c.title }} — join consultation">
-            <div class="conv-card-left">
-              <span class="conv-dot conv-dot--available" aria-hidden="true"></span>
-              <div class="conv-card-info">
-                <h3 class="conv-card-title">{{ c.title }}</h3>
-              </div>
-            </div>
-            <span class="conv-card-action" aria-hidden="true">JOIN →</span>
-          </a>
-        </li>
-        {% endfor %}
-      </ul>
-    </div>
-  </section>
-  {% endif %}
+    </section>
+    {% endif %}
 
-  {% if archived_joined %}
-  <section aria-labelledby="sec-closed">
-    <div class="home-section">
-      <div class="home-section-header">
-        <h2 class="home-section-label" id="sec-closed">Closed</h2>
-        <span class="home-section-count" aria-hidden="true">{{ archived_joined | length }} consultation{{ 's' if archived_joined | length != 1 }}</span>
-      </div>
-      <ul class="conv-list">
-        {% for c in archived_joined %}
-        {% set part = pseudonym_map.get(c.id) %}
-        <li>
-          <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card"
-             aria-label="{{ c.title }}{% if part and part.pseudonym %} — your pseudonym: {{ part.pseudonym }}{% endif %} — closed{% if c.closed_at %} {{ c.closed_at.strftime('%B %Y') }}{% endif %}">
-            <div class="conv-card-left">
-              <span class="conv-dot conv-dot--closed" aria-hidden="true"></span>
-              <div class="conv-card-info">
+    {% if archived_joined %}
+    <section aria-labelledby="sec-closed">
+      <div class="home-section">
+        <div class="home-section-header">
+          <h2 class="home-section-label" id="sec-closed">Closed</h2>
+          <span class="home-section-count" aria-hidden="true">{{ archived_joined | length }}</span>
+        </div>
+        <ul class="conv-list">
+          {% for c in archived_joined %}
+          {% set part = pseudonym_map.get(c.id) %}
+          {% set sig  = signals_map.get(c.id, {}) %}
+          <li>
+            <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card conv-card--phase"
+               aria-label="{{ c.title }}{% if part and part.pseudonym %} — pseudonym: {{ part.pseudonym }}{% endif %} — closed{% if c.closed_at %} {{ c.closed_at.strftime('%B %Y') }}{% endif %}">
+              <div class="conv-card-left conv-card-left--col">
                 <div class="conv-card-title-row">
                   <h3 class="conv-card-title">{{ c.title }}</h3>
                   {% if part and part.pseudonym %}<span class="conv-card-badge" aria-hidden="true">{{ part.pseudonym }}</span>{% endif %}
+                  {% if c.closed_at %}<span class="conv-card-badge conv-card-badge--muted" aria-hidden="true">{{ c.closed_at.strftime('%b %Y') }}</span>{% endif %}
                 </div>
-                {% if c.closed_at %}
-                <div class="conv-card-sub">closed {{ c.closed_at.strftime('%b %Y') }}</div>
-                {% endif %}
+                {{ phase_rail(sig.phases if sig.phases is defined else set()) }}
+                {% set chips = conv_chips(sig) %}
+                {% if chips.strip() %}<div class="conv-chips">{{ chips }}</div>{% endif %}
               </div>
-            </div>
-            <span class="conv-card-action" aria-hidden="true">VIEW →</span>
-          </a>
-        </li>
-        {% endfor %}
-      </ul>
-    </div>
-  </section>
-  {% endif %}
+              <span class="conv-card-action conv-card-action--muted" aria-hidden="true">VIEW →</span>
+            </a>
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </section>
+    {% endif %}
 
+    {% if not active_joined and not archived_joined %}
+    <div class="home-empty">
+      <p class="muted">You haven't joined any consultations yet. Use Browse to find one.</p>
+    </div>
+    {% endif %}
+
+  </div>{# /home-yours #}
+
+  {# ── Browse ────────────────────────────────────────────────────────────── #}
+  <div id="home-browse">
+
+    {% if available %}
+    <section aria-labelledby="sec-available">
+      <div class="home-section">
+        <div class="home-section-header">
+          <h2 class="home-section-label" id="sec-available">Open to you</h2>
+          <span class="home-section-count" aria-hidden="true">{{ available | length }}</span>
+        </div>
+        <ul class="conv-list">
+          {% for c in available %}
+          {% set sig = signals_map.get(c.id, {}) %}
+          <li>
+            <a href="{{ url_for('participant.conversation', slug=c.slug) }}" class="conv-card conv-card--phase"
+               aria-label="{{ c.title }} — join consultation">
+              <div class="conv-card-left conv-card-left--col">
+                <div class="conv-card-title-row">
+                  <h3 class="conv-card-title">{{ c.title }}</h3>
+                </div>
+                {{ phase_rail(sig.phases if sig.phases is defined else set()) }}
+              </div>
+              <span class="conv-card-action" aria-hidden="true">JOIN →</span>
+            </a>
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </section>
+    {% else %}
+    <div class="home-empty">
+      <p class="muted">No consultations open to you right now.</p>
+    </div>
+    {% endif %}
+
+  </div>{# /home-browse #}
+
+  {# ── You moderate (admin/moderator view — always visible) ─────────────── #}
   {% if moderating %}
   <section aria-labelledby="sec-moderate">
     <div class="home-section">
       <div class="home-section-header">
         <h2 class="home-section-label" id="sec-moderate">You moderate</h2>
-        <span class="home-section-count" aria-hidden="true">{{ moderating | length }} consultation{{ 's' if moderating | length != 1 }}</span>
+        <span class="home-section-count" aria-hidden="true">{{ moderating | length }}</span>
       </div>
       <ul class="conv-list">
         {% for c in moderating %}
@@ -181,7 +311,6 @@
               {% if not c.active %}<span class="conv-card-badge">closed</span>{% endif %}
             </div>
             <span class="conv-card-divider" aria-hidden="true"></span>
-            {# → aria-hidden on "Admin →" not needed — the aria-label overrides the text content #}
             <a href="{{ url_for('admin.admin_conversation_detail', conv_id=c.id) }}"
                class="admin-action-btn"
                aria-label="Open admin panel for {{ c.title }}">Admin →</a>
@@ -193,14 +322,35 @@
   </section>
   {% endif %}
 
-  {% if not active_joined and not available and not archived_joined and not moderating %}
-  <div class="landing-section">
-    <p class="muted">No consultations available at the moment. Check back later.</p>
-  </div>
-  {% endif %}
+{% endif %}{# /username #}
 
+</div>{# /container #}
+
+{% if username %}
+<script nonce="{{ csp_nonce }}">
+(function () {
+  var btns     = document.querySelectorAll('.home-mode-btn');
+  var yours    = document.getElementById('home-yours');
+  var browse   = document.getElementById('home-browse');
+  var stored   = localStorage.getItem('home-mode') || 'yours';
+
+  function setMode(m) {
+    localStorage.setItem('home-mode', m);
+    btns.forEach(function (b) {
+      b.classList.toggle('home-mode-btn--active', b.dataset.target === m);
+      b.setAttribute('aria-pressed', b.dataset.target === m ? 'true' : 'false');
+    });
+    yours.hidden  = m !== 'yours';
+    browse.hidden = m !== 'browse';
+  }
+
+  btns.forEach(function (b) {
+    b.addEventListener('click', function () { setMode(b.dataset.target); });
+  });
+
+  setMode(stored);
+}());
+</script>
 {% endif %}
-
-</div>
 
 {% endblock %}


### PR DESCRIPTION
## Summary

- **Phase journey legend** — static strip at the top of the authenticated home page: `[Explore] -o- [Arguments] -o- [Informed vote] -o- [Report]` with SVG icons (bars+checkmark, scales, bars+scales, document). Explanatory only; not repeated per tile.
- **Mode toggle** — "Your conversations" / "Browse" pill buttons; selection persisted in `localStorage`. Your conversations = active + archived joined; Browse = available to join.
- **Per-tile phase rail** — 4 dots per conversation card showing past (filled muted) / active (accent + glow) / future (empty) phase position, derived from `_active_phases()`.
- **Action chips** — statements remaining to vote (live Polis Postgres query) and reveal window countdown, shown inline on tiles when actionable.

## Data layer

- `_active_phases(conv) → set` — returns all currently-active phase keys including inferred `cleanup_window` and `closed`.
- `get_statements_remaining_bulk(zinvites, xid)` — single Postgres query across all conversations; resolves participant via `xids.xid → participants.pid` (no new schema migration needed).
- `signals_map` built in `index()` and passed to `home.html`.

## Test plan

- [x] 324 tests pass (1 pre-existing failure on `test_no_warning_when_pg_not_configured`, unrelated)
- [x] Phase legend renders with all 4 icons
- [x] Mode toggle switches sections; Browse shows empty state when no available conversations
- [x] Phase rail shows active dot on correct position (verified against Cats vs Dogs in informed-vote phase)
- [x] `localStorage` persistence: reload preserves selected mode
- [ ] Verify on staging with a real Polis backend that `statements_remaining` chip shows a count

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)