### PR TITLE
feat(#246): conversation-scoped participant identity (no cross-conversation chain)

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -906,9 +906,27 @@ def _validate_fetch_csrf():
         abort(400)
 
 
-def _proxy_to_particiapi(pa_path: str):
+def _conversation_subject(xid: str, conv) -> str:
+    """Conversation-scoped participant subject for Particiapi's trusted-sub binding.
+
+    Keyed by the **wiki-polis conversation id** so the same person resolves to the same
+    Polis uid across devices *within* one conversation, but to a **different** uid in a
+    different conversation — no cross-conversation linkage chain (#246). Using ``conv.id``
+    (not the Polis zinvite) keeps it stable across the conversation's Phase-2 and Phase-6
+    rounds, so an individual's initial and informed votes share one uid.
+    """
+    secret = current_app.config.get('PARTICIAPI_SUB_SECRET') or current_app.config['SECRET_KEY']
+    return hmac.new(str(secret).encode(), f'{xid}:{conv.id}'.encode(), hashlib.sha256).hexdigest()
+
+
+def _proxy_to_particiapi(pa_path: str, conv=None):
     """
     Proxy a browser request to Particiapi and return the response.
+
+    When ``conv`` is given (the per-conversation proxy route), the asserted identity is
+    **conversation-scoped** and the ``pa_session`` cookie is **path-scoped to that
+    conversation**, so each conversation gets its own session/uid (no cross-conversation
+    chain). The legacy unscoped route passes ``conv=None`` (bare-xid subject, root cookie).
 
     Browser ↔ Flask proxy ↔ Particiapi:
     - The browser stores a 'pa_session' cookie (Particiapi's session, renamed to
@@ -938,8 +956,11 @@ def _proxy_to_particiapi(pa_path: str):
     # they keep the same Polis uid across devices instead of a new anonymous uid each
     # session. Scoped to POST /api/session only — Particiapi consults the headers
     # nowhere else, so sending the secret on other requests is pure exposure surplus.
-    _sub = session.get('xid')
+    _xid = session.get('xid')
     _sub_secret = current_app.config.get('PARTICIAPI_SUB_SECRET')
+    # Conversation-scope the subject when we know the conversation, so the participant gets
+    # a different uid per conversation (no chain) while staying stable across devices in it.
+    _sub = _conversation_subject(_xid, conv) if (_xid and conv is not None) else _xid
     _bind_identity = (
         pa_path == 'api/session' and request.method == 'POST'
         and bool(_sub) and bool(_sub_secret)
@@ -1000,9 +1021,14 @@ def _proxy_to_particiapi(pa_path: str):
         'Content-Type', 'application/json')
 
     if 'session' in upstream.cookies:
+        # Path-scope the session cookie to this conversation's proxy base, so the browser
+        # only returns it on that conversation's calls — each conversation keeps its own
+        # session/uid (#246). The legacy unscoped route keeps the root path.
+        _cookie_path = f'/c/{conv.slug}/proxy/particiapi' if conv is not None else '/'
         flask_resp.set_cookie(
             'pa_session',
             upstream.cookies['session'],
+            path=_cookie_path,
             httponly=True,
             samesite='Lax',
             secure=not current_app.debug,
@@ -1302,6 +1328,16 @@ def conversation_statement_new(slug):
 @login_required
 def proxy_particiapi(pa_path):
     return _proxy_to_particiapi(pa_path)
+
+
+@proxy_bp.route('/c/<slug>/proxy/particiapi/<path:pa_path>',
+                methods=['GET', 'POST', 'PUT'])
+@login_required
+def proxy_particiapi_scoped(slug, pa_path):
+    """Per-conversation proxy: conversation-scoped identity + path-scoped session cookie,
+    so a participant gets a different Polis uid per conversation (#246)."""
+    conv = Conversation.query.filter_by(slug=slug).first_or_404()
+    return _proxy_to_particiapi(pa_path, conv=conv)
 
 admin_bp = Blueprint('admin', __name__)
 

--- a/v2/ref_cross-device-identity.md
+++ b/v2/ref_cross-device-identity.md
@@ -268,6 +268,12 @@ so it's worth being honest about what that does and does not protect.
   per-conversation **coolname pseudonyms**, which are not linked across conversations and not
   tied to the Wikimedia name. Voting stays pseudonymous to other participants.
 
+> **Superseded by #246 (conversation-scoped identity) — see the section below.** The "stable
+> per-person identifier across all conversations" described here was the #245 behaviour. #246
+> scopes the subject **per conversation**, so the cross-conversation linkage at the Polis layer
+> no longer exists. The Wikimedia-account *confirmation* limit (subject recomputable from an
+> enumerable `mw_user_id`) still applies **per conversation**.
+
 **But it is not perfect — this is operational protection, not cryptographic unlinkability:**
 - An operator / anyone with **DB or exported-dataset access can link a person's participation
   across all conversations** (one stable `uid`), and on prod can **confirm which Wikimedia
@@ -283,3 +289,41 @@ so it's worth being honest about what that does and does not protect.
 In short: acceptable given the Wikimedia-pseudonym model and internal-only handling, but it
 trades away cross-conversation unlinkability at the operator level and leans on export hygiene
 and secret handling rather than on a structural guarantee.
+
+## Conversation-scoped identity (#246, PR #247) — removes the cross-conversation chain
+
+#245 above used the **bare xid** as the trusted subject, giving one person **one uid across all
+conversations**. That is a cross-conversation linkage chain at the Polis layer. #246 scopes the
+subject **per conversation** so the chain no longer exists, while keeping the cross-device
+stability #245 bought.
+
+**Mechanism (wiki-polis side only — no Particiapi change):**
+- `_conversation_subject(xid, conv)` = `HMAC(PARTICIAPI_SUB_SECRET or SECRET_KEY, "{xid}:{conv.id}")`.
+  Deterministic per `(person, conversation)`: same person + same conversation → same subject →
+  same `uid` (across devices); different conversation → different subject → different `uid`.
+  `conv.id` (not the zid) keys it, so a conversation's P2/P6 zids share one uid.
+- New route `/c/<slug>/proxy/particiapi/<path>`; the participant client's proxy root points at it.
+  The `pa_session` cookie is **path-scoped** to `/c/<slug>/proxy/particiapi`, so the browser only
+  returns it on that conversation's calls — each conversation gets its own Polis session/uid with
+  no extra client logic. Legacy root route kept for back-compat (`conv=None` → bare-xid).
+
+**What it changes about the privacy posture above:**
+- The operator can **no longer link a person across conversations** at the Polis layer (different
+  `uid` + `subject` per conversation). The export-hygiene guardrail (#226) still matters, but a
+  leak now exposes per-conversation identity, not a cross-conversation chain.
+- Within a single conversation the Wikimedia-account *confirmation* limit is unchanged: the
+  subject is `HMAC(secret, "{xid}:{conv.id}")` and the xid is recomputable from an enumerable
+  `mw_user_id` only by a holder of both the xid scheme and `PARTICIAPI_SUB_SECRET`.
+- Side effect: admin-authored statements are no longer distinguishable by a stable
+  cross-conversation `uid` — acceptable / desirable.
+
+**Staging validation — PASSED (2026-06-23).** Combined branch `test/246-on-236` on `wiki-polis-dev`
+(staging DB is at #236 schema). One Wikimedia user: *dogs vs cats* on laptop **and** mobile both
+bound to the same participant (one uid, identical subject `32b6…`); *test1* bound to a **different**
+uid + subject. Two independent sessions deriving the identical subject confirms determinism.
+
+**Prod cutover (clean, no grandfather).** Deploy PR #247 to prod, then clear sessions exactly as in
+the [Production rollout](#production-rollout-step-by-step) recipe above
+(`DELETE FROM sessions` on the app DB) so everyone re-binds per-conversation. The per-person uids
+minted by #245 on prod orphan the same way the stale staging rows did — acceptable (~1 day of test
+data, no anon→identity merge exists anyway).

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -135,7 +135,7 @@
     <div class="voting-col">
 
       <pa-conversation
-        base="{{ request.url_root }}proxy/particiapi"
+        base="{{ request.url_root }}c/{{ conversation.slug }}/proxy/particiapi"
         conversation-id="{{ conversation.polis_id }}">
 
         {# ── Progress row ── #}


### PR DESCRIPTION
## What

Scopes the Polis participant identity **per conversation**. A logged-in Wikimedia user now gets a *different* Polis uid in each conversation, while staying stable across devices *within* a conversation.

Builds on #245, which bound a stable per-person identity (xid → trusted-sub) to fix cross-device vote fragmentation. #245 used the bare xid as the subject, so one person mapped to **one uid across all conversations** — an internal cross-conversation linkage chain. #246 removes that chain.

## How

- `_conversation_subject(xid, conv)` = `HMAC(PARTICIAPI_SUB_SECRET, "{xid}:{conv.id}")`. Same person → same subject → same uid *within* a conversation (across devices); different conversation → different subject → different uid. `conv.id` is stable across the conversation's P2/P6 zids, so a person's initial and informed votes share one uid.
- New route `/c/<slug>/proxy/particiapi/<path>` carries the conversation; the participant client's proxy root points at it. The `pa_session` cookie is **path-scoped** to that conversation, so the browser only returns it on that conversation's calls — each conversation gets its own Polis session/uid automatically.
- Legacy `/proxy/particiapi/<path>` route kept (`conv=None` → bare-xid, root cookie) for back-compat.
- **No Particiapi change** — the trusted-sub mechanism from #245 is reused as-is.

## Privacy effect

The operator can no longer link a participant's activity *across* conversations at the Polis layer (different uid + subject per conversation). Side effect: admin-authored statements are no longer distinguishable by a stable cross-conversation uid either — acceptable / desirable.

## Staging validation (2026-06-23)

Dry-run on `wiki-polis-dev` (combined branch `test/246-on-236`, since staging's DB is migrated to #236):

- **Cross-device stability** ✅ — laptop + mobile votes in *dogs vs cats* both landed on the same participant (one uid, identical subject). No fragmentation.
- **No cross-conversation chain** ✅ — *test1* got a different uid + different subject for the same person.
- Determinism confirmed: two independent sessions (laptop, mobile) derived the identical subject.

## Prod cutover (clean, no grandfather)

Deploy + `DELETE FROM sessions;` on the prod app DB so everyone re-binds per-conversation. The per-person uids minted by #245 on prod orphan the same way (~1 day of test data) — acceptable.

Closes #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)