### PR TITLE
feat(#143): statement provenance — capture derivative links + similarity scores

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -2017,11 +2017,20 @@ def admin_statement_seed(conv_id):
     derived_from = request.form.get('derived_from', type=int)
     try:
         if derived_from is not None:
+            # Validate the parent is a real statement in THIS conversation before recording a
+            # link — a typo'd / cross-conversation tid would otherwise store a bogus link.
+            text_map = _statement_text_map(conv.polis_id)
+            if derived_from not in text_map:
+                flash(f'Statement #{derived_from} was not found in this conversation — '
+                      'fix the "corrects" number and try again. Nothing was added.', 'error')
+                return redirect(url_for('admin.admin_conversation_statements', conv_id=conv_id))
             new_tid = _polis_server_client().add_seed_return_id(conv.polis_id, text)
-            parent_text = _fetch_statement_text(conv.polis_id, derived_from)
-            record_statement_provenance(conv_id, new_tid, derived_from,
-                                        parent_text=parent_text, new_text=text)
-            flash(f'Seed statement added (recorded as a correction of #{derived_from}).', 'success')
+            prov = record_statement_provenance(conv_id, new_tid, derived_from,
+                                               parent_text=text_map.get(derived_from), new_text=text)
+            if prov is None:
+                flash('Seed statement added, but the correction link could not be recorded.', 'warning')
+            else:
+                flash(f'Seed statement added (recorded as a correction of #{derived_from}).', 'success')
             record_audit('statement.seed', conv_id=conv_id, target_type='statement',
                          target_id=new_tid, derived_from=derived_from)
         else:

--- a/v2/app.py
+++ b/v2/app.py
@@ -36,7 +36,7 @@ from wtforms.validators import ValidationError
 
 from db import (ACCESS_POLICIES, ADMIN_ROLES, AdminRole, Argument, ArgumentSideState,
                 ArgumentVote, AuditEvent, Conversation, ConversationInvite, FeaturedStatement,
-                Participant, Participation, db)
+                Participant, Participation, StatementProvenance, StatementSimilarityScore, db)
 from polis_admin import (PolisParticipantClient, PolisParticipantError,
                          PolisServerClient, PolisServerError)
 from seed_csv import MAX_FILE_BYTES, MAX_ROWS, parse_csv_bytes, strip_formula_prefixes
@@ -1955,6 +1955,9 @@ def admin_conversation_statements(conv_id):
         fs.polis_statement_id
         for fs in FeaturedStatement.query.filter_by(conversation_id=conv_id).all()
     }
