### PR TITLE
feat(logging): logging foundation — structured logs, request-id, redaction (Plan 1)

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -12,6 +12,7 @@ import os
 import random
 import re
 import secrets
+import time
 from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode, urlparse, urljoin
 
@@ -28,6 +29,7 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_wtf.csrf import CSRFProtect, validate_csrf
 from sqlalchemy import text as _sa_text
+from sqlalchemy.engine import make_url
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import joinedload
 from wtforms.validators import ValidationError
@@ -38,6 +40,7 @@ from db import (ACCESS_POLICIES, ADMIN_ROLES, AdminRole, Argument, ArgumentSideS
 from polis_admin import (PolisParticipantClient, PolisParticipantError,
                          PolisServerClient, PolisServerError)
 from seed_csv import MAX_FILE_BYTES, MAX_ROWS, parse_csv_bytes, strip_formula_prefixes
+from logging_setup import configure_logging
 
 load_dotenv(os.path.join(os.path.dirname(os.path.abspath(__file__)), '.env'))
 
@@ -2755,6 +2758,10 @@ def phase6_vote(slug):
     return resp
 
 
+# Accepted shape for a reused inbound X-Request-Id (only honoured behind a trusted proxy).
+_REQUEST_ID_RE = re.compile(r'^[A-Za-z0-9_-]{1,64}$')
+
+
 def create_app(test_config: dict | None = None) -> Flask:
     app = Flask(__name__)
 
@@ -2907,6 +2914,9 @@ def create_app(test_config: dict | None = None) -> Flask:
             'rate-limit keys do not expose raw client identities in shared Redis.'
         )
 
+    # Configure logging before extensions init so their startup logs are formatted/correlated.
+    configure_logging(app, on_toolforge=_on_toolforge)
+
     db.init_app(app)
     Migrate(app, db)
     Session(app)
@@ -2952,6 +2962,19 @@ def create_app(test_config: dict | None = None) -> Flask:
     def _set_csp_nonce():
         g.csp_nonce = secrets.token_urlsafe(16)
 
+    @app.before_request
+    def _set_request_id():
+        # Mint a fresh id by default. Only honour an inbound X-Request-Id when behind a
+        # trusted proxy AND it is well-formed — an unvalidated inbound value is a
+        # log-forging / header-injection vector.
+        rid = None
+        if app.config.get('TRUST_PROXY_HEADERS'):
+            inbound = request.headers.get('X-Request-Id', '')
+            if _REQUEST_ID_RE.match(inbound):
+                rid = inbound
+        g.request_id = rid or secrets.token_urlsafe(8)
+        g._t0 = time.perf_counter()
+
     @app.context_processor
     def _inject_globals():
         participant = _current_participant()
@@ -2979,6 +3002,18 @@ def create_app(test_config: dict | None = None) -> Flask:
         response.headers['Referrer-Policy']         = 'strict-origin-when-cross-origin'
         # X-Frame-Options superseded by frame-ancestors in CSP above, but kept for old browsers
         response.headers['X-Frame-Options']         = 'DENY'
+        response.headers['X-Request-Id']            = g.get('request_id', '-')
+
+        # Diagnostic completion line. request_id + participant_id ride the LogRecord factory
+        # (no DB access here). Skip successful static-asset hits to keep the log signal-dense;
+        # static errors (>=400) still log.
+        if not (request.path.startswith('/static/') and response.status_code < 400):
+            _t0 = g.get('_t0')
+            _ms = round((time.perf_counter() - _t0) * 1000, 1) if _t0 is not None else None
+            app.logger.info(
+                '%s %s -> %s (%sms)', request.method, request.path, response.status_code, _ms,
+                extra={'http_method': request.method, 'http_path': request.path,
+                       'http_status': response.status_code, 'duration_ms': _ms})
 
         # Cache static assets (fonts, CSS, JS) for 1 week.
         # URLs include ?v=<git-sha> so each deploy busts the cache automatically.
