### PR TITLE
fix(#245): Issue 2 follow-up — transport hardening + docs

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -8,6 +8,7 @@ import dataclasses
 import functools
 import hashlib
 import hmac
+import ipaddress
 import os
 import random
 import re
@@ -1591,6 +1592,24 @@ def _proxy_auth_response(pa_path: str):
     return redirect(url_for('login'))
 
 
+def _is_secure_pa_transport(base_url: str) -> bool:
+    """True if the sub-secret can be sent safely: HTTPS, or HTTP to loopback only.
+
+    X-Particiapi-Sub-Secret is a long-lived master credential; combined with an
+    enumerable xid, a wire-capture of it lets an attacker forge any user's identity.
+    Used only to emit a loud warning when it would traverse a cleartext non-loopback
+    link (#245 review) — the actual fix is encrypting that hop.
+    """
+    u = urlparse(base_url)
+    if u.scheme == 'https':
+        return True
+    host = (u.hostname or '').strip('[]')
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return host == 'localhost'
+
+
 def _conversation_subject(xid: str, conv) -> str:
     """Conversation-scoped participant subject for Particiapi's trusted-sub binding.
 
@@ -1654,6 +1673,16 @@ def _proxy_to_particiapi(pa_path: str, conv=None):
         and pa_path == 'api/session' and request.method == 'POST'
         and bool(_sub) and bool(_sub_secret)
     )
+
+    # Loud warning (#245 review): the sub-secret is a master credential. If the transport
+    # to Particiapi is cleartext non-loopback, a wire-capture forges any user's identity.
+    # We still bind (the link is firewalled-private in prod) but surface it on every bind
+    # so an unencrypted hop can't stay invisible. The real fix is encrypting the hop.
+    if _bind_identity and not _is_secure_pa_transport(current_app.config['PARTICIAPI_BASE']):
+        current_app.logger.warning(
+            'PARTICIAPI_SUB_SECRET is being sent over a cleartext non-loopback transport '
+            '(%s); encrypt the Toolforge<->VPS hop (WireGuard/TLS)',
+            current_app.config['PARTICIAPI_BASE'])
 
     # On a bind we deliberately do NOT forward any existing pa_session cookie: a stale
     # (possibly anonymous) session would make Particiapi skip the bind path and pin the

--- a/v2/guide_deployment.md
+++ b/v2/guide_deployment.md
@@ -362,7 +362,18 @@ toolforge envvars create POLIS_ADMIN_PASSWORD
 toolforge envvars create POLIS_DATABASE_URL
 toolforge envvars create RATELIMIT_KEY_PREFIX
 toolforge envvars create RATELIMIT_IDENTITY_SECRET
+toolforge envvars create PARTICIAPI_SUB_SECRET
 ```
+
+> ⚠️ **`PARTICIAPI_SUB_SECRET` is a long-lived master credential.** It lets the proxy
+> assert any logged-in user's identity to Particiapi (cross-device stable participant).
+> It must match Particiapi's `TRUSTED_SUB_SECRET`, and it is sent to `PARTICIAPI_BASE_URL`
+> on every identity bind — so that link **must be encrypted (WireGuard/TLS) or loopback**.
+> A wire-capture of this secret, combined with the enumerable xid, would let an attacker
+> forge any user's identity — so do not set it until the Toolforge↔VPS hop is encrypted
+> (WireGuard/TLS) or loopback. If the secret is sent over a cleartext non-loopback
+> transport the app logs a warning on every bind. Leave `PARTICIAPI_SUB_SECRET` unset to
+> fall back to the old anonymous-per-session behaviour.
 
 Non-secret values can be passed as arguments:
 
@@ -623,7 +634,8 @@ export SECRET_KEY=$(toolforge envvars show SECRET_KEY | tail -1 | awk '{print $N
 | `OAUTH_CLIENT_ID` | yes (prod) | Wikimedia OAuth consumer key |
 | `OAUTH_CLIENT_SECRET` | yes (prod) | Wikimedia OAuth consumer secret |
 | `OAUTH_REDIRECT_URI` | yes (prod) | Must match registered callback URL |
-| `PARTICIAPI_BASE_URL` | yes | Internal URL of Particiapi (e.g. `http://10.x.x.x:8000`) |
+| `PARTICIAPI_BASE_URL` | yes | Internal URL of Particiapi (e.g. `http://10.x.x.x:8000`) — **must be encrypted (TLS) or loopback if `PARTICIAPI_SUB_SECRET` is set** |
+| `PARTICIAPI_SUB_SECRET` | no | Shared master secret for cross-device identity binding; must match Particiapi's `TRUSTED_SUB_SECRET`. Unset → anonymous-per-session. Only set it when the transport is encrypted (TLS) or loopback |
 | `DATABASE_URL` | yes (prod) | SQLAlchemy DB URL; defaults to `sqlite:///dev.db` |
 | `POLIS_SERVER_URL` | yes | Direct Polis server URL (e.g. `http://10.x.x.x:8001`) — required for conversation creation |
 | `POLIS_ADMIN_EMAIL` | yes | Email of the Polis system account (created once on VPS) |

--- a/v2/tests/test_proxy_blueprint.py
+++ b/v2/tests/test_proxy_blueprint.py
@@ -503,3 +503,42 @@ def test_unscoped_route_never_emits_identity_headers(bind_client):
     assert 'X-Particiapi-Sub' not in sent['headers']
     assert 'X-Particiapi-Sub-Secret' not in sent['headers']
     assert sent['params'].get('create') == 'true'  # falls back to anonymous create
+
+
+# ── Cleartext-transport warning for the sub-secret (PR #245 review, Issue 2) ──────
+
+def test_is_secure_pa_transport():
+    from app import _is_secure_pa_transport
+    assert _is_secure_pa_transport('https://particiapi.example')
+    assert _is_secure_pa_transport('http://localhost:8000')
+    assert _is_secure_pa_transport('http://127.0.0.1:8000')
+    assert _is_secure_pa_transport('http://[::1]:8000')
+    assert not _is_secure_pa_transport('http://10.0.0.5:8000')      # private but cleartext
+    assert not _is_secure_pa_transport('http://particiapi.example')  # cleartext non-loopback
+
+
+def test_bind_warns_on_cleartext_but_still_binds(bind_client, app, caplog):
+    """Cleartext non-loopback transport logs a loud warning on bind, but still binds —
+    the warning must not silently disable the live cross-device feature."""
+    import logging
+    app.config['PARTICIAPI_BASE'] = 'http://10.0.0.5:8000'
+    _make_conv('bind-w', 'bindw00001')
+    up = _fake_upstream()
+    with caplog.at_level(logging.WARNING), \
+            patch('app.requests.request', return_value=up) as req:
+        bind_client.post('/c/bind-w/proxy/particiapi/api/session',
+                         headers=_SAME_ORIGIN, json={})
+    assert 'X-Particiapi-Sub-Secret' in req.call_args.kwargs['headers']  # still binds
+    assert any('cleartext non-loopback' in r.message for r in caplog.records)
+
+
+def test_bind_no_warning_on_loopback(bind_client, app, caplog):
+    import logging
+    app.config['PARTICIAPI_BASE'] = 'http://localhost:8000'
+    _make_conv('bind-l', 'bindl00001')
+    up = _fake_upstream()
+    with caplog.at_level(logging.WARNING), \
+            patch('app.requests.request', return_value=up):
+        bind_client.post('/c/bind-l/proxy/particiapi/api/session',
+                         headers=_SAME_ORIGIN, json={})
+    assert not any('cleartext non-loopback' in r.message for r in caplog.records)


### PR DESCRIPTION
Follow-up to the post-merge review of #245 (Issue 2: transport hardening).

**Depends on #263 — merge that first.** This branch is stacked on `fix/pr245-followup-a`, so until #263 merges this PR's diff also shows its commit.

Adds a runtime warning on every identity bind when the upstream link is unencrypted and non-loopback (we still bind — no behaviour change to the live feature), plus deployment-guide docs. The fail-closed flag was dropped as low-value; the warning is the kept half. Full rationale is in the commit message (cc51729).

🤖 Generated with [Claude Code](https://claude.com/claude-code)