### PR TITLE
feat(#42): admin participants tab + last_engagement tracking

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -912,8 +912,10 @@ def _validate_fetch_csrf():
 _ENGAGEMENT_THROTTLE_SECONDS = 60
 
 # Phase-2 statement votes reach Particiapi through the generic proxy as
-# POST api/conversations/<polis_id>/votes — match it to record last_engagement (#42).
-_PROXY_VOTE_RE = re.compile(r'^api/conversations/([^/]+)/votes/?$')
+# PUT api/conversations/<polis_id>/votes/<tid> (the web client's addVote;
+# value in the body, statement id in the path) — match it to record last_engagement (#42).
+# The optional trailing segment also tolerates a POST .../votes form defensively.
+_PROXY_VOTE_RE = re.compile(r'^api/conversations/([^/]+)/votes(?:/[^/]+)?/?$')
 
 
 def _touch_engagement(participation) -> None:
@@ -1039,7 +1041,9 @@ def _proxy_to_particiapi(pa_path: str):
         )
 
     # Record meaningful-action recency for a successful Phase-2 statement vote (#42).
-    if request.method == 'POST' and 200 <= upstream.status_code < 300:
+    # The web client casts votes with PUT (and we tolerate POST); the GET vote-fetch
+    # path is deliberately excluded so reads don't count as engagement.
+    if request.method in ('POST', 'PUT') and 200 <= upstream.status_code < 300:
         m = _PROXY_VOTE_RE.match(pa_path)
         if m:
             _touch_engagement_by_polis_id(m.group(1))
@@ -1998,6 +2002,7 @@ def admin_conversation_participants(conv_id):
     participations = (Participation.query
                       .filter_by(conversation_id=conv_id)
                       .join(Participant)
+                      .options(joinedload(Participation.participant))
                       .order_by(Participation.accepted_at.desc())
                       .all())
 

--- a/v2/app.py
+++ b/v2/app.py
@@ -906,6 +906,57 @@ def _validate_fetch_csrf():
         abort(400)
 
 