@@ -3004,6 +3039,22 @@ def create_app(test_config: dict | None = None) -> Flask:
     app.register_blueprint(admin_bp)
     app.register_blueprint(participant_bp)
     csrf.exempt(proxy_bp)
+
+    # Startup fingerprint — config-only, no secrets, no live probe. Answers
+    # "is this environment configured as expected" before chasing a phantom bug.
+    try:
+        _db_backend = make_url(app.config.get('SQLALCHEMY_DATABASE_URI', '')).drivername
+    except Exception:
+        _db_backend = 'unknown'
+    app.logger.info(
+        'startup env=%s db=%s polis=%s polis_pg=%s version=%s',
+        'toolforge' if _on_toolforge else 'dev', _db_backend,
+        bool(app.config.get('POLIS_SERVER_URL')), bool(app.config.get('POLIS_DATABASE_URL')),
+        _GIT_VERSION,
+        extra={'env': 'toolforge' if _on_toolforge else 'dev', 'db_backend': _db_backend,
+               'polis_configured': bool(app.config.get('POLIS_SERVER_URL')),
+               'polis_pg_configured': bool(app.config.get('POLIS_DATABASE_URL')),
+               'git_version': _GIT_VERSION})
 
     return app
 

--- a/v2/guide_logging.md
+++ b/v2/guide_logging.md
@@ -1,0 +1,65 @@
+# Logging guide (contributor reference)
+
+How logging works in wiki-polis and the rules for adding log statements. This is the
+Phase 1 (foundation) slice; audit logging (Plan 2) and engagement instrumentation
+(Plan 4) are documented separately when they land. Design rationale lives in
+`.claude/plan-logging.md`.
+
+## Where logs go
+
+- **Dev / tests:** human-readable text on stderr, e.g.
+  `2026-06-11 12:00:00 INFO [a1B2c3 pid=None] app: GET / -> 200 (4.1ms)`
+- **Production (Toolforge):** one JSON object per line on stderr → `uwsgi.log`, e.g.
+  `{"timestamp": "...", "level": "INFO", "service": "wiki-polis", "logger": "app", "message": "...", "request_id": "...", "participant_id": 42}`
+  Format is chosen by `_on_toolforge` (the `TOOL_TOOLFORGE_API_URL` env var) — **not** by
+  debug mode, so tests always get text.
+
+Configuration is in `logging_setup.py` (`configure_logging`), called once in `create_app`
+before extensions init. It configures the **root** logger imperatively (no `dictConfig`),
+so every logger — `app.logger`, `polis_admin`'s module logger, `werkzeug` — flows through
+the same handler. Don't add per-module handlers.
+
+## Levels — use them consistently
+
+| Level | When | Example |
+|-------|------|---------|
+| `DEBUG` | Dev-only detail; never relied on in prod | tracing a value while developing |
+| `INFO` | Normal operation worth a record | `request complete`, `startup`, a phase transition |
+| `WARNING` | Soft failure / degraded but handled | a non-fatal external call failed and we fell back |
+| `ERROR` / `logger.exception` | Hard failure | an unhandled exception (Flask logs these for you) |
+
+Prefer `current_app.logger` in request code. Unhandled exceptions are logged by Flask
+itself — **don't** add your own catch-all 5xx logger (it would double the stack).
+
+## Request correlation
+
+Every record automatically carries:
+- `request_id` — minted per request (`secrets.token_urlsafe(8)`). An inbound `X-Request-Id`
+  is honoured **only** behind a trusted proxy (`TRUST_PROXY_HEADERS`) and only if it matches
+  `^[A-Za-z0-9_-]{1,64}$`; otherwise a fresh one is minted. It is echoed in the response
+  `X-Request-Id` header.
+- `participant_id` — the internal participant id, **best-effort** (only present when the
+  request already resolved `g.participant`; the logging path never issues a query). This is
+  how an error log ties back to the user who hit it.
+
+Both are injected by a `LogRecord` factory, so they appear on *every* record (including
+Flask's exception logs and pytest's `caplog`).
+
+## Privacy — hard rules
+
+- **Never log** statement text, vote values/direction, raw `xid`, `mw_user_id`,
+  Wikimedia username, email, session contents, secrets, or tokens.
+- Reference a participant by **internal `participant_id` only** — never their username/xid.
+- A minimal `RedactingFormatter` scrubs URL-embedded credentials, sha256/`xid`-shaped hex,
+  and `key: value` secrets (authorization / cookie / token / password / api-key) from the
+  final line **including tracebacks**. This is a backstop, **not** a licence to log
+  sensitive data — the full redaction catalogue is Plan 3. See `tests/test_logging.py`.
+- The startup fingerprint logs only the DB **scheme** (`make_url(...).drivername`) and
+  booleans — never a URL with a password or any credential.
+
+## Adding a log statement — checklist
+
+1. Right level (table above)?
+2. No PII / secrets / vote content in the message or its `%`-args?
+3. Reference participants as `participant_id`, not username/xid?
+4. In the request path, no DB query just to enrich a log line.

