### PR TITLE
UI polish from #236 review (Wave 1 + staged quick-fixes)

### DIFF
--- a/v2/static/redesign.css
+++ b/v2/static/redesign.css
@@ -141,9 +141,13 @@
 /* Per-box simple/advanced — the distinction belongs to ONE control box at a
    time (e.g. the phase control), never the whole console. No global mode, no
    header switch. A box opts in by carrying [data-mode] and a .box-mode toggle. */
-[data-mode] .mode-advanced-part { display: none; }
+[data-mode] .mode-advanced-part { display: none; margin-top: 14px; }
 [data-mode="advanced"] .mode-advanced-part { display: revert; }
 [data-mode="advanced"] .mode-guided-part   { display: none; }
+/* In Advanced mode the toggles are the point of the box — float them directly under the
+   timeline/switch instead of below all the guided stats/pause content. */
+[data-mode="advanced"] .phase-hero-body { display: flex; flex-direction: column; }
+[data-mode="advanced"] .mode-advanced-part { order: -1; margin-top: 0; margin-bottom: 14px; }
 
 .box-adv-note {
   display: none;

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -2002,6 +2002,14 @@ a { color: var(--pass); }
   white-space: nowrap;
   font-size: 12px;
 }
+/* Vote tallies, ordered Agree · Pass · Disagree, each labelled + colour-coded so the three
+   numbers aren't an unlabelled "+ − ·" run. */
+.stmt-votes .vcount { font-variant-numeric: tabular-nums; }
+.stmt-votes .vcount + .vcount { margin-left: 18px; }
+.stmt-votes .vlabel { font-weight: 700; opacity: 0.7; }
+.vcount--agree { color: var(--agree); }
+.vcount--pass { color: var(--muted); }
+.vcount--disagree { color: var(--disagree); }
 
 .stmt-actions {
   white-space: nowrap;

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -1804,8 +1804,32 @@ a { color: var(--pass); }
 .btn-small:hover { border-color: var(--pass); color: var(--pass); }
 
 
+/* Disabled small/danger buttons must read as inert — greyed, not-allowed cursor, and
+   no hover affordance — otherwise a guarded action (e.g. delete-with-votes) still looks
+   clickable and clicking it silently does nothing. */
+.btn-small:disabled,
+.btn-small[disabled],
+.btn-small[aria-disabled="true"] {
+  opacity: .45;
+  cursor: not-allowed;
+}
+.btn-small:disabled:hover,
+.btn-small[disabled]:hover,
+.btn-small[aria-disabled="true"]:hover {
+  border-color: var(--border);
+  color: var(--body);
+  background: var(--surface);
+}
+
 .btn-danger { border-color: var(--red); color: var(--red); }
 .btn-danger:hover { background: var(--red); color: white; border-color: var(--red); }
+.btn-danger:disabled:hover,
+.btn-danger[disabled]:hover,
+.btn-danger[aria-disabled="true"]:hover {
+  background: var(--surface);
+  color: var(--red);
+  border-color: var(--red);
+}
 .btn-warn { border-color: var(--spot); color: var(--spot); }
 .btn-warn:hover { background: var(--spot); color: white; border-color: var(--spot); }
 .btn-pause        { border-color: var(--spot); color: var(--spot); }

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -236,7 +236,7 @@
         {# Guided 'Move on' (#156): consequences + tick-each-precondition checklist.
            Submit ships ENABLED (no-JS can advance; route enforces server-side); JS
            disables it until every box is ticked. Gating logic unchanged. #}
-        <div class="moveon phase-move-box" style="margin-top:14px">
+        <div class="moveon phase-move-box">
           <div class="moveon-head">
             <span class="moveon-from">{{ transition.source.label }}</span>
             <span class="moveon-arrow" aria-hidden="true">→</span>
@@ -325,7 +325,6 @@
 
       {% if is_admin and schedule.can_schedule %}
       <div class="schedule-card" style="margin-top:14px">
-        <div class="schedule-icon" aria-hidden="true">UTC</div>
         <div class="schedule-main">
           <div class="schedule-title">Schedule wind-down to {{ schedule.transition.target.label }}</div>
           {% if schedule.scheduled_at %}
@@ -345,6 +344,7 @@
           <input id="scheduled-at" name="scheduled_at" type="datetime-local"
                  {% if schedule.scheduled_at %}value="{{ schedule.scheduled_at.strftime('%Y-%m-%dT%H:%M') }}"{% endif %}
                  aria-label="Scheduled transition time in UTC">
+          <span class="schedule-utc" aria-hidden="true">UTC</span>
           <button type="submit" class="btn-ghost">{{ 'Edit' if schedule.scheduled_at else 'Set' }}</button>
         </form>
         {% if schedule.scheduled_at %}
@@ -370,7 +370,7 @@
 
     {# ── Advanced (mode-advanced-part) — global admin only ──────────────── #}
     {% if is_admin %}
-    <div class="mode-advanced-part" style="margin-top:14px">
+    <div class="mode-advanced-part">
       <div class="box-adv-note">
         <span aria-hidden="true">⚠️</span>
         <span><strong>Advanced.</strong> These toggles act independently and out of order, with no

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -715,6 +715,16 @@
     f.addEventListener('change', function () { save.classList.add('phases-save--dirty'); });
   });
 
+  // Schedule picker is interpreted as UTC server-side, but a native datetime-local renders in
+  // the browser's local zone. Pre-fill an empty picker with the current UTC time so the admin
+  // adjusts from "now (UTC)" rather than a blank mm/dd/yyyy that silently means local.
+  (function () {
+    var sched = document.getElementById('scheduled-at');
+    if (sched && !sched.value) {
+      sched.value = new Date().toISOString().slice(0, 16); // YYYY-MM-DDTHH:MM in UTC
+    }
+  }());
+
   document.querySelectorAll('[data-countdown-target]').forEach(function (el) {
     var target = Date.parse(el.dataset.countdownTarget);
     if (!Number.isFinite(target)) return;

--- a/v2/templates/admin_statements.html
+++ b/v2/templates/admin_statements.html
@@ -24,7 +24,7 @@
       an approved or hidden statement to the review queue.
     </p>
     <ul style="font-size:13px;padding-left:1.25rem;margin-bottom:.6rem">
-      <li>Vote counts show agree, disagree, and pass totals from Polis when the statistics database is available.</li>
+      <li>Vote counts show <strong>A</strong>gree · <strong>P</strong>ass · <strong>D</strong>isagree totals from Polis when the statistics database is available.</li>
       <li>Seed statements come from moderator entry or imports; participant-submitted statements appear in the same moderation lists.</li>
       <li>A star marks statements already selected as featured. A correction marker links derived statements back to the original TID.</li>
       <li>Seed entry and imports are available only during preparation or open statement submission.</li>
@@ -185,10 +185,10 @@
                 title="Derived from statement #{{ prov.derived_from_tid }}. Similarity 1.00 = identical.{% for sc in prov.scores %} {{ sc.model }} {{ '%.2f'|format(sc.value) }}.{% endfor %}">
             <span class="sr-only">derived from statement {{ prov.derived_from_tid }}, </span>↳ #{{ prov.derived_from_tid }}{% for sc in prov.scores %} · {{ sc.model }}&nbsp;{{ '%.2f'|format(sc.value) }}{% endfor %}</span>{% endif %}</td>
         <td class="stmt-text">{{ s.txt }}</td>
-        <td class="stmt-votes muted">
-          +{{ s.agree_count or 0 }}
-          −{{ s.disagree_count or 0 }}
-          ·{{ s.pass_count or 0 }}
+        <td class="stmt-votes">
+          <span class="vcount vcount--agree" title="Agree votes"><span class="vlabel">A</span> {{ s.agree_count or 0 }}</span>
+          <span class="vcount vcount--pass" title="Pass votes"><span class="vlabel">P</span> {{ s.pass_count or 0 }}</span>
+          <span class="vcount vcount--disagree" title="Disagree votes"><span class="vlabel">D</span> {{ s.disagree_count or 0 }}</span>
         </td>
         <td class="stmt-actions">
           <form method="post" style="display:inline"
@@ -239,10 +239,10 @@
                 title="Derived from statement #{{ prov.derived_from_tid }}. Similarity 1.00 = identical.{% for sc in prov.scores %} {{ sc.model }} {{ '%.2f'|format(sc.value) }}.{% endfor %}">
             <span class="sr-only">derived from statement {{ prov.derived_from_tid }}, </span>↳ #{{ prov.derived_from_tid }}{% for sc in prov.scores %} · {{ sc.model }}&nbsp;{{ '%.2f'|format(sc.value) }}{% endfor %}</span>{% endif %}</td>
         <td class="stmt-text">{{ s.txt }}</td>
-        <td class="stmt-votes muted">
-          +{{ s.agree_count or 0 }}
-          −{{ s.disagree_count or 0 }}
-          ·{{ s.pass_count or 0 }}
+        <td class="stmt-votes">
+          <span class="vcount vcount--agree" title="Agree votes"><span class="vlabel">A</span> {{ s.agree_count or 0 }}</span>
+          <span class="vcount vcount--pass" title="Pass votes"><span class="vlabel">P</span> {{ s.pass_count or 0 }}</span>
+          <span class="vcount vcount--disagree" title="Disagree votes"><span class="vlabel">D</span> {{ s.disagree_count or 0 }}</span>
         </td>
         <td class="stmt-actions">
           <form method="post" style="display:inline"
@@ -287,10 +287,10 @@
       <tr>
         <td class="muted">{{ s.tid }}</td>
         <td class="stmt-text">{{ s.txt }}</td>
-        <td class="stmt-votes muted">
-          +{{ s.agree_count or 0 }}
-          −{{ s.disagree_count or 0 }}
-          ·{{ s.pass_count or 0 }}
+        <td class="stmt-votes">
+          <span class="vcount vcount--agree" title="Agree votes"><span class="vlabel">A</span> {{ s.agree_count or 0 }}</span>
+          <span class="vcount vcount--pass" title="Pass votes"><span class="vlabel">P</span> {{ s.pass_count or 0 }}</span>
+          <span class="vcount vcount--disagree" title="Disagree votes"><span class="vlabel">D</span> {{ s.disagree_count or 0 }}</span>
         </td>
         <td class="stmt-actions">
           <form method="post" style="display:inline"

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -516,8 +516,8 @@
             Featured statement
           </div>
           <p class="at-stmt">{{ item.text }}</p>
-          {# One-line summary shown only when collapsed after all-done #}
-          <p class="at-stmt-summary" aria-hidden="true">{{ item.text | truncate(80, True) }}</p>
+          {# (Collapsed-state one-liner is rendered by .at-revisit-bar; the old .at-stmt-summary
+             here was orphaned dead markup that just duplicated .at-stmt when expanded.) #}
           {{ content_flag_form(url_for('participant.statement_flag', slug=conversation.slug, tid=fs.polis_statement_id), 'statement-' ~ fs.id, 'statement') }}
         </div>
 
@@ -542,9 +542,9 @@
               <div class="at-step-name">2 · Prioritise</div>
               <div class="at-step-sub" id="step2-sub-{{ fs.id }}">
                 {%- if both_gate -%}
-                  {{ item.pro_voted_count }}/{{ item.k }} for · {{ item.con_voted_count }}/{{ item.k }} against · can change
+                  Mark the most important — {{ item.pro_voted_count }} of {{ item.k }} for, {{ item.con_voted_count }} of {{ item.k }} against · you can still change these
                 {%- else -%}
-                  after step 1
+                  Unlocks after step 1
                 {%- endif -%}
               </div>
             </div>
@@ -2167,7 +2167,7 @@
     var pickedPro = countVoted(fsId, 'pro');
     var pickedCon = countVoted(fsId, 'con');
     var s2sub = document.getElementById('step2-sub-' + fsId);
-    if (s2sub) s2sub.textContent = pickedPro + '/' + k + ' for · ' + pickedCon + '/' + k + ' against · can change';
+    if (s2sub) s2sub.textContent = 'Mark the most important — ' + pickedPro + ' of ' + k + ' for, ' + pickedCon + ' of ' + k + ' against · you can still change these';
     paintAllCircles();
   }
 

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -12,7 +12,7 @@
 {% endblock %}
 {% macro content_flag_form(action, uid, label) -%}
 <details class="content-flag">
-  <summary aria-label="Flag {{ label }} for moderator review">flag</summary>
+  <summary aria-label="Flag {{ label }} for moderator review">flag concerns about this {{ label }}</summary>
   <form method="post" action="{{ action }}">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <label class="sr-only" for="flag-category-{{ uid }}">Reason</label>


### PR DESCRIPTION
Small, low-risk UI fixes surfaced during the #236 walk-through review (https://github.com/lgelauff/wiki-polis/pull/236#issuecomment-4789450626). Targets `feat/parallel-lanes` so it doesn't collide with in-flight work there.

## At a glance — before → after
| Area | Before → After |
|---|---|
| Flag control copy | `flag` → **`flag concerns about this {statement\|argument}`** (uses the macro `{{ label }}`) |
| Admin statement vote tallies | `+1 −0 ·0` (unlabelled) → **`A 1 · P 0 · D 0`** — Agree · Pass · Disagree, labelled, colour-coded, wider spacing |
| "Prioritise" step copy | `{x}/{k} for · {y}/{k} against · can change` → **`Mark the most important — {x} of {k} for, {y} of {k} against · you can still change these`**; `after step 1` → **`Unlocks after step 1`** (template + the JS that rewrites it) |
| Featured statement text | removed the orphaned `.at-stmt-summary` that **doubled** the statement text when expanded (collapsed state is rendered by `.at-revisit-bar`) |
| "No blocking checks" summary | dropped the 14px gap so it attaches to the **move-on box below**, not the pause banner above |
| Advanced-mode toggles | float **directly under the timeline/switch** (CSS `order` on `.phase-hero-body`) instead of below all guided content |
| Schedule card | removed the odd left "UTC" box; "UTC" now sits **after** the datetime input; empty picker **pre-fills current UTC** |
| Disabled buttons | greyed + `not-allowed` + no hover, so a guarded action (e.g. delete-with-votes) reads as **inert** instead of clickable |

## Notes
- `ruff` clean · **469 tests pass**.
- The layout items (advanced-toggle order, summary grouping, schedule card) are visual — worth a glance on staging.
- **Not in scope** (separate follow-ups, per the maintainer — not blockers): flag popup positioning/redesign #254, for/against + prioritise widget #255, phase-7 contradiction #256, eligibility #257, archive #258, home buckets #253, moderation model #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
