### PR TITLE
ci: GitHub Actions — pytest + inline-JS gate + ruff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
 
       - name: Set up Node (for the inline-JS syntax gate)
         uses: actions/setup-node@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,13 @@ jobs:
       run:
         working-directory: v2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
 
       - name: Set up Node (for the inline-JS syntax gate)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: v2
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Node (for the inline-JS syntax gate)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Lint (ruff — pyflakes; catches undefined names / unused)
+        run: uvx ruff check .
+
+      - name: Tests + inline-template-JS syntax gate
+        # No .env in CI, and app.py instantiates the app at import, so the
+        # production startup checks need these supplied. FLASK_DEBUG=1 bypasses
+        # the web-server-only guards; the security tests override it per-test.
+        env:
+          DATABASE_URL: "sqlite:///:memory:"
+          SECRET_KEY: "0000000000000000000000000000000000000000"
+          FLASK_DEBUG: "1"
+        run: uv run pytest -q

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Set up Node (for the inline-JS syntax gate)
         uses: actions/setup-node@v5

--- a/v2/app.py
+++ b/v2/app.py
@@ -209,7 +209,7 @@ def _build_phase6_results(
             current_app.config['PARTICIAPI_BASE']
         ).get_results(p6_zinvite)
     except Exception:
-        logger.exception('Particiapi get_results failed for Phase 6 zinvite %s', p6_zinvite)
+        current_app.logger.exception('Particiapi get_results failed for Phase 6 zinvite %s', p6_zinvite)
 
     clusters = None
     source_divergence = None