+# Minimum gap between two last_engagement writes for the same participation — a voting
+# burst should not cause a DB write per click. Minutes-level recency is ample for the
+# drop-off signal (#42).
+_ENGAGEMENT_THROTTLE_SECONDS = 60
+
+# Phase-2 statement votes reach Particiapi through the generic proxy as
+# POST api/conversations/<polis_id>/votes — match it to record last_engagement (#42).
+_PROXY_VOTE_RE = re.compile(r'^api/conversations/([^/]+)/votes/?$')
+
+
+def _touch_engagement(participation) -> None:
+    """Best-effort: bump ``Participation.last_engagement`` on a meaningful action (#42).
+
+    Records action *recency only* — never page-views, statement ids, or vote content.
+    Never blocks or fails the action; skips the write when the stored value is younger
+    than ``_ENGAGEMENT_THROTTLE_SECONDS``.
+    """
+    if participation is None:
+        return
+    now = datetime.now(timezone.utc)
+    last = participation.last_engagement
+    if last is not None:
+        if last.tzinfo is None:            # stored naive-UTC
+            last = last.replace(tzinfo=timezone.utc)
+        if (now - last).total_seconds() < _ENGAGEMENT_THROTTLE_SECONDS:
+            return
+    try:
+        participation.last_engagement = now
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        current_app.logger.exception('last_engagement update failed')
+
+
+def _touch_engagement_by_polis_id(polis_id: str) -> None:
+    """Resolve (conversation, current participant) → participation and touch engagement.
+
+    Used by the Particiapi proxy for Phase-2 statement votes, which have no dedicated
+    Flask handler. Best-effort: any miss (unknown conv, no participation) is silent.
+    """
+    participant = _current_participant()
+    if participant is None:
+        return
+    conv = Conversation.query.filter_by(polis_id=polis_id).first()
+    if conv is None:
+        return
+    part = Participation.query.filter_by(
+        participant_id=participant.id, conversation_id=conv.id).first()
+    _touch_engagement(part)
+
+
 def _proxy_to_particiapi(pa_path: str):
     """
     Proxy a browser request to Particiapi and return the response.
@@ -986,6 +1037,12 @@ def _proxy_to_particiapi(pa_path: str):
             samesite='Lax',
             secure=not current_app.debug,
         )
+
+    # Record meaningful-action recency for a successful Phase-2 statement vote (#42).
+    if request.method == 'POST' and 200 <= upstream.status_code < 300:
+        m = _PROXY_VOTE_RE.match(pa_path)
+        if m:
+            _touch_engagement_by_polis_id(m.group(1))
 
     return flask_resp
 
@@ -1265,6 +1322,7 @@ def conversation_statement_new(slug):
             ids.append(stmt_id)
             part.new_stmt_ids = ids
             db.session.commit()
+        _touch_engagement(part)  # meaningful action (#42)
         flask_resp = make_response(stmt_resp.content, 201)
         flask_resp.headers['Content-Type'] = 'application/json'
     else:
@@ -1925,6 +1983,54 @@ def admin_invite_remove(conv_id, invite_id):
     record_audit('invite.remove', conv_id=conv_id, target_type='invite', target_id=invite_id)
     return redirect(url_for('admin.admin_conversation_invites', conv_id=conv_id))
 
+# ── Admin: participants tab ───────────────────────────────────────────────
+
+@admin_bp.get('/admin/conversations/<int:conv_id>/participants')
+@login_required
+def admin_conversation_participants(conv_id):
+    """Per-conversation engagement table: who is active, who has dropped off (#42).
+
+    Local-DB only for now — per-participant statement vote counts need Polis PG access
+    (#41) and are shown as unavailable until then.
+    """
+    conv = _require_mod_for_conv(conv_id)
+
+    participations = (Participation.query
+                      .filter_by(conversation_id=conv_id)
+                      .join(Participant)
+                      .order_by(Participation.accepted_at.desc())
+                      .all())
+
+    # Arguments submitted, per participant, in this conversation.
+    arg_counts = dict(
+        db.session.query(Argument.proposer_id, db.func.count(Argument.id))
+        .join(FeaturedStatement, Argument.featured_statement_id == FeaturedStatement.id)
+        .filter(FeaturedStatement.conversation_id == conv_id,
+                Argument.proposer_id.isnot(None))
+        .group_by(Argument.proposer_id)
+        .all())
+
+    # Argument votes cast, per participant, in this conversation.
+    arg_vote_counts = dict(
+        db.session.query(ArgumentVote.participant_id, db.func.count(ArgumentVote.id))
+        .join(Argument, ArgumentVote.argument_id == Argument.id)
+        .join(FeaturedStatement, Argument.featured_statement_id == FeaturedStatement.id)
+        .filter(FeaturedStatement.conversation_id == conv_id)
+        .group_by(ArgumentVote.participant_id)
+        .all())
+
+    rows = [{
+        'participation':       p,
+        'participant':         p.participant,
+        'statements_submitted': len(p.new_stmt_ids or []),
+        'arguments_submitted':  arg_counts.get(p.participant_id, 0),
+        'arguments_voted':      arg_vote_counts.get(p.participant_id, 0),
+        'last_engagement':      p.last_engagement,
+    } for p in participations]
+
+    return render_template('admin_participants.html', conversation=conv, rows=rows)
+
+
 # ── Admin: Polis statement moderation ─────────────────────────────────────
 
 @admin_bp.get('/admin/conversations/<int:conv_id>/statements')
@@ -2524,6 +2630,7 @@ def argument_submit(slug, fs_id):
     state.argument_order = order
 
     db.session.commit()
+    _touch_engagement(part)  # meaningful action (#42)
     if request.headers.get('X-Requested-With') == 'fetch':
         return jsonify({'ok': True, 'id': arg.id, 'body': body})
     return redirect(url_for('participant.conversation', slug=slug) + f'#fs-{fs_id}')
@@ -2554,6 +2661,7 @@ def argument_skip(slug, fs_id, side):
     elif not state.skipped:
         state.skipped = True
         db.session.commit()
+    _touch_engagement(part)  # meaningful action (#42)
     if request.headers.get('X-Requested-With') == 'fetch':
         return jsonify({'ok': True})
     return redirect(url_for('participant.conversation', slug=slug) + f'#fs-{fs_id}')
@@ -2614,6 +2722,7 @@ def argument_vote(slug, arg_id):
             participant_id=part.participant_id,
         ))
         db.session.commit()
+    _touch_engagement(part)  # meaningful action (#42)
     if is_ajax:
         return jsonify({'ok': True})
     return redirect(url_for('participant.conversation', slug=slug) + '#tab-arguments')
@@ -2630,6 +2739,7 @@ def argument_unvote(slug, arg_id):
     if existing:
         db.session.delete(existing)
         db.session.commit()
+    _touch_engagement(part)  # meaningful action (#42)
     if request.headers.get('X-Requested-With') == 'fetch':
         return jsonify({'ok': True})
     return redirect(url_for('participant.conversation', slug=slug) + '#tab-arguments')
@@ -2810,6 +2920,9 @@ def phase6_vote(slug):
     except requests.RequestException:
         current_app.logger.exception('Particiapi error in phase6_vote')
         abort(502)
+
+    if 200 <= upstream.status_code < 300:
+        _touch_engagement(participation)  # meaningful action (#42)
 
     resp = make_response('', upstream.status_code)
     if new_pa_cookie:

--- a/v2/db.py
+++ b/v2/db.py
@@ -113,6 +113,11 @@ class Participation(db.Model):
     # Nullified automatically 60 days after conversation close (data minimisation).
     public_username   = db.Column(db.String(255), nullable=True)
     revealed_at       = db.Column(db.DateTime, nullable=True)
+    # Recency of this participant's most recent *meaningful action* in the conversation
+    # (statement vote/submission, argument submit/vote/skip, phase-6 vote) — NOT a passive
+    # last-seen / page-view timestamp (see #42). Drives the admin participants tab's drop-off
+    # signal; updated best-effort + throttled in the action handlers.
+    last_engagement   = db.Column(db.DateTime, nullable=True)
     # Polis statement IDs of entirely new statements submitted by this participant.
     # Quota = len(new_stmt_ids). Slots consumed at submit time; never returned.
     new_stmt_ids      = db.Column(db.JSON, nullable=False, default=list)

--- a/v2/migrations/versions/f4a5b6c7d8e9_add_last_engagement_to_participations.py
+++ b/v2/migrations/versions/f4a5b6c7d8e9_add_last_engagement_to_participations.py
@@ -1,0 +1,27 @@
+"""add last_engagement to participations (#42)
+
+Revision ID: f4a5b6c7d8e9
+Revises: e3f4a5b6c7d8
+Create Date: 2026-06-14 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f4a5b6c7d8e9'
+down_revision = 'e3f4a5b6c7d8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Recency of a participant's most recent meaningful action (#42) — action-based, not
+    # a passive last-seen. Nullable: existing rows have no recorded action yet.
+    op.add_column('participations',
+                  sa.Column('last_engagement', sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('participations', 'last_engagement')

--- a/v2/migrations/versions/f4a5b6c7d8e9_add_last_engagement_to_participations.py
+++ b/v2/migrations/versions/f4a5b6c7d8e9_add_last_engagement_to_participations.py
@@ -19,9 +19,11 @@ depends_on = None
 def upgrade():
     # Recency of a participant's most recent meaningful action (#42) — action-based, not
     # a passive last-seen. Nullable: existing rows have no recorded action yet.
-    op.add_column('participations',
-                  sa.Column('last_engagement', sa.DateTime(), nullable=True))
+    # batch_alter_table keeps downgrade working on SQLite < 3.35 (matches the chain convention).
+    with op.batch_alter_table('participations') as batch_op:
+        batch_op.add_column(sa.Column('last_engagement', sa.DateTime(), nullable=True))
 
 
 def downgrade():
-    op.drop_column('participations', 'last_engagement')
+    with op.batch_alter_table('participations') as batch_op:
+        batch_op.drop_column('last_engagement')

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -399,8 +399,12 @@
         <div class="manage-card-title">Featured statements</div>
         <div class="manage-card-desc">Curate the set for arguments &amp; informed voting</div>
       </a>
-      {# TODO(#165/#42): a 'Statistics' manage-card linking to a per-conversation
-         stats page goes here once that page exists. #}
+      <a class="manage-card" href="{{ url_for('admin.admin_conversation_participants', conv_id=conversation.id) }}">
+        <div class="manage-card-top"><span class="manage-card-count">{{ participant_count }} joined</span></div>
+        <div class="manage-card-title">Participants</div>
+        <div class="manage-card-desc">Engagement &amp; drop-off — who is active, who to nudge</div>
+      </a>
+      {# TODO(#165): a broader 'Statistics' manage-card can join this row once it exists. #}
     </div>
   </div>
 

--- a/v2/templates/admin_participants.html
+++ b/v2/templates/admin_participants.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+{% block title %}Participants — {{ conversation.title }} — wiki-polis{% endblock %}
+{% block header_mode %}{% if is_admin %}header--admin{% endif %}{% endblock %}
+{% block header_crumb %}
+<span class="header-crumb">
+  <span class="header-crumb-sep">/</span>
+  {% if is_admin %}<a href="{{ url_for('admin.admin') }}">Admin</a><span class="header-crumb-sep">/</span>{% endif %}
+  <a href="{{ url_for('admin.admin_conversation_detail', conv_id=conversation.id) }}">{{ conversation.title | truncate(20, True, '…') }}</a>
+  <span class="header-crumb-sep">/</span>
+  <span>Participants</span>
+</span>
+{% endblock %}
+{% block content %}
+<div class="container">
+  <h2>Participants — {{ conversation.title }}</h2>
+  <p class="muted" style="font-size:13px;margin-bottom:1.5rem">
+    {{ rows | length }} participant{{ '' if rows | length == 1 else 's' }} joined.
+    Per-participant statement vote counts are not yet available (needs Polis database access — #41).
+    <strong>Last engagement</strong> is the time of each participant's most recent action
+    (vote, statement, or argument) — not page-views.
+  </p>
+  {% if rows %}
+  <table class="admin-table">
+    <thead>
+      <tr>
+        <th>Username</th>
+        <th>Joined</th>
+        <th>Statements submitted</th>
+        <th>Arguments submitted</th>
+        <th>Arguments voted</th>
+        <th>Last engagement</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in rows %}
+      <tr>
+        <td>{{ row.participant.mw_username }}</td>
+        <td style="white-space:nowrap">{{ row.participation.accepted_at.strftime('%Y-%m-%d') }}</td>
+        <td>{{ row.statements_submitted }}</td>
+        <td>{{ row.arguments_submitted }}</td>
+        <td>{{ row.arguments_voted }}</td>
+        <td style="white-space:nowrap">{{ row.last_engagement.strftime('%Y-%m-%d %H:%M') if row.last_engagement else '—' }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="muted">No participants yet.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/v2/templates/admin_participants.html
+++ b/v2/templates/admin_participants.html
@@ -12,23 +12,24 @@
 {% endblock %}
 {% block content %}
 <div class="container">
-  <h2>Participants — {{ conversation.title }}</h2>
+  <h1>Participants — {{ conversation.title }}</h1>
   <p class="muted" style="font-size:13px;margin-bottom:1.5rem">
     {{ rows | length }} participant{{ '' if rows | length == 1 else 's' }} joined.
     Per-participant statement vote counts are not yet available (needs Polis database access — #41).
-    <strong>Last engagement</strong> is the time of each participant's most recent action
+    <strong>Last engagement</strong> is the time (UTC) of each participant's most recent action
     (vote, statement, or argument) — not page-views.
   </p>
   {% if rows %}
   <table class="admin-table">
+    <caption class="sr-only">Participants in {{ conversation.title }}, with engagement counts and last action time.</caption>
     <thead>
       <tr>
-        <th>Username</th>
-        <th>Joined</th>
-        <th>Statements submitted</th>
-        <th>Arguments submitted</th>
-        <th>Arguments voted</th>
-        <th>Last engagement</th>
+        <th scope="col">Username</th>
+        <th scope="col">Joined</th>
+        <th scope="col">Statements submitted</th>
+        <th scope="col">Arguments submitted</th>
+        <th scope="col">Arguments voted</th>
+        <th scope="col">Last engagement (UTC)</th>
       </tr>
     </thead>
     <tbody>

--- a/v2/tests/conftest.py
+++ b/v2/tests/conftest.py
@@ -29,6 +29,11 @@ def app(tmp_path):
         'TRUST_PROXY_HEADERS': '',
         'TOOL_TOOLFORGE_API_URL': '',
         'TOOL_REDIS_URI': '',
+        # Neutralise the developer .env (app.py auto-loads it) so the test app is hermetic:
+        # tests that need Polis configured set these on app.config explicitly, and the rest
+        # must see them unset regardless of the local machine (else phase-stats tests flake).
+        'POLIS_DATABASE_URL': '',
+        'POLIS_SERVER_URL': '',
     }
     with patch.dict(os.environ, env_overrides, clear=False):
         a = create_app({

--- a/v2/tests/test_admin_participants.py
+++ b/v2/tests/test_admin_participants.py
@@ -1,0 +1,79 @@
+"""Tests for the admin participants tab + last_engagement tracking (#42)."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from flask import g
+
+from app import _touch_engagement, _touch_engagement_by_polis_id
+from db import Participation, db
+
+
+@pytest.fixture
+def participation(app, participant, conversation):
+    p = Participation(
+        participant_id=participant.id,
+        conversation_id=conversation.id,
+        pseudonym='quiet-otter',
+    )
+    db.session.add(p)
+    db.session.commit()
+    return p
+
+
+# ── last_engagement helper ──────────────────────────────────────────────────
+
+def test_touch_sets_when_none(participation):
+    assert participation.last_engagement is None
+    _touch_engagement(participation)
+    assert participation.last_engagement is not None
+
+
+def test_touch_is_throttled(participation):
+    # naive-UTC, as the column stores it (SQLite/MySQL strip tzinfo on round-trip).
+    recent = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(seconds=5)
+    participation.last_engagement = recent
+    db.session.commit()
+    _touch_engagement(participation)
+    # Within the throttle window → unchanged.
+    assert participation.last_engagement == recent
+
+
+def test_touch_updates_past_throttle(participation):
+    stale = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=5)
+    participation.last_engagement = stale
+    db.session.commit()
+    _touch_engagement(participation)
+    assert participation.last_engagement > stale
+
+
+def test_touch_none_is_noop(app):
+    # Must not raise on a missing participation.
+    _touch_engagement(None)
+
+
+def test_touch_by_polis_id_resolves_participant(app, participant, conversation, participation):
+    with app.test_request_context():
+        g.participant = participant
+        _touch_engagement_by_polis_id(conversation.polis_id)
+    db.session.refresh(participation)
+    assert participation.last_engagement is not None
+
+
+def test_touch_by_polis_id_unknown_conv_is_silent(app, participant):
+    with app.test_request_context():
+        g.participant = participant
+        _touch_engagement_by_polis_id('nope9999')  # no matching conversation
+
+
+# ── admin participants route ────────────────────────────────────────────────
+
+def test_participants_tab_ok_for_admin(admin_client, conversation, participation):
+    resp = admin_client.get(f'/admin/conversations/{conversation.id}/participants')
+    assert resp.status_code == 200
+    assert b'testuser' in resp.data          # the participant's username
+    assert b'Last engagement' in resp.data
+
+
+def test_participants_tab_forbidden_for_non_moderator(auth_client, conversation, participation):
+    resp = auth_client.get(f'/admin/conversations/{conversation.id}/participants')
+    assert resp.status_code == 403

--- a/v2/tests/test_admin_participants.py
+++ b/v2/tests/test_admin_participants.py
@@ -1,11 +1,22 @@
 """Tests for the admin participants tab + last_engagement tracking (#42)."""
 from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
 
 import pytest
 from flask import g
 
 from app import _touch_engagement, _touch_engagement_by_polis_id
 from db import Participation, db
+
+
+def _fake_upstream(status_code=200, content=b'{}'):
+    """Stand-in for a requests Response from Particiapi (mirrors test_proxy_blueprint)."""
+    m = MagicMock()
+    m.status_code = status_code
+    m.content = content
+    m.headers = {'Content-Type': 'application/json'}
+    m.cookies = {}
+    return m
 
 
 @pytest.fixture
@@ -77,3 +88,27 @@ def test_participants_tab_ok_for_admin(admin_client, conversation, participation
 def test_participants_tab_forbidden_for_non_moderator(auth_client, conversation, participation):
     resp = auth_client.get(f'/admin/conversations/{conversation.id}/participants')
     assert resp.status_code == 403
+
+
+# ── Phase-2 vote through the proxy bumps last_engagement (regression: the web
+#    client casts votes with PUT .../votes/<tid>, not POST .../votes) ───────────
+
+def test_phase2_vote_put_via_proxy_touches_engagement(auth_client, conversation, participation):
+    assert participation.last_engagement is None
+    with patch('app.requests.request', return_value=_fake_upstream()):
+        resp = auth_client.put(
+            f'/proxy/particiapi/api/conversations/{conversation.polis_id}/votes/7',
+            headers={'Sec-Fetch-Site': 'same-origin'}, json={'value': -1})
+    assert resp.status_code == 200
+    db.session.refresh(participation)
+    assert participation.last_engagement is not None
+
+
+def test_proxy_vote_fetch_get_does_not_touch_engagement(auth_client, conversation, participation):
+    # A GET to the votes path is a read, not an action — must NOT count as engagement.
+    with patch('app.requests.request', return_value=_fake_upstream()):
+        resp = auth_client.get(
+            f'/proxy/particiapi/api/conversations/{conversation.polis_id}/votes')
+    assert resp.status_code == 200
+    db.session.refresh(participation)
+    assert participation.last_engagement is None


### PR DESCRIPTION
Recreated after the 2026-06-23 main reset (the original was merged prematurely without per-PR testing, then reverted via reset). Original: #221. Branch unchanged from before that merge — to be tested thoroughly, then rebased on current main and re-merged.

⚠️ Note: the `last_engagement` migration (`f4a5b6c7d8e9`) was already applied to prod during the premature merge and was left in place (harmless unused column). On re-merge the migration is effectively a no-op there.