### PR TITLE
fix(#269): dedup admin per-statement vote counts (votes_latest_unique + COUNT DISTINCT pid)

### DIFF
--- a/v2/polis_admin.py
+++ b/v2/polis_admin.py
@@ -26,15 +26,18 @@ _SAFE_ZINVITE = re.compile(r'^[A-Za-z0-9]{6,20}$')
 # Returns all active statements with vote counts, seeds first then by agree rate.
 # The agree-rate ordering is a heuristic proxy for group-representativeness when
 # cluster data (math_main) is not yet available or computed.
+# Counts use votes_latest_unique + COUNT(DISTINCT pid) so a participant is counted
+# once at their CURRENT vote — raw `votes` + COUNT(*) would inflate every count by
+# vote changes (see #269).
 _STATEMENTS_SQL = """
     WITH z AS (SELECT zid FROM zinvites WHERE zinvite = %s),
     vote_stats AS (
       SELECT
         v.tid,
-        COUNT(*) FILTER (WHERE v.vote = -1)::int AS agree_count,
-        COUNT(*) FILTER (WHERE v.vote =  1)::int AS disagree_count,
-        COUNT(*) FILTER (WHERE v.vote =  0)::int AS pass_count
-      FROM votes v, z WHERE v.zid = z.zid GROUP BY v.tid
+        COUNT(DISTINCT v.pid) FILTER (WHERE v.vote = -1)::int AS agree_count,
+        COUNT(DISTINCT v.pid) FILTER (WHERE v.vote =  1)::int AS disagree_count,
+        COUNT(DISTINCT v.pid) FILTER (WHERE v.vote =  0)::int AS pass_count
+      FROM votes_latest_unique v, z WHERE v.zid = z.zid GROUP BY v.tid
     )
     SELECT
       c.tid,
@@ -56,10 +59,10 @@ _FEATURED_CANDIDATES_SQL = """
     vote_stats AS (
       SELECT
         v.tid,
-        COUNT(*) FILTER (WHERE v.vote = -1)::int  AS n_agree,
-        COUNT(*) FILTER (WHERE v.vote =  1)::int  AS n_disagree,
-        COUNT(*) FILTER (WHERE v.vote != 0)::int  AS n_votes
-      FROM votes v, z WHERE v.zid = z.zid GROUP BY v.tid
+        COUNT(DISTINCT v.pid) FILTER (WHERE v.vote = -1)::int  AS n_agree,
+        COUNT(DISTINCT v.pid) FILTER (WHERE v.vote =  1)::int  AS n_disagree,
+        COUNT(DISTINCT v.pid) FILTER (WHERE v.vote != 0)::int  AS n_votes
+      FROM votes_latest_unique v, z WHERE v.zid = z.zid GROUP BY v.tid
     )
     SELECT
       c.tid,

--- a/v2/tests/test_stats_dedup_guard.py
+++ b/v2/tests/test_stats_dedup_guard.py
@@ -1,0 +1,39 @@
+"""Guard: admin per-statement vote counts must be deduplicated (#269).
+
+Repro of the bug this guards against — one participant, one statement:
+    (passed)          A 0  P 1  D 0
+    vote agree     -> A 1  P 1  D 0   (pass still counted!)
+    change disagree-> A 1  P 1  D 1   (agree still counted!)
+    change agree   -> A 2  P 1  D 1   (every event counted)
+
+Root cause: counting the raw append-only `votes` table with COUNT(*) counts every
+vote *event* (including changes). The fix counts DISTINCT participants at their
+CURRENT vote via `votes_latest_unique`.
+
+The query runs against a Polis Postgres view, so we can't execute it in the SQLite
+unit env (a true behavioural test needs the Polis PG — local-e2e / integration tier).
+Instead we assert the query SHAPE so a regression to the raw form fails CI.
+"""
+from polis_admin import _FEATURED_CANDIDATES_SQL, _STATEMENTS_SQL
+
+# Every admin SQL that reports per-statement vote counts to a human.
+ADMIN_COUNT_SQL = {
+    '_STATEMENTS_SQL': _STATEMENTS_SQL,
+    '_FEATURED_CANDIDATES_SQL': _FEATURED_CANDIDATES_SQL,
+}
+
+
+def test_admin_counts_use_deduplicated_source():
+    for name, sql in ADMIN_COUNT_SQL.items():
+        assert 'votes_latest_unique' in sql, \
+            f'{name} must count from votes_latest_unique, not raw votes (#269)'
+        assert 'FROM votes v,' not in sql, \
+            f'{name} must NOT count the raw append-only `votes` table (#269)'
+
+
+def test_admin_counts_count_distinct_participants():
+    for name, sql in ADMIN_COUNT_SQL.items():
+        assert 'COUNT(DISTINCT v.pid)' in sql, \
+            f'{name} must COUNT(DISTINCT v.pid) — one count per participant (#269)'
+        assert 'COUNT(*)' not in sql, \
+            f'{name} must not COUNT(*) vote rows (inflates on vote changes) (#269)'


### PR DESCRIPTION
Closes #269.

## Bug

The statements moderation page counted the **raw append-only `votes` table with `COUNT(*)`**, so every vote *event* — including vote changes — inflated the counts. Confirmed on staging (one participant, one statement):

| action | shown | should be |
|---|---|---|
| (passed) | A0 P1 D0 | A0 P1 D0 |
| vote agree | A1 **P1** D0 | A1 P0 D0 |
| change → disagree | **A1** P1 D1 | A0 P0 D1 |
| change → agree | **A2** P1 D1 | A1 P0 D0 |

## Fix

Switch `_STATEMENTS_SQL` and `_FEATURED_CANDIDATES_SQL` to **`votes_latest_unique` + `COUNT(DISTINCT v.pid)`** — one count per participant at their *current* vote — matching the participant-facing results and the conversation-level tiles (which already use this source). No other query touched.

## Test

`tests/test_stats_dedup_guard.py` — a CI guard asserting the admin count SQL uses `votes_latest_unique` + `COUNT(DISTINCT pid)` and never raw `votes` / `COUNT(*)`. The counts run against a Polis Postgres view, so a true *behavioural* test needs the Polis PG (local-e2e / integration tier); this guards the query **shape** so a regression fails CI.

- Full suite: **381 passed**; ruff clean.
- Manual verification (staging, real data): re-run the repro above → counts should now stay deduplicated (A1 P0 D0 throughout).

## Relationship
- Prerequisite for **#268** (featured-candidate ranking builds on these counts).
- **#236** relabeled these counts (A·P·D), which is what made the discrepancy visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)