@@ -226,7 +226,7 @@ def _build_phase6_results(
         if pa_n and p6_total_participants:
             source_divergence = abs(pa_n - p6_total_participants) / max(p6_total_participants, 1)
             if source_divergence > 0.05:
-                logger.warning(
+                current_app.logger.warning(
                     'Phase 6 source divergence %.1f%% for conv %s '
                     '(PG=%d, Particiapi=%d) — may indicate moderation sync lag',
                     source_divergence * 100, conv.slug, p6_total_participants, pa_n,

--- a/v2/pyproject.toml
+++ b/v2/pyproject.toml
@@ -45,3 +45,12 @@ packages = []
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["."]
+
+[tool.ruff.lint]
+# Start with pyflakes (real errors: undefined names, unused imports/vars) —
+# this is what caught the undefined `logger` bug. Tighten to E/W (style) later.
+select = ["F"]
+
+[tool.ruff.lint.per-file-ignores]
+# Unused test imports/locals are low-value noise; clean up opportunistically.
+"tests/*" = ["F401", "F841"]

--- a/v2/simulate_cats_vs_dogs.py
+++ b/v2/simulate_cats_vs_dogs.py
@@ -246,9 +246,9 @@ def create_polis_conversation(topic: str, description: str) -> str:
     """Insert a new conversation directly into Polis PostgreSQL. Returns zinvite."""
     zinvite = ''.join(random.choices(string.ascii_lowercase + string.digits, k=10))
     zid = psql(
-        f"INSERT INTO conversations "
-        f"(topic, description, owner, is_active, is_public, write_type, vis_type) "
-        f"VALUES ($$%s$$, $$%s$$, 1, true, true, 1, 1) RETURNING zid;" % (topic, description)
+        "INSERT INTO conversations "
+        "(topic, description, owner, is_active, is_public, write_type, vis_type) "
+        "VALUES ($$%s$$, $$%s$$, 1, true, true, 1, 1) RETURNING zid;" % (topic, description)
     )
     psql(f"INSERT INTO zinvites (zid, zinvite) VALUES ({zid}, '{zinvite}');")
     return zinvite
@@ -430,10 +430,10 @@ def run_simulation(conv_id: str) -> None:
           + f", {len(pool)} statements total")
 
     print(f"\n{'=' * 62}")
-    print(f"Simulation complete.")
+    print("Simulation complete.")
     print(f"  Polis conversation: {conv_id}")
     print(f"  Particiapi results: {PARTICIAPI}/api/conversations/{conv_id}/results/")
-    print(f"  (Polis math runs in the background — typically 30–60 s)")
+    print("  (Polis math runs in the background — typically 30–60 s)")
 
     # Build text → tid mapping for the caller (used by seed_featured_statements).
     text_to_tid = {}

--- a/v2/tests/test_conversations.py
+++ b/v2/tests/test_conversations.py
@@ -222,12 +222,14 @@ def test_empty_results_triggers_recompute_and_shows_computing_message(
     recompute_called = []
     monkeypatch.setattr(polis_admin.PolisServerClient, 'queue_math_recompute',
                         lambda self, zinvite: recompute_called.append(zinvite) or True)
-    # Reset rate-limit state so the trigger fires.
-    monkeypatch.setitem(app_module._math_recompute_last, conv.id, 0)
-    # Hermetic: the trigger is also gated on POLIS_DATABASE_URL being configured
-    # (app.py polis_pg_configured). Set it explicitly instead of relying on ambient
-    # config/.env — otherwise this passes locally but fails in CI's collection order.
-    auth_client.application.config['POLIS_DATABASE_URL'] = 'postgresql://ci/test'
+    # Reset rate-limit state so the trigger fires. The gate is
+    # `time.monotonic() - _last > _MATH_RECOMPUTE_COOLDOWN`, so _last must be set
+    # to the PAST relative to now — not 0. On a freshly-booted CI runner
+    # monotonic() is near 0, so `now - 0` is < cooldown and the trigger wouldn't
+    # fire (passed locally, where monotonic() is large, but failed in CI).
+    import time
+    monkeypatch.setitem(app_module._math_recompute_last, conv.id,
+                        time.monotonic() - app_module._MATH_RECOMPUTE_COOLDOWN - 1)
 
     resp = auth_client.get('/c/test-conv')
     assert resp.status_code == 200

--- a/v2/tests/test_conversations.py
+++ b/v2/tests/test_conversations.py
@@ -224,6 +224,10 @@ def test_empty_results_triggers_recompute_and_shows_computing_message(
                         lambda self, zinvite: recompute_called.append(zinvite) or True)
     # Reset rate-limit state so the trigger fires.
     monkeypatch.setitem(app_module._math_recompute_last, conv.id, 0)
+    # Hermetic: the trigger is also gated on POLIS_DATABASE_URL being configured
+    # (app.py polis_pg_configured). Set it explicitly instead of relying on ambient
+    # config/.env — otherwise this passes locally but fails in CI's collection order.
+    auth_client.application.config['POLIS_DATABASE_URL'] = 'postgresql://ci/test'
 
     resp = auth_client.get('/c/test-conv')
     assert resp.status_code == 200

--- a/v2/tests/test_inline_js.py
+++ b/v2/tests/test_inline_js.py
@@ -1,0 +1,58 @@
+"""Inline-<script> JS syntax gate — rides the pytest job in CI.
+
+Vendored from the agent-tooling toolkit's scripts/check_inline_js.py (canonical:
+github.com/lgelauff/wikimedia-coding-agent-lessons). Catches the dead-<script>
+class — e.g. a smart/curly quote used as a JS string delimiter — that renders
+fine and passes every server-side test but never executes in the browser (the
+PR #174 arguments-tab blocker). Skips if `node` is absent locally; CI installs it.
+"""
+import glob
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+TEMPLATES = os.path.join(os.path.dirname(__file__), os.pardir, "templates")
+_SCRIPT = re.compile(r"<script\b([^>]*)>(.*?)</script>", re.DOTALL | re.IGNORECASE)
+
+
+def _is_js(attrs):
+    if re.search(r"\bsrc\s*=", attrs, re.IGNORECASE):
+        return False
+    m = re.search(r'type\s*=\s*["\']([^"\']*)["\']', attrs, re.IGNORECASE)
+    if m:
+        return m.group(1).lower() in ("", "text/javascript", "module", "application/javascript")
+    return True
+
+
+def _strip_jinja(s):
+    s = re.sub(r"\{#.*?#\}", "", s, flags=re.DOTALL)
+    s = re.sub(r"\{%.*?%\}", "", s, flags=re.DOTALL)
+    return re.sub(r"\{\{.*?\}\}", "0", s, flags=re.DOTALL)
+
+
+def _scripts(html):
+    for m in _SCRIPT.finditer(html):
+        if m.group(2).strip() and _is_js(m.group(1)):
+            yield html.count("\n", 0, m.start(2)) + 1, m.group(2)
+
+
+@pytest.mark.skipif(not shutil.which("node"), reason="node not available")
+@pytest.mark.parametrize("path", sorted(glob.glob(os.path.join(TEMPLATES, "*.html"))))
+def test_inline_js_parses(path):
+    html = open(path, encoding="utf-8").read()
+    for line, body in _scripts(html):
+        with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as fh:
+            fh.write(_strip_jinja(body))
+            tmp = fh.name
+        try:
+            r = subprocess.run(["node", "--check", tmp],
+                               capture_output=True, text=True, timeout=30)
+        finally:
+            os.unlink(tmp)
+        msg = (r.stderr.strip().splitlines() or ["parse error"])[0] if r.returncode else ""
+        assert r.returncode == 0, \
+            f"{os.path.basename(path)} <script> at line {line}: {msg}"


### PR DESCRIPTION
First CI for wiki-polis. One backend-free job (~2 min) on PRs + pushes to `main`:

- **ruff** (pyflakes `F`) — undefined names / unused. This is what surfaced the undefined `logger` bug, **fixed here on main** too (`app.py:212/229` → `current_app.logger`; it was a live NameError on the Phase-6 error paths). Tests ignore `F401/F841`; tighten to `E/W` later.
- **pytest** (343 tests) with the CI env (no `.env` in CI; the app instantiates at import).
- **inline-template-JS syntax gate** (`tests/test_inline_js.py`, `node --check`) — catches the dead-`<script>` class (the #174 smart-quote blocker) that renders + passes server tests but never runs in the browser. Skips if node absent; CI installs it. Vendored from the agent-tooling toolkit.

Also auto-fixed 5 redundant f-strings (F541) so ruff starts green. Validated locally: `343 passed` via the exact CI command, ruff clean, all templates parse.

**After merge:** enable branch protection on `main` requiring the `test` check (merge-blocking).