+    # Provenance (#143): which listed statements are recorded derivatives → {tid: row}.
+    all_tids = [s['tid'] for s in (list(pending) + list(approved) + list(hidden))]
+    provenance_map = _provenance_map(conv_id, all_tids)
     return render_template('admin_statements.html',
                            conversation=conv,
                            pending=pending,
@@ -1962,6 +1965,7 @@ def admin_conversation_statements(conv_id):
                            hidden=hidden,
                            settings=settings,
                            featured_tids=featured_tids,
+                           provenance_map=provenance_map,
                            phase_active=conv.phase_argument_mapping,
                            polis_public_url=current_app.config.get('POLIS_PUBLIC_URL') or 'https://pol.is',
                            max_import_rows=MAX_ROWS,
@@ -2008,10 +2012,22 @@ def admin_statement_seed(conv_id):
     text = nh3.clean(text, tags=frozenset())
     if not text or len(text) > 280:
         abort(400)
+    # Optional provenance (#143): the tid this statement corrects/derives from. When set,
+    # we need the NEW statement's tid back, so seed via add_seed_return_id and record the link.
+    derived_from = request.form.get('derived_from', type=int)
     try:
-        _polis_server_client().add_seed(conv.polis_id, text)
-        flash('Seed statement added.', 'success')
-        record_audit('statement.seed', conv_id=conv_id)   # no text (statement content)
+        if derived_from is not None:
+            new_tid = _polis_server_client().add_seed_return_id(conv.polis_id, text)
+            parent_text = _fetch_statement_text(conv.polis_id, derived_from)
+            record_statement_provenance(conv_id, new_tid, derived_from,
+                                        parent_text=parent_text, new_text=text)
+            flash(f'Seed statement added (recorded as a correction of #{derived_from}).', 'success')
+            record_audit('statement.seed', conv_id=conv_id, target_type='statement',
+                         target_id=new_tid, derived_from=derived_from)
+        else:
+            _polis_server_client().add_seed(conv.polis_id, text)
+            flash('Seed statement added.', 'success')
+            record_audit('statement.seed', conv_id=conv_id)   # no text (statement content)
     except PolisServerError:
         current_app.logger.exception('add_seed failed')
         flash('Could not add seed statement. Check server logs for details.', 'error')
@@ -2831,6 +2847,97 @@ def record_audit(operation, *, conv_id=None, target_type=None, target_id=None,
         'audit %s', operation,
         extra={'audit': True, 'operation': operation, 'conversation_id': conv_id,
                'target_type': target_type, 'target_id': target_id, 'outcome': outcome})
+
+
+def _char_similarity(new_text, parent_text):
+    """Cheap, always-available character-level similarity (stdlib difflib; no dependency,
+    language-agnostic). 1.0 = identical, 0.0 = no overlap."""
+    import difflib
+    return round(difflib.SequenceMatcher(None, parent_text or '', new_text or '').ratio(), 4)
+
+
+def _semantic_similarity(new_text, parent_text):
+    """Seam for #207: multilingual sentence-embedding similarity. Returns None until #207
+    supplies a model — wiring it here adds the 'semantic' score with no schema/flow change.
+
+    #207 implements this by POSTing both texts to the embedding sidecar (#208, FastAPI +
+    paraphrase-multilingual-MiniLM) and returning its **cosine similarity** directly (the
+    standard metric; every scorer here returns similarity, higher = more similar). Keep it
+    best-effort: a short-timeout synchronous call that returns None on timeout/sidecar-down,
+    so the 'char' score still records and the seed never blocks.
+    """
+    return None
+
+
+# Similarity-at-creation scorers (#143/#207). Each: (new_text, parent_text) -> float | None
+# in [0, 1], higher = more similar. Best-effort — a scorer returning None or raising is
+# skipped. The 'char' fallback ships working now; #207 fills in 'semantic' (cosine).
+_SIMILARITY_SCORERS = {'char': _char_similarity, 'semantic': _semantic_similarity}
+
+
+def record_statement_provenance(conv_id, new_tid, derived_from_tid,
+                                parent_text=None, new_text=None):
+    """Record that `new_tid` is a derivative of `derived_from_tid` (#143), best-effort.
+
+    Writes one StatementProvenance row (declared link) plus a StatementSimilarityScore row
+    per scorer that yields a value. A scorer failure never blocks the link; a provenance
+    write failure is swallowed (logged). Returns the row, or None on failure.
+    """
+    try:
+        row = StatementProvenance(
+            conversation_id=conv_id, polis_statement_id=new_tid,
+            derived_from_tid=derived_from_tid, provenance_type='derivative',
+            link_method='declared')
+        db.session.add(row)
+        db.session.flush()        # need row.id for the score FKs
+        if parent_text is not None and new_text is not None:
+            for name, fn in _SIMILARITY_SCORERS.items():
+                try:
+                    value = fn(new_text, parent_text)
+                except Exception:
+                    current_app.logger.exception('similarity scorer %s failed for tid %s', name, new_tid)
+                    continue
+                if value is not None:
+                    db.session.add(StatementSimilarityScore(
+                        provenance_id=row.id, model=name, value=value))
+        db.session.commit()
+        return row
+    except Exception:
+        db.session.rollback()
+        current_app.logger.exception('provenance write failed for tid %s', new_tid)
+        return None
+
+
+def _provenance_map(conv_id, tids):
+    """{tid: StatementProvenance} for the given tids in one query (bulk, like the other maps)."""
+    tids = [t for t in tids if t is not None]
+    if not tids:
+        return {}
+    rows = (StatementProvenance.query
+            .options(joinedload(StatementProvenance.scores))
+            .filter(StatementProvenance.conversation_id == conv_id,
+                    StatementProvenance.polis_statement_id.in_(tids))
+            .all())
+    return {r.polis_statement_id: r for r in rows}
+
+
+def _lineage_group(conv_id, tid):
+    """Walk `derived_from_tid` from `tid` up to its root; return [tid, parent, …, root].
+
+    The primitive the clustering/weighting consumers (#143 follow-ups) build on. Cycle-safe.
+    """
+    by_tid = {r.polis_statement_id: r.derived_from_tid
+              for r in StatementProvenance.query.filter_by(conversation_id=conv_id).all()}
+    chain, seen = [tid], {tid}
+    cur = tid
+    while cur in by_tid:
+        parent = by_tid[cur]
+        if parent in seen:          # defensive: stop on any cycle
+            break
+        chain.append(parent)
+        seen.add(parent)
+        cur = parent
+    return chain
 
 
 def create_app(test_config: dict | None = None) -> Flask:

--- a/v2/db.py
+++ b/v2/db.py
@@ -278,6 +278,69 @@ class AuditEvent(db.Model):
     )
 
 