--- a/v2/logging_setup.py
+++ b/v2/logging_setup.py
@@ -1,0 +1,142 @@
+"""Logging foundation (Plan 1 / Phase 1).
+
+Substrate only: how records are formatted (text in dev/test, JSON in prod),
+correlated (request_id + participant_id via a LogRecord factory), and redacted
+(a minimal secret/identifier scrub). Domain logging (audit, engagement) is Plans 2/4.
+
+Design notes from the expert review:
+- We configure the root logger *imperatively* (add a handler, set levels) rather than
+  via ``logging.config.dictConfig``. dictConfig's ``disable_existing_loggers`` defaults
+  to True and would silence already-imported loggers (e.g. ``polis_admin``, ``werkzeug``);
+  configuring imperatively never disables anything, so those keep flowing to root.
+- request_id / participant_id are injected by a ``LogRecord`` factory, not a Filter, so
+  the fields land on *every* record — including Flask's built-in exception log and
+  pytest's ``caplog`` — without attaching a filter to each handler.
+- Redaction happens in the *formatter* (post-format), so it also scrubs exception
+  tracebacks rendered by the formatter (which a record-level filter cannot see).
+- participant_id is the internal id only (never username / mw_username / xid) and is read
+  best-effort from ``g`` — the factory never issues a query.
+"""
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+
+from flask import g, has_request_context
+from sqlalchemy.engine import make_url  # noqa: F401  (re-exported for callers/tests)
+
+_HANDLER_NAME = 'wikipolis-stderr'
+_factory_installed = False
+
+# Minimal redaction (full catalogue is Plan 3). Each entry scrubs a concrete high-risk
+# token from the final formatted line (message + traceback).
+_REDACTIONS = [
+    # credentials embedded in a URL: scheme://user:PASSWORD@host -> scheme://user:***@host
+    (re.compile(r'(://[^:/?#\s]+:)[^@/?#\s]+(@)'), r'\1***\2'),
+    # xid / sha256-shaped hex (reversible identifier, #96)
+    (re.compile(r'\b[0-9a-fA-F]{64}\b'), '[redacted-hash]'),
+    # key=value / key: value for sensitive keys — redact the whole value run (handles
+    # multi-word values like "Bearer <token>"), stopping at a field delimiter.
+    (re.compile(r'(?i)\b(authorization|cookie|set-cookie|token|secret|password|passwd|pwd|api[_-]?key)\b'
+                r'(["\s:=]+)[^\r\n,;}"\']+'), r'\1\2[redacted]'),
+]
+
+
+def _redact(s: str) -> str:
+    for pattern, repl in _REDACTIONS:
+        s = pattern.sub(repl, s)
+    return s
+
+
+# Extra record attributes the JSON formatter surfaces as top-level fields when present.
+_JSON_EXTRA_FIELDS = ('http_method', 'http_path', 'http_status', 'duration_ms',
+                      'env', 'db_backend', 'polis_configured', 'polis_pg_configured', 'git_version')
+
+
+class RedactingJsonFormatter(logging.Formatter):
+    """One JSON object per line, mirroring the Polis server's winston shape."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            'timestamp':   datetime.fromtimestamp(record.created, timezone.utc).isoformat(),
+            'level':       record.levelname,
+            'service':     'wiki-polis',
+            'logger':      record.name,
+            'message':     record.getMessage(),
+            'request_id':  getattr(record, 'request_id', '-'),
+        }
+        pid = getattr(record, 'participant_id', None)
+        if pid is not None:
+            payload['participant_id'] = pid
+        for field in _JSON_EXTRA_FIELDS:
+            if hasattr(record, field):
+                payload[field] = getattr(record, field)
+        if record.exc_info:
+            payload['stack'] = self.formatException(record.exc_info)
+        return _redact(json.dumps(payload, default=str))
+
+
+class RedactingTextFormatter(logging.Formatter):
+    """Human-readable, for dev/test. Redacts the fully-rendered line (incl. traceback)."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        return _redact(super().format(record))
+
+
+def _install_record_factory() -> None:
+    """Wrap the LogRecord factory once to stamp request_id + participant_id on every record."""
+    global _factory_installed
+    if _factory_installed:
+        return
+    old_factory = logging.getLogRecordFactory()
+
+    def factory(*args, **kwargs):
+        record = old_factory(*args, **kwargs)
+        if has_request_context():
+            record.request_id = g.get('request_id', '-')
+            participant = g.get('participant')
+            record.participant_id = getattr(participant, 'id', None)  # best-effort, no query
+        else:
+            record.request_id = '-'
+            record.participant_id = None
+        return record
+
+    logging.setLogRecordFactory(factory)
+    _factory_installed = True
+
+
+def configure_logging(app, on_toolforge: bool = False) -> None:
+    """Idempotent. Text in dev/test, JSON in prod (gated on on_toolforge only)."""
+    _install_record_factory()
+
+    root = logging.getLogger()
+    # Idempotent: remove only OUR previously-installed handler — never clear all root
+    # handlers (that would drop pytest's caplog handler mid-test).
+    for handler in [h for h in root.handlers if getattr(h, 'name', None) == _HANDLER_NAME]:
+        root.removeHandler(handler)
+
+    root.setLevel(logging.INFO if on_toolforge else logging.DEBUG)
+
+    # Defend against an accidental SQLALCHEMY_ECHO / echo=True dumping SQL + bound values.
+    for noisy in ('sqlalchemy', 'sqlalchemy.engine', 'sqlalchemy.pool'):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+
+    # Flask's lazy app.logger: drop its default handler and let it propagate to root,
+    # so there is a single handler (no double-logging).
+    app.logger.handlers = []
+    app.logger.propagate = True
+
+    # In tests, let pytest's caplog own the root handler. The record factory still
+    # provides request_id / participant_id, so assertions on those fields work.
+    if app.testing:
+        return
+
+    handler = logging.StreamHandler()  # defaults to sys.stderr
+    handler.name = _HANDLER_NAME
+    if on_toolforge:
+        handler.setFormatter(RedactingJsonFormatter())
+    else:
+        handler.setFormatter(RedactingTextFormatter(
+            '%(asctime)s %(levelname)s [%(request_id)s pid=%(participant_id)s] %(name)s: %(message)s'))
+    root.addHandler(handler)

