### PR TITLE
feat(audit): accountability logging for admin writes (Plan 2, #135)

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -1910,7 +1910,8 @@ def admin_invite_add(conv_id):
     except Exception:
         db.session.rollback()
     else:
-        record_audit('invite.add', conv_id=conv_id, count=added)  # count only — no usernames (PII)
+        if added:
+            record_audit('invite.add', conv_id=conv_id, count=added)  # count only — no usernames (PII)
     return redirect(url_for('admin.admin_conversation_invites', conv_id=conv_id))
 
 @admin_bp.post('/admin/conversations/<int:conv_id>/invites/<int:invite_id>/remove')
@@ -2816,6 +2817,11 @@ def record_audit(operation, *, conv_id=None, target_type=None, target_id=None,
     this contract is the control (enforced by tests).
     """
     actor = getattr(g.get('participant'), 'id', None)
+    if actor is None and session.get('username'):
+        # Authenticated admin with no Participant row (env-listed ADMIN_USERS superadmin).
+        # Mark the row so a NULL actor is explained, not ambiguous — without storing the
+        # username (PII). See _is_global_admin's ADMIN_USERS branch.
+        detail.setdefault('actor_kind', 'env_admin')
     try:
         db.session.add(AuditEvent(
             actor_participant_id=actor, conversation_id=conv_id, operation=operation,

--- a/v2/app.py
+++ b/v2/app.py
@@ -35,7 +35,7 @@ from sqlalchemy.orm import joinedload
 from wtforms.validators import ValidationError
 
 from db import (ACCESS_POLICIES, ADMIN_ROLES, AdminRole, Argument, ArgumentSideState,
-                ArgumentVote, Conversation, ConversationInvite, FeaturedStatement,
+                ArgumentVote, AuditEvent, Conversation, ConversationInvite, FeaturedStatement,
                 Participant, Participation, db)
 from polis_admin import (PolisParticipantClient, PolisParticipantError,
                          PolisServerClient, PolisServerError)
@@ -1399,8 +1399,10 @@ def admin_conversation_new():
                 'Pass a polis_id manually or set the env vars.'
             )))
 
-    db.session.add(Conversation(slug=slug, active=True, polis_id=polis_id, **fields))
+    conv = Conversation(slug=slug, active=True, polis_id=polis_id, **fields)
+    db.session.add(conv)
     db.session.commit()
+    record_audit('conversation.create', conv_id=conv.id, slug=slug)
     return redirect(url_for('admin.admin'))
 
 @admin_bp.post('/admin/conversations/<int:conv_id>/edit')
@@ -1419,6 +1421,7 @@ def admin_conversation_edit(conv_id):
     conv.outro_text    = fields['outro_text']
     conv.access_policy = fields['access_policy']
     db.session.commit()
+    record_audit('conversation.edit', conv_id=conv.id)
     return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
 
 @admin_bp.post('/admin/conversations/<int:conv_id>/pause')
@@ -1430,6 +1433,7 @@ def admin_conversation_pause(conv_id):
         abort(400)
     conv.paused = not conv.paused
     db.session.commit()
+    record_audit('conversation.pause', conv_id=conv.id, paused=conv.paused)
     return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
 
 @admin_bp.post('/admin/conversations/<int:conv_id>/close')
@@ -1443,6 +1447,7 @@ def admin_conversation_close(conv_id):
     conv.paused    = False
     conv.closed_at = datetime.now(timezone.utc)
     db.session.commit()
+    record_audit('conversation.close', conv_id=conv.id)
     return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
 
 def _sync_vis_type(conv) -> bool:
@@ -1483,6 +1488,10 @@ def admin_conversation_phases(conv_id):
     conv.phase_public_results   = bool(request.form.get('phase_public_results'))
     conv.phase_informed_voting  = bool(request.form.get('phase_informed_voting'))
     db.session.commit()
+    record_audit('phase.set', conv_id=conv.id, phases={
+        'submission': conv.phase_submission, 'personal_results': conv.phase_personal_results,
+        'argument_mapping': conv.phase_argument_mapping, 'cleanup': conv.phase_cleanup,
+        'public_results': conv.phase_public_results, 'informed_voting': conv.phase_informed_voting})
 
     if not _sync_vis_type(conv):
         flash('Phases saved, but updating results visibility in Polis failed — '
@@ -1589,6 +1598,10 @@ def admin_conversation_advance(conv_id):
             flash('Could not move on — a database error occurred. Please try again.', 'error')
         return redirect_to
 
+    record_audit('phase.advance', conv_id=conv.id, target_type='phase', target_id=nxt['key'],
+                 from_phase=cur['key'], phase6_created=bool(created_p6),
+                 auto_closed=bool(ctx['auto_close']))
+
     if not _sync_vis_type(conv):
         flash('Phase moved, but updating results visibility in Polis failed.', 'error')
     if sync_msg:                                  # re-entry re-synced round 6 (#175)
@@ -1649,6 +1662,7 @@ def admin_phase6_init(conv_id):
         flash('Phase 6 initialisation failed due to a database error. '
               'Contact a site admin — the Polis conversation id has been logged.', 'error')
         return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
+    record_audit('phase6.init', conv_id=conv.id)
     flash(msg, 'success')
     return redirect(url_for('admin.admin_conversation_detail', conv_id=conv_id))
 
@@ -1807,6 +1821,7 @@ def admin_global_admin_add():
         return redirect(url_for('admin.admin'))
     p.is_global_admin = True
     db.session.commit()
+    record_audit('global_admin.grant', target_type='participant', target_id=p.id)
     return redirect(url_for('admin.admin'))
 
 @admin_bp.post('/admin/global-admins/<int:participant_id>/remove')
@@ -1816,6 +1831,7 @@ def admin_global_admin_remove(participant_id):
     p = Participant.query.get_or_404(participant_id)
     p.is_global_admin = False
     db.session.commit()
+    record_audit('global_admin.revoke', target_type='participant', target_id=p.id)
     return redirect(url_for('admin.admin'))
 
 @admin_bp.post('/admin/roles/add')
@@ -1845,6 +1861,8 @@ def admin_role_add():
             granted_by=grantor.id if grantor else None,
         ))
         db.session.commit()
+        record_audit('role.grant', conv_id=conversation_id, target_type='participant',
+                     target_id=participant_id, role=role)
     return redirect(_safe_redirect(request.form.get('redirect_to', ''), url_for('admin.admin')))
 
 @admin_bp.post('/admin/roles/<int:role_id>/remove')
@@ -1852,8 +1870,11 @@ def admin_role_add():
 @admin_required
 def admin_role_remove(role_id):
     role = AdminRole.query.get_or_404(role_id)
+    conv_id, pid, role_name = role.conversation_id, role.participant_id, role.role
     db.session.delete(role)
     db.session.commit()
+    record_audit('role.revoke', conv_id=conv_id, target_type='participant',
+                 target_id=pid, role=role_name)
     return redirect(_safe_redirect(request.form.get('redirect_to', ''), url_for('admin.admin')))
 
 @admin_bp.get('/admin/conversations/<int:conv_id>/invites')
@@ -1878,14 +1899,18 @@ def admin_invite_add(conv_id):
         return redirect(url_for('admin.admin_conversation_invites', conv_id=conv_id))
     existing = {inv.mw_username for inv in
                 ConversationInvite.query.filter_by(conversation_id=conv_id).all()}
+    added = 0
     for username in usernames:
         if username not in existing:
             db.session.add(ConversationInvite(
                 conversation_id=conv_id, mw_username=username))
+            added += 1
     try:
         db.session.commit()
     except Exception:
         db.session.rollback()
+    else:
+        record_audit('invite.add', conv_id=conv_id, count=added)  # count only — no usernames (PII)
     return redirect(url_for('admin.admin_conversation_invites', conv_id=conv_id))
 
 @admin_bp.post('/admin/conversations/<int:conv_id>/invites/<int:invite_id>/remove')
@@ -1896,6 +1921,7 @@ def admin_invite_remove(conv_id, invite_id):
         id=invite_id, conversation_id=conv_id).first_or_404()
     db.session.delete(invite)
     db.session.commit()
+    record_audit('invite.remove', conv_id=conv_id, target_type='invite', target_id=invite_id)
     return redirect(url_for('admin.admin_conversation_invites', conv_id=conv_id))
 
 # ── Admin: Polis statement moderation ─────────────────────────────────────
@@ -1969,6 +1995,8 @@ def admin_statement_moderate(conv_id, tid):
         current_app.logger.exception('moderate failed')
         flash('Moderation action failed. Check server logs for details.', 'error')
         return redirect(url_for('admin.admin_conversation_statements', conv_id=conv_id))
+    record_audit('statement.moderate', conv_id=conv_id, target_type='statement',
+                 target_id=tid, decision=mod)
     return redirect(url_for('admin.admin_conversation_statements', conv_id=conv_id))
 
 @admin_bp.post('/admin/conversations/<int:conv_id>/statements/seed')
@@ -1982,6 +2010,7 @@ def admin_statement_seed(conv_id):
     try:
         _polis_server_client().add_seed(conv.polis_id, text)
         flash('Seed statement added.', 'success')
+        record_audit('statement.seed', conv_id=conv_id)   # no text (statement content)
     except PolisServerError:
         current_app.logger.exception('add_seed failed')
         flash('Could not add seed statement. Check server logs for details.', 'error')
@@ -2119,6 +2148,9 @@ def admin_statement_seed_import(conv_id):
     else:
         flash('⚠ 0 imported — Polis returned no result', 'import_result')
 
+    if successes:
+        record_audit('statement.seed_import', conv_id=conv_id,
+                     imported=successes, skipped=n_skipped, errors=n_errors)
     return redirect(redirect_target)
 
 @admin_bp.post('/admin/conversations/<int:conv_id>/strict-moderation')
@@ -2128,6 +2160,7 @@ def admin_conversation_strict_moderation(conv_id):
     enabled = request.form.get('strict_moderation') == '1'
     try:
         _polis_server_client().set_strict_moderation(conv.polis_id, enabled)
+        record_audit('strict_moderation.set', conv_id=conv_id, enabled=enabled)
     except PolisServerError:
         current_app.logger.exception('set_strict_moderation failed')
         flash('Could not update moderation settings. Check server logs for details.', 'error')
@@ -2173,6 +2206,7 @@ def admin_featured_confirm(conv_id):
             confirmed_by_admin=True,
         ))
         db.session.commit()
+        record_audit('featured.confirm', conv_id=conv_id, target_type='statement', target_id=tid)
     return redirect(url_for('admin.admin_conversation_featured', conv_id=conv_id))
 
 @admin_bp.post('/admin/conversations/<int:conv_id>/featured/add')
@@ -2192,6 +2226,7 @@ def admin_featured_add(conv_id):
             confirmed_by_admin=True,
         ))
         db.session.commit()
+        record_audit('featured.add', conv_id=conv_id, target_type='statement', target_id=tid)
     return redirect(url_for('admin.admin_conversation_featured', conv_id=conv_id))
 
 @admin_bp.post('/admin/conversations/<int:conv_id>/featured/<int:fs_id>/remove')
@@ -2207,6 +2242,7 @@ def admin_featured_remove(conv_id, fs_id):
             return redirect(url_for('admin.admin_conversation_featured', conv_id=conv_id))
     db.session.delete(fs)
     db.session.commit()
+    record_audit('featured.remove', conv_id=conv_id, target_type='featured', target_id=fs_id)
     return redirect(url_for('admin.admin_conversation_featured', conv_id=conv_id))
 
 @admin_bp.post('/admin/conversations/<int:conv_id>/arguments/<int:arg_id>/delete')
@@ -2216,8 +2252,11 @@ def admin_argument_delete(conv_id, arg_id):
     arg  = Argument.query.filter_by(id=arg_id).first_or_404()
     FeaturedStatement.query.filter_by(
         id=arg.featured_statement_id, conversation_id=conv.id).first_or_404()
+    fs_id = arg.featured_statement_id
     db.session.delete(arg)
     db.session.commit()
+    record_audit('argument.delete', conv_id=conv_id, target_type='argument', target_id=arg_id,
+                 featured_statement_id=fs_id)
     return redirect(url_for('admin.admin_conversation_featured', conv_id=conv_id))
 
 
@@ -2760,6 +2799,37 @@ def phase6_vote(slug):
 
 # Accepted shape for a reused inbound X-Request-Id (only honoured behind a trusted proxy).
 _REQUEST_ID_RE = re.compile(r'^[A-Za-z0-9_-]{1,64}$')
+
+
+def record_audit(operation, *, conv_id=None, target_type=None, target_id=None,
+                 outcome='ok', **detail):
+    """Append an AuditEvent (#135) and emit a correlated structured log line.
+
+    Table-primary, log-as-backstop: the row is the system of record; the log line is the
+    redundant correlated copy (carries request_id + participant_id via the Phase-1 factory),
+    so the event survives even if the row write fails.
+
+    Call AFTER the audited action has committed — so a rolled-back action leaves no audit row.
+
+    PRIVACY CONTRACT: `detail` and target_* may contain ONLY ids / enums / counts — never
+    statement text, vote values, usernames, xid, or any PII. The row is not redaction-filtered;
+    this contract is the control (enforced by tests).
+    """
+    actor = getattr(g.get('participant'), 'id', None)
+    try:
+        db.session.add(AuditEvent(
+            actor_participant_id=actor, conversation_id=conv_id, operation=operation,
+            target_type=target_type,
+            target_id=(str(target_id) if target_id is not None else None),
+            outcome=outcome, detail=detail))
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        current_app.logger.exception('audit write failed: %s', operation)
+    current_app.logger.info(
+        'audit %s', operation,
+        extra={'audit': True, 'operation': operation, 'conversation_id': conv_id,
+               'target_type': target_type, 'target_id': target_id, 'outcome': outcome})
 
 
 def create_app(test_config: dict | None = None) -> Flask:

--- a/v2/db.py
+++ b/v2/db.py
@@ -247,6 +247,37 @@ class ArgumentSideState(db.Model):
     featured_statement = db.relationship('FeaturedStatement')
 
 
+class AuditEvent(db.Model):
+    """Append-only accountability record (#135): who did what when, for admin/moderation
+    write actions. NEVER updated. Holds ids / enums / counts only — never statement text,
+    vote content, usernames, xid, or any PII (the writer's contract; see record_audit).
+
+    FKs use ON DELETE SET NULL (not CASCADE): the trail must outlive a deleted participant
+    or conversation — governance durability.
+    """
+    __tablename__ = 'audit_events'
+
+    id                   = db.Column(db.Integer, primary_key=True)
+    ts                   = db.Column(db.DateTime, nullable=False,
+                                     default=lambda: datetime.now(timezone.utc))
+    actor_participant_id = db.Column(db.Integer,
+                                     db.ForeignKey('participants.id', ondelete='SET NULL'),
+                                     nullable=True)
+    conversation_id      = db.Column(db.Integer,
+                                     db.ForeignKey('conversations.id', ondelete='SET NULL'),
+                                     nullable=True)
+    operation            = db.Column(db.String(64), nullable=False)
+    target_type          = db.Column(db.String(32), nullable=True)
+    target_id            = db.Column(db.String(64), nullable=True)
+    outcome              = db.Column(db.String(16), nullable=False, default='ok')
+    detail               = db.Column(db.JSON, nullable=False, default=dict)
+
+    __table_args__ = (
+        db.Index('ix_audit_events_conv_ts', 'conversation_id', 'ts'),
+        db.Index('ix_audit_events_actor_ts', 'actor_participant_id', 'ts'),
+    )
+
+
 # Explicit indexes — MySQL/MariaDB does not auto-index FK columns.
 # Cover the highest-volume lookup patterns in the argument mapping flow.
 db.Index('ix_participations_participant_id', Participation.participant_id)

--- a/v2/guide_logging.md
+++ b/v2/guide_logging.md
@@ -57,6 +57,27 @@ Flask's exception logs and pytest's `caplog`).
 - The startup fingerprint logs only the DB **scheme** (`make_url(...).drivername`) and
   booleans — never a URL with a password or any credential.
 
+## Audit events (#135)
+
+Admin/moderation **write** actions are recorded in the append-only `audit_events` table
+(durable governance trail) via `record_audit(...)`, which also emits a correlated
+`audit <operation>` log line.
+
+- **Call it after the action commits** — so a rolled-back action leaves no audit row.
+- **Privacy contract — ids / enums / counts ONLY.** Never put statement text, vote values,
+  usernames, `xid`, or any PII in `target_id` or `detail`. The audit *row* is not run through
+  the RedactingFormatter (that only scrubs the log line) — this discipline is the control, and
+  `tests/test_audit.py` enforces it. Reference participants by internal `participant_id`.
+- **Admin identity is recorded openly** (`actor_participant_id`): an admin acting in an official
+  capacity has a reduced expectation of privacy (privacy-statement disclosure #2). This is the
+  one place a name-resolvable id is deliberately retained long-term.
+
+Canonical operation names (keep stable; add here when you add a route):
+`conversation.create|edit|pause|close`, `phase.set`, `phase.advance`, `phase6.init`,
+`global_admin.grant|revoke`, `role.grant|revoke`, `invite.add|remove`,
+`statement.moderate|seed|seed_import`, `strict_moderation.set`,
+`featured.confirm|add|remove`, `argument.delete`.
+
 ## Adding a log statement — checklist
 
 1. Right level (table above)?

--- a/v2/logging_setup.py
+++ b/v2/logging_setup.py
@@ -52,7 +52,9 @@ def _redact(s: str) -> str:
 
 # Extra record attributes the JSON formatter surfaces as top-level fields when present.
 _JSON_EXTRA_FIELDS = ('http_method', 'http_path', 'http_status', 'duration_ms',
-                      'env', 'db_backend', 'polis_configured', 'polis_pg_configured', 'git_version')
+                      'env', 'db_backend', 'polis_configured', 'polis_pg_configured', 'git_version',
+                      # audit backstop fields (Plan 2) — so the log line carries the full event
+                      'operation', 'target_type', 'target_id', 'outcome', 'conversation_id')
 
 
 class RedactingJsonFormatter(logging.Formatter):

--- a/v2/migrations/versions/d2e3f4a5b6c7_add_audit_events.py
+++ b/v2/migrations/versions/d2e3f4a5b6c7_add_audit_events.py
@@ -1,0 +1,46 @@
+"""add audit_events table (#135)
+
+Revision ID: d2e3f4a5b6c7
+Revises: c1a2b3d4e5f6
+Create Date: 2026-06-11 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd2e3f4a5b6c7'
+down_revision = 'c1a2b3d4e5f6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Append-only accountability trail (#135). ON DELETE SET NULL so the record
+    # outlives a deleted participant/conversation.
+    op.create_table(
+        'audit_events',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('ts', sa.DateTime(), nullable=False),
+        sa.Column('actor_participant_id', sa.Integer(), nullable=True),
+        sa.Column('conversation_id', sa.Integer(), nullable=True),
+        sa.Column('operation', sa.String(length=64), nullable=False),
+        sa.Column('target_type', sa.String(length=32), nullable=True),
+        sa.Column('target_id', sa.String(length=64), nullable=True),
+        sa.Column('outcome', sa.String(length=16), nullable=False),
+        sa.Column('detail', sa.JSON(), nullable=False),
+        sa.ForeignKeyConstraint(['actor_participant_id'], ['participants.id'], ondelete='SET NULL'),
+        sa.ForeignKeyConstraint(['conversation_id'], ['conversations.id'], ondelete='SET NULL'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    with op.batch_alter_table('audit_events', schema=None) as batch_op:
+        batch_op.create_index('ix_audit_events_conv_ts', ['conversation_id', 'ts'])
+        batch_op.create_index('ix_audit_events_actor_ts', ['actor_participant_id', 'ts'])
+
+
+def downgrade():
+    with op.batch_alter_table('audit_events', schema=None) as batch_op:
+        batch_op.drop_index('ix_audit_events_actor_ts')
+        batch_op.drop_index('ix_audit_events_conv_ts')
+    op.drop_table('audit_events')

--- a/v2/tests/test_audit.py
+++ b/v2/tests/test_audit.py
@@ -78,20 +78,31 @@ def test_close_route_writes_audit_row(client, app):
 
 def test_audit_rows_carry_no_pii_or_content(client, app):
     """Drive routes whose inputs include statement text / usernames and assert none of
-    that ever reaches an audit row — only ids / enums / counts."""
-    pid = _login(client, app)
+    that ever reaches an audit row — only ids / enums / counts.
+
+    The Polis client is mocked so statement.seed actually reaches its record_audit call
+    (otherwise add_seed raises and no row is written — the assertion would be vacuous)."""
+    from unittest.mock import patch
+
+    _login(client, app)
     with app.app_context():
         conv = Conversation(slug='auditp', title='Audit P', active=True, polis_id='p2')
         db.session.add(conv)
         db.session.commit()
         conv_id = conv.id
     secret_text = 'THE QUICK BROWN FOX statement body'
-    # statement.seed posts statement text; global_admin.grant posts a username.
-    client.post(f'/admin/conversations/{conv_id}/statements/seed', data={'txt': secret_text})
+    with patch('app.PolisServerClient.add_seed'):          # seed path now commits a row
+        r = client.post(f'/admin/conversations/{conv_id}/statements/seed',
+                        data={'txt': secret_text})
+        assert r.status_code in (302, 303)
     client.post('/admin/global-admins/add', data={'mw_username': 'AdminUser'})
+
     with app.app_context():
+        ops = {row.operation for row in AuditEvent.query.all()}
+        assert 'statement.seed' in ops                     # the seed row WAS written (not vacuous)
+        assert 'global_admin.grant' in ops
         for row in AuditEvent.query.all():
             blob = f'{row.target_type} {row.target_id} {row.detail}'
-            assert secret_text not in blob
-            assert 'AdminUser' not in blob
-            assert 'f' * 64 not in blob                # xid never present
+            assert secret_text not in blob                 # statement text never stored
+            assert 'AdminUser' not in blob                 # username never stored
+            assert 'f' * 64 not in blob                    # xid never present

--- a/v2/tests/test_audit.py
+++ b/v2/tests/test_audit.py
@@ -1,0 +1,97 @@
+"""Phase 2 audit logging tests (#135).
+
+Covers: record_audit writes a correct append-only row + a correlated log line; real
+admin routes produce audit rows; and the load-bearing privacy contract — no statement
+text / username / xid ever lands in an audit row.
+"""
+import logging
+
+from db import AuditEvent, Conversation, Participant, db
+
+
+def _make_admin(app):
+    with app.app_context():
+        p = Participant(mw_user_id=99, mw_username='AdminUser', xid='f' * 64, is_global_admin=True)
+        db.session.add(p)
+        db.session.commit()
+        return p.id
+
+
+def _login(client, app):
+    pid = _make_admin(app)
+    with client.session_transaction() as s:
+        s['xid'] = 'f' * 64
+        s['username'] = 'AdminUser'
+    return pid
+
+
+# ── record_audit unit behaviour ─────────────────────────────────────────────
+
+def test_record_audit_writes_row_and_logs(app, caplog):
+    from app import record_audit
+    with app.test_request_context('/'):
+        from flask import g
+        g.request_id = 'rid-9'
+        with caplog.at_level(logging.INFO):
+            record_audit('conversation.close', conv_id=None, target_type='conversation',
+                         target_id=7, outcome='ok', note='x')
+        rows = AuditEvent.query.all()
+    assert len(rows) == 1
+    r = rows[0]
+    assert r.operation == 'conversation.close'
+    assert r.target_type == 'conversation'
+    assert r.target_id == '7'                       # coerced to str
+    assert r.outcome == 'ok'
+    assert r.detail == {'note': 'x'}
+    rec = [x for x in caplog.records if x.getMessage().startswith('audit ')]
+    assert rec and rec[0].operation == 'conversation.close'
+    assert rec[0].request_id == 'rid-9'             # correlated via the Phase-1 factory
+
+
+def test_audit_row_target_id_none_stays_none(app):
+    from app import record_audit
+    with app.test_request_context('/'):
+        record_audit('phase.set', conv_id=None)
+        rows = AuditEvent.query.all()
+    assert rows[0].target_id is None
+
+
+# ── A real admin route produces an audit row ────────────────────────────────
+
+def test_close_route_writes_audit_row(client, app):
+    pid = _login(client, app)
+    with app.app_context():
+        conv = Conversation(slug='auditc', title='Audit C', active=True, polis_id='p1')
+        db.session.add(conv)
+        db.session.commit()
+        conv_id = conv.id
+    r = client.post(f'/admin/conversations/{conv_id}/close')
+    assert r.status_code in (302, 303)
+    with app.app_context():
+        rows = AuditEvent.query.filter_by(operation='conversation.close').all()
+        assert len(rows) == 1
+        assert rows[0].conversation_id == conv_id
+        assert rows[0].actor_participant_id == pid     # the acting admin
+
+
+# ── Privacy contract: no content / PII in audit rows ────────────────────────
+
+def test_audit_rows_carry_no_pii_or_content(client, app):
+    """Drive routes whose inputs include statement text / usernames and assert none of
+    that ever reaches an audit row — only ids / enums / counts."""
+    pid = _login(client, app)
+    with app.app_context():
+        conv = Conversation(slug='auditp', title='Audit P', active=True, polis_id='p2')
+        db.session.add(conv)
+        db.session.commit()
+        conv_id = conv.id
+    secret_text = 'THE QUICK BROWN FOX statement body'
+    # statement.seed posts statement text; global_admin.grant posts a username.
+    client.post(f'/admin/conversations/{conv_id}/statements/seed', data={'txt': secret_text})
+    client.post('/admin/global-admins/add', data={'mw_username': 'AdminUser'})
+    with app.app_context():
+        for row in AuditEvent.query.all():
+            blob = f'{row.target_type} {row.target_id} {row.detail}'
+            assert secret_text not in blob
+            assert 'AdminUser' not in blob
+            assert 'f' * 64 not in blob                # xid never present


### PR DESCRIPTION
## Summary

Plan 2 of the logging architecture (design: `v2/.claude/plan-logging.md`). An **append-only "who did what when"** trail for the 21 admin/moderation write routes — the governance record Polis itself doesn't keep (its moderation is a destructive `UPDATE`).

**Stacked on [#198](https://github.com/lgelauff/wiki-polis/pull/198)** (Phase 1 logging foundation) — base is `feat/logging-phase1`; merge #198 first. Re-target to `main` once #198 lands.

- **`db.py`** — `AuditEvent` model: append-only (never updated), FKs `ON DELETE SET NULL` so the trail outlives deleted participants/conversations, indexed `(conversation_id, ts)` / `(actor_participant_id, ts)`.
- **migration `d2e3f4a5b6c7`** — creates `audit_events`, chains off `c1a2b3d4e5f6`.
- **`app.py`** — `record_audit()`: table-primary + correlated log backstop (rides Phase-1 request_id/participant_id); own commit **after** the action so a rollback leaves no row. Threaded into all 21 `@admin_bp.post` routes with a stable operation taxonomy. **Privacy contract: ids/enums/counts only** — never statement text, vote values, usernames, or xid. Admin actor id is recorded openly (reduced privacy expectation, privacy-statement disclosure #2).
- **`tests/test_audit.py`**, **`guide_logging.md`** (Audit events section), **`logging_setup.py`** (audit fields surfaced in the JSON backstop).

## Review

Plan was cross-reviewed before build; the implemented diff was reviewed by a database + security + senior-engineer panel → **GO**. Findings applied: fixed a vacuous no-PII test (now mocks the seed path so a real row is written and checked), explained NULL actor for env-admins (`actor_kind`), completed the JSON log backstop, guarded a no-op `invite.add`.

## Tested

**Automated (green):**
- Full suite **361 pass**, ruff clean (SQLite-in-memory, CI command). Because the test DB builds from the models, every existing admin-write test now also exercises `record_audit` without breakage.
- `test_audit.py`: row+log correlation (request_id), `target_id=None` stays NULL, a real route (`/close`) writes one row with correct actor/conversation, and the **no-PII contract** — *after the review fix* this mocks `add_seed` so `statement.seed` commits a real row, then asserts no statement text / username / xid in any row.
- **Migration round-trip** (`upgrade`/`downgrade`) verified via alembic op context on SQLite — table + both indexes created then dropped.

**Not yet tested (carry-forward):**
- **MySQL** specifically — tests are SQLite. Post-deploy, run `SHOW CREATE TABLE audit_events` on prod MySQL to confirm `ON DELETE SET NULL` materialized (MySQL silently degrades FKs on non-InnoDB; both PKs are InnoDB, so expected fine).
- **Live staging** — no audit row observed against the real backend yet. Recommend `staging-chrome-test` after deploy: do a moderation + a close, confirm an `audit_events` row and a correlated `audit …` JSON line in `uwsgi.log`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)