+class StatementProvenance(db.Model):
+    """Records that a statement is a *derivative* of an existing one (#143).
+
+    wiki-polis has no general statement table — statements live in Polis (`comments`),
+    keyed by a Polis statement id (`tid`). So provenance lives here, keyed by
+    (conversation_id, polis_statement_id of the NEW statement). Absence of a row = `new`
+    (the default); a row exists only for derivatives.
+
+    `derived_from_tid` is a parent pointer, so derivatives form a chain/tree that the
+    clustering/weighting consumers resolve into lineage groups (see _lineage_group).
+
+    Similarity-at-creation scores live in the related StatementSimilarityScore rows — one
+    per metric (e.g. a cheap 'char' fallback now, a 'semantic' model from #207 later), so a
+    link can carry several kinds of score without a schema change.
+    """
+    __tablename__ = 'statement_provenance'
+
+    id                 = db.Column(db.Integer, primary_key=True)
+    conversation_id    = db.Column(db.Integer,
+                                   db.ForeignKey('conversations.id', ondelete='CASCADE'),
+                                   nullable=False)
+    polis_statement_id = db.Column(db.Integer, nullable=False)   # the NEW (derivative) tid
+    derived_from_tid   = db.Column(db.Integer, nullable=False)   # the parent it improves on
+    provenance_type    = db.Column(db.String(16), nullable=False, default='derivative')  # new|derivative
+    link_method        = db.Column(db.String(16), nullable=False, default='declared')    # declared|detected
+    created_at         = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+
+    scores = db.relationship('StatementSimilarityScore', back_populates='provenance',
+                             cascade='all, delete-orphan')
+
+    __table_args__ = (
+        db.UniqueConstraint('conversation_id', 'polis_statement_id',
+                            name='uq_statement_provenance_conv_tid'),
+        db.Index('ix_statement_provenance_conv', 'conversation_id'),
+    )
+
+
+class StatementSimilarityScore(db.Model):
+    """One similarity-at-creation score for a provenance link (#143/#207).
+
+    Several kinds coexist — a cheap always-available `char` fallback and a `semantic`
+    model score (#207) — so consumers can prefer semantic when present and fall back to
+    char. `model` names the scorer/version; `value` is a similarity in [0, 1], **higher =
+    more similar** (cosine similarity is the standard metric). Unique per (provenance,
+    model) so re-scoring a metric replaces rather than duplicates.
+    """
+    __tablename__ = 'statement_similarity_scores'
+
+    id            = db.Column(db.Integer, primary_key=True)
+    provenance_id = db.Column(db.Integer,
+                              db.ForeignKey('statement_provenance.id', ondelete='CASCADE'),
+                              nullable=False)
+    model         = db.Column(db.String(64), nullable=False)   # scorer name/version, e.g. 'char', 'semantic-v1'
+    value         = db.Column(db.Float, nullable=False)        # similarity, higher = more similar
+    scored_at     = db.Column(db.DateTime, default=lambda: datetime.now(timezone.utc))
+
+    provenance = db.relationship('StatementProvenance', back_populates='scores')
+
+    __table_args__ = (
+        db.UniqueConstraint('provenance_id', 'model', name='uq_similarity_score_prov_model'),
+    )
+
+
 # Explicit indexes — MySQL/MariaDB does not auto-index FK columns.
 # Cover the highest-volume lookup patterns in the argument mapping flow.
 db.Index('ix_participations_participant_id', Participation.participant_id)