--- a/v2/logging_setup.py
+++ b/v2/logging_setup.py
@@ -32,8 +32,9 @@ _factory_installed = False
 # Minimal redaction (full catalogue is Plan 3). Each entry scrubs a concrete high-risk
 # token from the final formatted line (message + traceback).
 _REDACTIONS = [
-    # credentials embedded in a URL: scheme://user:PASSWORD@host -> scheme://user:***@host
-    (re.compile(r'(://[^:/?#\s]+:)[^@/?#\s]+(@)'), r'\1***\2'),
+    # credentials embedded in a URL: scheme://[user]:PASSWORD@host -> scheme://[user]:***@host
+    # (username optional so scheme://:password@host is also caught)
+    (re.compile(r'(://[^:/?#\s]*:)[^@/?#\s]+(@)'), r'\1***\2'),
     # xid / sha256-shaped hex (reversible identifier, #96)
     (re.compile(r'\b[0-9a-fA-F]{64}\b'), '[redacted-hash]'),
     # key=value / key: value for sensitive keys — redact the whole value run (handles

--- a/v2/tests/test_logging.py
+++ b/v2/tests/test_logging.py
@@ -1,0 +1,127 @@
+"""Phase 1 logging foundation tests (Plan 1).
+
+Covers the review's must-prove items: loggers aren't disabled, request_id +
+participant_id ride records without a DB query, X-Request-Id is minted/validated,
+redaction scrubs secrets, the startup fingerprint exposes only a scheme, and the
+completion line skips successful static hits.
+"""
+import json
+import logging
+import re
+
+import pytest
+from flask import Flask
+
+from logging_setup import (RedactingJsonFormatter, _HANDLER_NAME, _redact,
+                           configure_logging)
+
+
+# ── Redaction (minimal Phase-1 filter) ──────────────────────────────────────
+
+def test_redact_db_url_password():
+    out = _redact('mysql+pymysql://user:supersecret@host/db')
+    assert 'supersecret' not in out
+    assert '***' in out
+
+
+def test_redact_xid_sha256():
+    xid = 'a' * 64
+    assert xid not in _redact(f'participant xid={xid}')
+
+
+def test_redact_sensitive_kv():
+    for line in ('token=abc123secretvalue', 'password: hunter2hunter2', 'Authorization: Bearer xyz789abc'):
+        out = _redact(line)
+        assert 'abc123secretvalue' not in out
+        assert 'hunter2hunter2' not in out
+        assert 'xyz789abc' not in out
+
+
+# ── JSON formatter shape + redaction (mirrors the prod line) ─────────────────
+
+def test_json_formatter_shape_and_redaction():
+    rec = logging.LogRecord('x', logging.INFO, __file__, 1,
+                            'connect mysql://u:pw@h/db', None, None)
+    rec.request_id = 'abc'
+    rec.participant_id = None
+    out = RedactingJsonFormatter().format(rec)
+    data = json.loads(out)
+    assert data['service'] == 'wiki-polis'
+    assert data['request_id'] == 'abc'
+    assert 'participant_id' not in data           # omitted when None
+    assert 'pw' not in out                         # password scrubbed inside JSON
+
+
+def test_startup_fingerprint_logs_scheme_only():
+    # The fingerprint logs make_url(...).drivername — never the full URL/password.
+    from sqlalchemy.engine import make_url
+    url = make_url('mysql+pymysql://user:s3cret@host/db')
+    assert url.drivername == 'mysql+pymysql'
+    assert 's3cret' not in url.drivername
+
+
+# ── configure_logging idempotency (non-testing app) ─────────────────────────
+
+def test_configure_logging_idempotent():
+    a = Flask('idem-test')          # .testing is False → installs the stderr handler
+    root = logging.getLogger()
+    try:
+        configure_logging(a, on_toolforge=True)
+        configure_logging(a, on_toolforge=True)
+        ours = [h for h in root.handlers if getattr(h, 'name', None) == _HANDLER_NAME]
+        assert len(ours) == 1
+    finally:
+        for h in [h for h in root.handlers if getattr(h, 'name', None) == _HANDLER_NAME]:
+            root.removeHandler(h)
+
+
+# ── Behaviour through a real request (app/client fixtures) ───────────────────
+
+def test_polis_admin_logger_not_disabled(app):
+    # We configure imperatively (no dictConfig), so existing loggers are never disabled.
+    assert logging.getLogger('polis_admin').disabled is False
+
+
+def test_request_id_minted_and_returned(client):
+    r = client.get('/')
+    rid = r.headers.get('X-Request-Id')
+    assert rid and re.match(r'^[A-Za-z0-9_-]{1,64}$', rid)
+
+
+def test_inbound_request_id_ignored_without_trusted_proxy(client):
+    r = client.get('/', headers={'X-Request-Id': 'attacker-supplied'})
+    assert r.headers['X-Request-Id'] != 'attacker-supplied'   # minted instead
+
+
+def test_inbound_request_id_reused_when_trusted_and_valid(app):
+    app.config['TRUST_PROXY_HEADERS'] = True
+    r = app.test_client().get('/', headers={'X-Request-Id': 'valid_id-123'})
+    assert r.headers['X-Request-Id'] == 'valid_id-123'
+
+
+def test_inbound_request_id_rejected_when_malformed(app):
+    app.config['TRUST_PROXY_HEADERS'] = True
+    c = app.test_client()
+    for bad in ('has spaces', 'y' * 65):               # fail the strict pattern
+        r = c.get('/', headers={'X-Request-Id': bad})
+        assert r.headers['X-Request-Id'] != bad
+
+
+def test_completion_line_carries_request_id_no_participant(client, caplog):
+    with caplog.at_level(logging.INFO):
+        r = client.get('/')
+    recs = [rec for rec in caplog.records if getattr(rec, 'http_path', None) == '/']
+    assert recs, 'expected a request-completion log record'
+    assert recs[0].request_id == r.headers['X-Request-Id']
+    assert recs[0].participant_id is None              # anonymous; no DB query forced
+
+
+def test_successful_static_hit_not_logged(client, caplog):
+    with caplog.at_level(logging.INFO):
+        resp = client.get('/static/style.css')
+    if resp.status_code == 200:
+        static_recs = [r for r in caplog.records
+                       if str(getattr(r, 'http_path', '')).startswith('/static/')]
+        assert not static_recs                          # skipped to keep logs signal-dense
+    else:
+        pytest.skip('static asset not served in this checkout')

--- a/v2/tests/test_logging.py
+++ b/v2/tests/test_logging.py
@@ -52,12 +52,35 @@ def test_json_formatter_shape_and_redaction():
     assert 'pw' not in out                         # password scrubbed inside JSON
 
 
-def test_startup_fingerprint_logs_scheme_only():
-    # The fingerprint logs make_url(...).drivername — never the full URL/password.
-    from sqlalchemy.engine import make_url
-    url = make_url('mysql+pymysql://user:s3cret@host/db')
-    assert url.drivername == 'mysql+pymysql'
-    assert 's3cret' not in url.drivername
+def test_startup_fingerprint_logs_scheme_not_secrets(tmp_path, caplog):
+    # Drive the real create_app fingerprint and assert it logs the DB scheme but no secret.
+    import os
+    from unittest.mock import patch
+
+    from cachelib.file import FileSystemCache
+
+    from app import create_app
+
+    session_dir = tmp_path / 'sessions'
+    session_dir.mkdir()
+    env = {'FLASK_DEBUG': '0', 'DEV_LOGIN_USER': '', 'RATELIMIT_STORAGE_URI': '',
+           'RATELIMIT_KEY_PREFIX': '', 'RATELIMIT_IDENTITY_SECRET': '', 'TRUST_PROXY_HEADERS': '',
+           'TOOL_TOOLFORGE_API_URL': '', 'TOOL_REDIS_URI': ''}
+    with caplog.at_level(logging.INFO):
+        with patch.dict(os.environ, env, clear=False):
+            create_app({
+                'TESTING': True,
+                'SQLALCHEMY_DATABASE_URI': f'sqlite:///{tmp_path}/t.db',
+                'WTF_CSRF_ENABLED': False, 'RATELIMIT_ENABLED': False,
+                'SECRET_KEY': 'super-secret-key', 'SESSION_TYPE': 'cachelib',
+                'SESSION_CACHELIB': FileSystemCache(str(session_dir)),
+                'SESSION_PERMANENT': False,
+            })
+    startup = [r for r in caplog.records if r.getMessage().startswith('startup ')]
+    assert startup, 'expected a startup fingerprint log record'
+    msg = startup[0].getMessage()
+    assert 'db=sqlite' in msg                 # scheme only
+    assert 'super-secret-key' not in msg      # no SECRET_KEY in the line
 
 
 # ── configure_logging idempotency (non-testing app) ─────────────────────────
@@ -105,6 +128,23 @@ def test_inbound_request_id_rejected_when_malformed(app):
     for bad in ('has spaces', 'y' * 65):               # fail the strict pattern
         r = c.get('/', headers={'X-Request-Id': bad})
         assert r.headers['X-Request-Id'] != bad
+
+
+def test_participant_id_rides_record_when_resolved(app, caplog):
+    # Proves the factory stamps participant_id from g.participant (not inert), no query.
+    from flask import g
+
+    class _P:
+        id = 4242
+
+    with app.test_request_context('/'):
+        g.request_id = 'rid-xyz'
+        g.participant = _P()
+        with caplog.at_level(logging.INFO):
+            logging.getLogger('test').info('hello')
+    rec = [r for r in caplog.records if r.getMessage() == 'hello'][0]
+    assert rec.participant_id == 4242
+    assert rec.request_id == 'rid-xyz'
 
 
 def test_completion_line_carries_request_id_no_participant(client, caplog):


### PR DESCRIPTION
## Summary

Phase 1 of the logging architecture (design: `v2/.claude/plan-logging.md`). **Substrate only** — audit logging (Plan 2) and engagement instrumentation (Plan 4) are later, separate PRs.

- **`v2/logging_setup.py`** (new) — `configure_logging()` sets up the root logger **imperatively** (no `dictConfig`, so existing loggers like `polis_admin`/`werkzeug` are never disabled). Text in dev/test, JSON in prod (gated on `_on_toolforge`, matching the Polis server's winston shape). A `LogRecord` factory stamps `request_id` + best-effort `participant_id` (internal id only, **no DB query**) on every record — including Flask's exception logs and pytest `caplog`. A `RedactingFormatter` scrubs URL credentials, sha256/`xid`-shaped hex, and `key: value` secrets from the final line **including tracebacks**. `sqlalchemy.*` pinned to `WARNING`.
- **`v2/app.py`** — call `configure_logging` before extension init; mint/validate `X-Request-Id` (inbound honoured only behind `TRUST_PROXY_HEADERS` + strict pattern) and echo it; zero-DB request-completion line (skips successful `/static/`); config-only startup fingerprint (DB scheme + booleans, no secrets). Relies on Flask's built-in exception logging (no double-stack).
- **`v2/tests/test_logging.py`** (new) — 14 tests: redaction, JSON shape, idempotency, request-id mint/validate/reject, completion line carries request_id without forcing a query, participant_id stamping, loggers not disabled, static skip, startup fingerprint logs scheme not secrets.
- **`v2/guide_logging.md`** (new) — contributor reference (levels, correlation, privacy rules).

## Review

Plan was cross-reviewed (security + database + senior engineer) before implementation; the implemented diff was reviewed again (security + senior). **GO, no blockers.** Panel findings applied: tightened URL-credential redaction for userless DSNs, replaced a tautological fingerprint test with a real `create_app`+caplog test, added a positive `participant_id` test.

## Test plan

- [x] 357 tests pass; ruff clean.
- [x] Manual smoke check: prod-mode JSON line is valid and scrubs a URL password + token.
- [ ] **Staging (human):** after deploy, confirm one clean JSON line per record in `uwsgi.log` under uwsgi multi-worker stderr, and that `X-Request-Id` round-trips. Local pytest can't exercise the multi-worker path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)