### PR TITLE
fix(phase6): logger NameError + reveal state names in admin

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -209,7 +209,7 @@ def _build_phase6_results(
             current_app.config['PARTICIAPI_BASE']
         ).get_results(p6_zinvite)
     except Exception:
-        logger.exception('Particiapi get_results failed for Phase 6 zinvite %s', p6_zinvite)
+        current_app.logger.exception('Particiapi get_results failed for Phase 6 zinvite %s', p6_zinvite)
 
     clusters = None
     source_divergence = None
@@ -226,7 +226,7 @@ def _build_phase6_results(
         if pa_n and p6_total_participants:
             source_divergence = abs(pa_n - p6_total_participants) / max(p6_total_participants, 1)
             if source_divergence > 0.05:
-                logger.warning(
+                current_app.logger.warning(
                     'Phase 6 source divergence %.1f%% for conv %s '
                     '(PG=%d, Particiapi=%d) — may indicate moderation sync lag',
                     source_divergence * 100, conv.slug, p6_total_participants, pa_n,

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -463,16 +463,16 @@
             {% endif %}
           </div>
           <div class="danger-row-desc">
-            {% if reveal and reveal.state == 'cooldown' %}
+            {% if reveal and reveal.state == 'pending' %}
               Closed {{ conversation.closed_at.strftime('%-d %b %Y') }}.
               The identity-reveal window opens on {{ reveal.opens_at.strftime('%-d %b %Y') }}
-              ({{ reveal.days_until_open }} day{{ 's' if reveal.days_until_open != 1 }} away) — nothing to do until then.
+              ({{ reveal.days_left }} day{{ 's' if reveal.days_left != 1 }} away) — nothing to do until then.
             {% elif reveal and reveal.state == 'open' %}
               Closed {{ conversation.closed_at.strftime('%-d %b %Y') }}.
               The identity-reveal window is open until {{ reveal.closes_at.strftime('%-d %b %Y') }}.
-            {% elif reveal and reveal.state == 'closed' %}
+            {% elif reveal and reveal.state == 'expired' %}
               Closed {{ conversation.closed_at.strftime('%-d %b %Y') }}.
-              The identity-reveal window has closed; records are permanently pseudonymous.
+              The identity-reveal window has ended — records are permanently pseudonymous.
             {% else %}
               Closed{% if conversation.closed_at %} {{ conversation.closed_at.strftime('%-d %b %Y') }}{% endif %}. Cannot be reopened.
             {% endif %}


### PR DESCRIPTION
## Summary

- **`_build_phase6_results`**: replace bare `logger` calls with `current_app.logger` — `logger` was never defined at module level, making both the exception log and the divergence warning a latent `NameError` on any Particiapi failure
- **`admin_conversation.html`**: align reveal state names with `_reveal_context` return values — `'cooldown'`/`'closed'`/`days_until_open` were stale names that never matched; the three affected branches were dead code silently falling through to the generic else

## Test plan

- [x] 317 tests pass
- [x] pr-check: GO — all review candidates refuted (state names verified against `_reveal_context` source)
- [ ] Staging: not required — no live-backend paths touched, no new routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)