--- a/v2/db.py
+++ b/v2/db.py
@@ -309,9 +309,10 @@ class StatementProvenance(db.Model):
                              cascade='all, delete-orphan')
 
     __table_args__ = (
+        # The composite unique also serves conversation_id-only lookups (leading column),
+        # so no standalone conversation_id index is needed.
         db.UniqueConstraint('conversation_id', 'polis_statement_id',
                             name='uq_statement_provenance_conv_tid'),
-        db.Index('ix_statement_provenance_conv', 'conversation_id'),
     )
 
 

--- a/v2/guide_organizer.md
+++ b/v2/guide_organizer.md
@@ -142,6 +142,23 @@ This seeds statements the same way the manual "add statement" form does; everyth
 [*Writing good statements*](#3-writing-good-statements) above still applies — the limits
 are deliberately low because a good seed set is ~10–15 statements, not hundreds.
 
+### Recording a correction (statement provenance)
+
+Moderators **cannot edit** an existing statement's text ([#142]); the workflow is to **hide**
+the original and **add a corrected version**. When you do, the "Add seed statement" form has an
+optional **"Corrects statement # (optional)"** field — enter the `#id` of the statement you're
+replacing. This records that the new statement is a *derivative* of the original (#143).
+
+Today this is just captured (and shown as a small `↳ #id` note next to the statement in the admin
+list, with a cheap text-similarity score, so you can verify it landed). Future work will use these
+links to cluster a statement with its derivatives and avoid over-representing the same idea in the
+presented set, and to estimate how *semantically similar* a "correction" is to the original ([#207]).
+Leave the field blank for a genuinely new statement.
+
+[#142]: https://github.com/lgelauff/wiki-polis/issues/142
+[#143]: https://github.com/lgelauff/wiki-polis/issues/143
+[#207]: https://github.com/lgelauff/wiki-polis/issues/207
+
 ## 4. Open submission and moderate
 
 Once open, participants vote and propose statements. **How strict should moderation be?**

--- a/v2/migrations/versions/e3f4a5b6c7d8_add_statement_provenance.py
+++ b/v2/migrations/versions/e3f4a5b6c7d8_add_statement_provenance.py
@@ -32,8 +32,6 @@ def upgrade():
         sa.UniqueConstraint('conversation_id', 'polis_statement_id',
                             name='uq_statement_provenance_conv_tid'),
     )
-    with op.batch_alter_table('statement_provenance', schema=None) as batch_op:
-        batch_op.create_index('ix_statement_provenance_conv', ['conversation_id'])
 
     # Similarity-at-creation scores — many kinds per link (char fallback now, semantic #207 later).
     op.create_table(
@@ -51,6 +49,4 @@ def upgrade():
 
 def downgrade():
     op.drop_table('statement_similarity_scores')
-    with op.batch_alter_table('statement_provenance', schema=None) as batch_op:
-        batch_op.drop_index('ix_statement_provenance_conv')
     op.drop_table('statement_provenance')

--- a/v2/migrations/versions/e3f4a5b6c7d8_add_statement_provenance.py
+++ b/v2/migrations/versions/e3f4a5b6c7d8_add_statement_provenance.py
@@ -1,0 +1,56 @@
+"""add statement_provenance table (#143)
+
+Revision ID: e3f4a5b6c7d8
+Revises: d2e3f4a5b6c7
+Create Date: 2026-06-12 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e3f4a5b6c7d8'
+down_revision = 'd2e3f4a5b6c7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Provenance for derivative statements (#143). One row per derivative; absence = 'new'.
+    op.create_table(
+        'statement_provenance',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('conversation_id', sa.Integer(), nullable=False),
+        sa.Column('polis_statement_id', sa.Integer(), nullable=False),
+        sa.Column('derived_from_tid', sa.Integer(), nullable=False),
+        sa.Column('provenance_type', sa.String(length=16), nullable=False),
+        sa.Column('link_method', sa.String(length=16), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['conversation_id'], ['conversations.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('conversation_id', 'polis_statement_id',
+                            name='uq_statement_provenance_conv_tid'),
+    )
+    with op.batch_alter_table('statement_provenance', schema=None) as batch_op:
+        batch_op.create_index('ix_statement_provenance_conv', ['conversation_id'])
+
+    # Similarity-at-creation scores — many kinds per link (char fallback now, semantic #207 later).
+    op.create_table(
+        'statement_similarity_scores',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('provenance_id', sa.Integer(), nullable=False),
+        sa.Column('model', sa.String(length=64), nullable=False),
+        sa.Column('value', sa.Float(), nullable=False),
+        sa.Column('scored_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['provenance_id'], ['statement_provenance.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('provenance_id', 'model', name='uq_similarity_score_prov_model'),
+    )
+
+
+def downgrade():
+    op.drop_table('statement_similarity_scores')
+    with op.batch_alter_table('statement_provenance', schema=None) as batch_op:
+        batch_op.drop_index('ix_statement_provenance_conv')
+    op.drop_table('statement_provenance')

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -3851,3 +3851,16 @@ a { color: var(--pass); }
   color: var(--muted);
   border-color: var(--hairline);
 }
+
+/* Statement provenance badge (#143) — marks a recorded derivative in the admin view. */
+.prov-badge {
+  display: inline-block;
+  font-size: 11px;
+  color: var(--spot, #b45309);
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid var(--hairline);
+  border-radius: 4px;
+  padding: 0 5px;
+  margin-top: 2px;
+  white-space: nowrap;
+}

--- a/v2/templates/admin_statements.html
+++ b/v2/templates/admin_statements.html
@@ -30,6 +30,11 @@
         <textarea name="txt" rows="3" maxlength="280" id="seed-txt" required
                   placeholder="Enter a statement participants will vote on…"></textarea>
       </label>
+      <label class="muted" style="display:block;margin-top:.5rem;font-size:13px">
+        Corrects statement&nbsp;#&nbsp;(optional)
+        <input type="number" name="derived_from" min="0" style="width:6rem"
+               title="If this is a corrected/derived version of an existing statement, enter its #id so the link is recorded (#143).">
+      </label>
       <div style="display:flex;align-items:center;gap:1rem;margin-top:.5rem">
         <button type="submit">Add seed statement</button>
         <span id="seed-count" class="muted" style="font-size:12px">0 / 280</span>
@@ -116,7 +121,9 @@
       {% set is_featured = s.tid in featured_tids %}
       {% set is_last_featured = is_featured and (featured_tids | length == 1) %}
       <tr>
-        <td class="muted">{{ s.tid }}{% if is_featured %} ★{% endif %}</td>
+        <td class="muted">{{ s.tid }}{% if is_featured %} ★{% endif %}
+          {%- set prov = provenance_map.get(s.tid) %}
+          {%- if prov %}<br><span class="prov-badge" title="Recorded as derived from #{{ prov.derived_from_tid }}">↳ #{{ prov.derived_from_tid }}{% for sc in prov.scores %} · {{ sc.model }}&nbsp;{{ '%.2f'|format(sc.value) }}{% endfor %}</span>{% endif %}</td>
         <td class="stmt-text">{{ s.txt }}</td>
         <td class="stmt-votes muted">
           +{{ s.agree_count or 0 }}
@@ -166,7 +173,9 @@
       {% set is_featured = s.tid in featured_tids %}
       {% set is_last_featured = is_featured and (featured_tids | length == 1) %}
       <tr>
-        <td class="muted">{{ s.tid }}{% if is_featured %} ★{% endif %}</td>
+        <td class="muted">{{ s.tid }}{% if is_featured %} ★{% endif %}
+          {%- set prov = provenance_map.get(s.tid) %}
+          {%- if prov %}<br><span class="prov-badge" title="Recorded as derived from #{{ prov.derived_from_tid }}">↳ #{{ prov.derived_from_tid }}{% for sc in prov.scores %} · {{ sc.model }}&nbsp;{{ '%.2f'|format(sc.value) }}{% endfor %}</span>{% endif %}</td>
         <td class="stmt-text">{{ s.txt }}</td>
         <td class="stmt-votes muted">
           +{{ s.agree_count or 0 }}

--- a/v2/templates/admin_statements.html
+++ b/v2/templates/admin_statements.html
@@ -123,7 +123,9 @@
       <tr>
         <td class="muted">{{ s.tid }}{% if is_featured %} ★{% endif %}
           {%- set prov = provenance_map.get(s.tid) %}
-          {%- if prov %}<br><span class="prov-badge" title="Recorded as derived from #{{ prov.derived_from_tid }}">↳ #{{ prov.derived_from_tid }}{% for sc in prov.scores %} · {{ sc.model }}&nbsp;{{ '%.2f'|format(sc.value) }}{% endfor %}</span>{% endif %}</td>
+          {%- if prov %}<br><span class="prov-badge"
+                title="Derived from statement #{{ prov.derived_from_tid }}. Similarity 1.00 = identical.{% for sc in prov.scores %} {{ sc.model }} {{ '%.2f'|format(sc.value) }}.{% endfor %}">
+            <span class="sr-only">derived from statement {{ prov.derived_from_tid }}, </span>↳ #{{ prov.derived_from_tid }}{% for sc in prov.scores %} · {{ sc.model }}&nbsp;{{ '%.2f'|format(sc.value) }}{% endfor %}</span>{% endif %}</td>
         <td class="stmt-text">{{ s.txt }}</td>
         <td class="stmt-votes muted">
           +{{ s.agree_count or 0 }}
@@ -175,7 +177,9 @@
       <tr>
         <td class="muted">{{ s.tid }}{% if is_featured %} ★{% endif %}
           {%- set prov = provenance_map.get(s.tid) %}
-          {%- if prov %}<br><span class="prov-badge" title="Recorded as derived from #{{ prov.derived_from_tid }}">↳ #{{ prov.derived_from_tid }}{% for sc in prov.scores %} · {{ sc.model }}&nbsp;{{ '%.2f'|format(sc.value) }}{% endfor %}</span>{% endif %}</td>
+          {%- if prov %}<br><span class="prov-badge"
+                title="Derived from statement #{{ prov.derived_from_tid }}. Similarity 1.00 = identical.{% for sc in prov.scores %} {{ sc.model }} {{ '%.2f'|format(sc.value) }}.{% endfor %}">
+            <span class="sr-only">derived from statement {{ prov.derived_from_tid }}, </span>↳ #{{ prov.derived_from_tid }}{% for sc in prov.scores %} · {{ sc.model }}&nbsp;{{ '%.2f'|format(sc.value) }}{% endfor %}</span>{% endif %}</td>
         <td class="stmt-text">{{ s.txt }}</td>
         <td class="stmt-votes muted">
           +{{ s.agree_count or 0 }}

--- a/v2/tests/test_provenance.py
+++ b/v2/tests/test_provenance.py
@@ -1,0 +1,124 @@
+"""#143 statement provenance — capture + lineage resolver (the socket + stub).
+
+Covers: a derivative seed writes a provenance row keyed by the NEW tid; the distance
+scorer is best-effort (stub None, and a raising scorer still commits the link); the
+lineage resolver walks a chain to its root; and the audit detail carries derived_from.
+"""
+import logging
+
+from db import Conversation, Participant, StatementProvenance, db
+
+
+def _login_admin(client, app):
+    with app.app_context():
+        p = Participant(mw_user_id=7, mw_username='Mod', xid='a' * 64, is_global_admin=True)
+        db.session.add(p)
+        db.session.commit()
+    with client.session_transaction() as s:
+        s['xid'] = 'a' * 64
+        s['username'] = 'Mod'
+
+
+def _conv(app, slug='provc'):
+    with app.app_context():
+        c = Conversation(slug=slug, title='Prov', active=True, polis_id='pz')
+        db.session.add(c)
+        db.session.commit()
+        return c.id
+
+
+# ── record_statement_provenance / helpers ───────────────────────────────────
+
+def test_record_provenance_writes_row_with_char_score(app):
+    from app import record_statement_provenance
+    conv_id = _conv(app)
+    with app.app_context():
+        # No texts → link recorded, but no scores computed.
+        row = record_statement_provenance(conv_id, new_tid=20, derived_from_tid=11)
+        assert row is not None
+        got = StatementProvenance.query.filter_by(conversation_id=conv_id,
+                                                  polis_statement_id=20).one()
+        assert got.derived_from_tid == 11
+        assert got.provenance_type == 'derivative'
+        assert got.link_method == 'declared'
+        assert got.scores == []
+        # With texts → the always-available 'char' similarity is written; 'semantic' (stub) is not.
+        record_statement_provenance(conv_id, 21, 11, parent_text='the cat sat', new_text='the cat sat down')
+        r = StatementProvenance.query.filter_by(conversation_id=conv_id, polis_statement_id=21).one()
+        models = {s.model: s.value for s in r.scores}
+        assert 'char' in models and 0.0 <= models['char'] <= 1.0   # similarity, higher = more similar
+        assert 'semantic' not in models             # #207 stub returns None → no row
+
+
+def test_distance_scorers_best_effort(app, monkeypatch):
+    import app as appmod
+    from app import record_statement_provenance
+    conv_id = _conv(app, 'provd')
+    # A working 'semantic' scorer (simulating #207) adds a second score alongside 'char'.
+    monkeypatch.setitem(appmod._SIMILARITY_SCORERS, 'semantic', lambda a, b: 0.25)
+    with app.app_context():
+        record_statement_provenance(conv_id, 30, 12, parent_text='p', new_text='n')
+        r = StatementProvenance.query.filter_by(conversation_id=conv_id, polis_statement_id=30).one()
+        models = {s.model: s.value for s in r.scores}
+        assert models.get('semantic') == 0.25 and 'char' in models   # multiple kinds coexist
+    # A raising scorer must NOT block the link or the other scores.
+    monkeypatch.setitem(appmod._SIMILARITY_SCORERS, 'semantic',
+                        lambda a, b: (_ for _ in ()).throw(RuntimeError('boom')))
+    with app.app_context():
+        row = record_statement_provenance(conv_id, 31, 12, parent_text='p', new_text='n')
+        assert row is not None
+        r = StatementProvenance.query.filter_by(conversation_id=conv_id, polis_statement_id=31).one()
+        models = {s.model for s in r.scores}
+        assert 'char' in models and 'semantic' not in models   # char still recorded, semantic skipped
+
+
+def test_lineage_group_walks_to_root(app):
+    from app import _lineage_group, record_statement_provenance
+    conv_id = _conv(app, 'provl')
+    with app.app_context():
+        record_statement_provenance(conv_id, 3, 2)   # 3 derived from 2
+        record_statement_provenance(conv_id, 2, 1)   # 2 derived from 1 (root)
+        assert _lineage_group(conv_id, 3) == [3, 2, 1]
+        assert _lineage_group(conv_id, 1) == [1]     # a root resolves to itself
+
+
+def test_lineage_group_cycle_safe(app):
+    from app import _lineage_group, record_statement_provenance
+    conv_id = _conv(app, 'provcyc')
+    with app.app_context():
+        record_statement_provenance(conv_id, 5, 6)
+        record_statement_provenance(conv_id, 6, 5)   # cycle
+        chain = _lineage_group(conv_id, 5)
+        assert chain[0] == 5 and len(chain) <= 3     # terminates, no infinite loop
+
+
+# ── Seed route writes provenance + audit when derived_from is given ──────────
+
+def test_seed_derivative_route_records_provenance_and_audit(client, app):
+    from unittest.mock import patch
+
+    from db import AuditEvent
+    _login_admin(client, app)
+    conv_id = _conv(app, 'provseed')
+    with patch('app.PolisServerClient.add_seed_return_id', return_value=99) as add_id, \
+         patch('app._fetch_statement_text', return_value='parent text'):
+        r = client.post(f'/admin/conversations/{conv_id}/statements/seed',
+                        data={'txt': 'a corrected statement', 'derived_from': '11'})
+    assert r.status_code in (302, 303)
+    add_id.assert_called_once()                       # used the id-returning seed
+    with app.app_context():
+        prov = StatementProvenance.query.filter_by(conversation_id=conv_id, polis_statement_id=99).one()
+        assert prov.derived_from_tid == 11
+        audit = AuditEvent.query.filter_by(operation='statement.seed').all()
+        assert audit and audit[0].detail.get('derived_from') == 11
+        assert audit[0].target_id == '99'
+
+
+def test_plain_seed_route_writes_no_provenance(client, app):
+    from unittest.mock import patch
+    _login_admin(client, app)
+    conv_id = _conv(app, 'provplain')
+    with patch('app.PolisServerClient.add_seed'):
+        client.post(f'/admin/conversations/{conv_id}/statements/seed', data={'txt': 'just a new one'})
+    with app.app_context():
+        assert StatementProvenance.query.filter_by(conversation_id=conv_id).count() == 0

--- a/v2/tests/test_provenance.py
+++ b/v2/tests/test_provenance.py
@@ -101,7 +101,7 @@ def test_seed_derivative_route_records_provenance_and_audit(client, app):
     _login_admin(client, app)
     conv_id = _conv(app, 'provseed')
     with patch('app.PolisServerClient.add_seed_return_id', return_value=99) as add_id, \
-         patch('app._fetch_statement_text', return_value='parent text'):
+         patch('app._statement_text_map', return_value={11: 'parent text'}):
         r = client.post(f'/admin/conversations/{conv_id}/statements/seed',
                         data={'txt': 'a corrected statement', 'derived_from': '11'})
     assert r.status_code in (302, 303)
@@ -112,6 +112,20 @@ def test_seed_derivative_route_records_provenance_and_audit(client, app):
         audit = AuditEvent.query.filter_by(operation='statement.seed').all()
         assert audit and audit[0].detail.get('derived_from') == 11
         assert audit[0].target_id == '99'
+
+
+def test_seed_derivative_unknown_tid_is_rejected(client, app):
+    """A derived_from tid not in this conversation → reject, seed nothing, record nothing."""
+    from unittest.mock import patch
+    _login_admin(client, app)
+    conv_id = _conv(app, 'provbad')
+    with patch('app._statement_text_map', return_value={5: 'a real one'}), \
+         patch('app.PolisServerClient.add_seed_return_id') as add_id:
+        client.post(f'/admin/conversations/{conv_id}/statements/seed',
+                    data={'txt': 'x', 'derived_from': '999'})
+    add_id.assert_not_called()                        # nothing seeded
+    with app.app_context():
+        assert StatementProvenance.query.filter_by(conversation_id=conv_id).count() == 0
 
 
 def test_plain_seed_route_writes_no_provenance(client, app):


### PR DESCRIPTION
## Summary

Records that a statement is a **derivative** of an existing one (#143), so downstream work can cluster/weight lineages and estimate drift. This is **capture + plumbing**, not display: it lays the socket that #207 (semantic distance) and #208 (embedding sidecar) plug into.

Statements live in Polis (`comments`), so provenance lives in our DB keyed by `(conversation_id, polis tid)`; absence of a row = `new`.

- **`db.py`** — `StatementProvenance` (parent-pointer `derived_from_tid`; `link_method` declared|detected) + `StatementSimilarityScore` side table — **many named scores per link** (a cheap `char` fallback now, a `semantic` model from #207 later), `value` in [0,1], **higher = more similar** (cosine is the standard metric). FKs `ON DELETE CASCADE`.
- **migration `e3f4a5b6c7d8`** — both tables; round-trips up/down.
- **`app.py`** — a `_SIMILARITY_SCORERS` registry: `char` (stdlib `difflib`, no dep, ships working) + `semantic` (a `None` stub #207 fills by calling sidecar #208 and returning cosine directly). Each scorer is **best-effort** (None/raise → skipped, never blocks the seed). `record_statement_provenance` writes the link + a score row per scorer. `_provenance_map` (bulk, eager-loads scores) + `_lineage_group` (walks to root, cycle-safe) are the resolver primitives for the consumer issues. The seed route takes an optional `derived_from` → **validates it's a real tid in this conversation** → seeds via `add_seed_return_id`, records the link, audits with `derived_from`.
- **`admin_statements.html`** — optional "Corrects statement #" field + a `↳ #id · char 0.60` badge (sr-only + explanatory title); `style.css` `.prov-badge`. **`guide_organizer.md`** — provenance section.

Relates to #207 (semantic scorer) and #208 (embedding sidecar); both slot into the `semantic` seam with no schema/flow change.

## Review

Reviewed by a database + security + senior-engineer + accessibility panel → **GO**. Findings applied: `derived_from` validation (reject unknown/typo'd tid), badge a11y (sr-only + explanatory title), honest flash on write failure, dropped a redundant index.

## Tested

- **368 tests pass**, ruff clean.
- `tests/test_provenance.py`: link capture, `char` score written / `semantic` stub skipped, multiple scores coexist, a raising scorer doesn't block the others, lineage resolver (incl. a cycle), the derivative-seed route writes provenance + audit, an **unknown `derived_from` is rejected**, and a plain seed writes nothing.
- Migration round-trips (both tables) on SQLite.

**Not yet tested (carry-forward):**
- **MySQL** — deploy with `--migrate`; confirm `SHOW CREATE TABLE` shows the `ON DELETE CASCADE` FKs on InnoDB.
- **Live staging** — hide a statement, add a correction, confirm a provenance row + `char` score + the badge, and that an unknown tid is rejected. Recommend `staging-chrome-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)