### PR TITLE
fix(#196): allow voting on your own argument

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -2538,11 +2538,6 @@ def argument_vote(slug, arg_id):
         if is_ajax:
             return jsonify({'ok': False, 'reason': 'hidden'}), 403
         abort(403)
-    if arg.proposer_id == part.participant_id:
-        if is_ajax:
-            return jsonify({'ok': False, 'reason': 'own'}), 403
-        abort(403)
-
     existing = ArgumentVote.query.filter_by(
         participant_id=part.participant_id, argument_id=arg_id).first()
     if not existing:

--- a/v2/app.py
+++ b/v2/app.py
@@ -2533,7 +2533,7 @@ def argument_vote(slug, arg_id):
             return jsonify({'ok': False, 'reason': 'cap'}), 409
         abort(409)   # cap reached
 
-    # Can't vote on hidden or own argument.
+    # Can't vote on a hidden argument.
     if arg.hidden:
         if is_ajax:
             return jsonify({'ok': False, 'reason': 'hidden'}), 403

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -654,9 +654,9 @@
           {% for arg in item.pro_args %}
           {% set is_own = arg.proposer_id == participation.participant_id %}
           {% set is_picked = arg.id in item.voted_ids %}
-          {% set pro_can_vote = both_gate and pro_vote_ready and not is_own and not arg.hidden %}
+          {% set pro_can_vote = both_gate and pro_vote_ready and not arg.hidden %}
           {% set pro_limit_reached = pro_can_vote and item.pro_voted_count >= item.k and not is_picked %}
-          {% set pro_vol_locked = both_gate and not pro_vote_ready and not is_own and not arg.hidden %}
+          {% set pro_vol_locked = both_gate and not pro_vote_ready and not arg.hidden %}
           <div class="at-card argument-card"
                data-side="pro"
                data-arg-id="{{ arg.id }}"
@@ -671,7 +671,7 @@
             <button class="at-pick argument-checkbox"
                     aria-pressed="{{ 'true' if is_picked else 'false' }}"
                     aria-label="{{ 'Unmark as most important' if is_picked else 'Mark as most important' }}"
-                    {% if is_own or arg.hidden %}aria-hidden="true" tabindex="-1"
+                    {% if arg.hidden %}aria-hidden="true" tabindex="-1"
                     {% elif pro_vol_locked %}tabindex="0" aria-disabled="true" aria-describedby="volnote-pro-{{ fs.id }}"
                     {% elif pro_can_vote %}tabindex="0"
                     {% else %}tabindex="-1"{% endif %}>
@@ -780,9 +780,9 @@
           {% for arg in item.con_args %}
           {% set is_own = arg.proposer_id == participation.participant_id %}
           {% set is_picked = arg.id in item.voted_ids %}
-          {% set con_can_vote = both_gate and con_vote_ready and not is_own and not arg.hidden %}
+          {% set con_can_vote = both_gate and con_vote_ready and not arg.hidden %}
           {% set con_limit_reached = con_can_vote and item.con_voted_count >= item.k and not is_picked %}
-          {% set con_vol_locked = both_gate and not con_vote_ready and not is_own and not arg.hidden %}
+          {% set con_vol_locked = both_gate and not con_vote_ready and not arg.hidden %}
           <div class="at-card argument-card"
                data-side="con"
                data-arg-id="{{ arg.id }}"
@@ -797,7 +797,7 @@
             <button class="at-pick argument-checkbox"
                     aria-pressed="{{ 'true' if is_picked else 'false' }}"
                     aria-label="{{ 'Unmark as most important' if is_picked else 'Mark as most important' }}"
-                    {% if is_own or arg.hidden %}aria-hidden="true" tabindex="-1"
+                    {% if arg.hidden %}aria-hidden="true" tabindex="-1"
                     {% elif con_vol_locked %}tabindex="0" aria-disabled="true" aria-describedby="volnote-con-{{ fs.id }}"
                     {% elif con_can_vote %}tabindex="0"
                     {% else %}tabindex="-1"{% endif %}>

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -2129,7 +2129,7 @@
           if (col) { var note = col.querySelector('.at-col-note'); if (note) note.remove(); }
           if (ready) {
             block.querySelectorAll('.argument-card[data-side="' + s + '"]').forEach(function (card) {
-              if (card.dataset.own !== 'true') {
+              if (card.dataset.hidden !== 'true') {
                 card.dataset.canVote = 'true';
                 var cb = card.querySelector('.argument-checkbox');
                 if (cb) {
@@ -2212,7 +2212,7 @@
             var msgs = {
               cap:  "You've already picked your " + kVal + " most important — unvote one first.",
               gate: 'Voting is not open yet — add or skip on each side first.',
-              own:  "You can't vote for your own argument.",
+              own:  'Could not record your pick — please try again.',
             };
             if (data && msgs[data.reason]) {
               var msg = msgs[data.reason];

--- a/v2/tests/test_arguments.py
+++ b/v2/tests/test_arguments.py
@@ -234,7 +234,7 @@ def test_vote_k_cap_enforced(auth_client, arg_conv, arg_part, fs,
     assert resp.status_code == 409
 
 
-def test_vote_own_argument_blocked(auth_client, arg_conv, arg_part, fs,
+def test_vote_own_argument_allowed(auth_client, arg_conv, arg_part, fs,
                                    participant, app):
     _pass_gate(auth_client, 'arg-conv', fs.id)
     own = Argument(featured_statement_id=fs.id, proposer_id=participant.id,
@@ -242,7 +242,7 @@ def test_vote_own_argument_blocked(auth_client, arg_conv, arg_part, fs,
     db.session.add(own)
     db.session.commit()
     resp = auth_client.post(f'/c/arg-conv/arguments/{own.id}/vote')
-    assert resp.status_code == 403
+    assert resp.status_code in (200, 302)
 
 
 def test_unvote_removes_vote(auth_client, arg_conv, arg_part, fs,


### PR DESCRIPTION
## Summary

- Participants can now mark their own submitted argument as most important
- Removes the backend 403 self-vote block in `argument_vote()`
- Drops `not is_own` from `pro/con_can_vote` in the template
- Pick button is now keyboard-reachable for own arguments (was `aria-hidden`)
- Updates `test_vote_own_argument_blocked` → `test_vote_own_argument_allowed`

## Test plan
- [x] 340 tests pass (2 pre-existing unrelated failures in `test_phase_stats`)
- [ ] Verify on staging: submit an argument, confirm pick button is active on your own card

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)