### PR TITLE
fix(#272): restore phase-scheduler Toolforge job wiring lost in the #236 merge

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -79,6 +79,18 @@ if [ "$MIGRATE" -eq 1 ]; then
   echo "    Migrations done."
 fi
 
+echo "==> Reconciling scheduled jobs (Toolforge jobs framework)..."
+# Idempotent: re-asserts the schedule defined in jobs.yaml on every deploy.
+# Non-fatal (a jobs failure must not block the web deploy) but LOUD — an earlier soft
+# "WARNING" let a failed load slide past unnoticed, leaving the scheduler unregistered.
+if toolforge jobs load ~/wiki-polis/jobs.yaml; then
+  toolforge jobs list   # echo what's now registered so a silent no-op is visible
+else
+  echo "!!  ERROR: 'toolforge jobs load' FAILED — scheduled jobs (phase-scheduler) are NOT registered." >&2
+  echo "!!  Web deploy will still finish, but scheduled phase transitions will NOT fire until you" >&2
+  echo "!!  run 'toolforge jobs load ~/wiki-polis/jobs.yaml' manually and check 'toolforge jobs list'." >&2
+fi
+
 echo "==> Restarting web service..."
 cd ~
 toolforge webservice --backend=kubernetes python3.13 restart

--- a/jobs.yaml
+++ b/jobs.yaml
@@ -1,0 +1,9 @@
+# Toolforge scheduled jobs for wiki-polis. Single source of truth — loaded by deploy.sh
+# (`toolforge jobs load ~/wiki-polis/jobs.yaml`) on every deploy, so the schedule is
+# version-controlled and re-asserted each time. Future scheduled jobs (e.g. app-DB
+# backups) go here too.
+- name: phase-scheduler
+  command: ./wiki-polis/v2/bin/phase-scheduler.sh
+  image: python3.13
+  schedule: "*/5 * * * *"     # every 5 min → a scheduled transition fires within ~5 min of its time
+  emails: onfailure

--- a/v2/bin/phase-scheduler.sh
+++ b/v2/bin/phase-scheduler.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Toolforge scheduled job: fire due scheduled phase transitions.
+# Registered via ../../jobs.yaml (loaded by deploy.sh). Runs with the tool's injected
+# envvars, so — unlike an interactive bastion shell — SECRET_KEY etc. are present and no
+# MIGRATION_MODE / manual env export is needed.
+set -euo pipefail
+cd "$HOME/wiki-polis/v2"
+exec "$HOME/www/python/venv/bin/flask" --app app process-phase-schedules


### PR DESCRIPTION
## What happened

The #236 PR ("Parallel batch... ~50 issues") was resolved and merge-tested at `e791be3` — deployed to staging, migrations confirmed, and a **real scheduled phase transition verified firing end-to-end** via the Toolforge cron job (`toolforge jobs logs phase-scheduler` → `1 fired, 0 aborted, 0 not due`, phase visibly advanced in the admin UI).

But the PR's actual merge into `main` used a different final commit (`50efc5c`, "Reconcile divergent branch lines...") as its second parent — not `e791be3`. That reconciliation silently dropped three files/steps:

- `jobs.yaml` — the declarative Toolforge job definition (`phase-scheduler`, `*/5 * * * *`)
- `v2/bin/phase-scheduler.sh` — the wrapper script the cron actually invokes
- `deploy.sh`'s `toolforge jobs load` step, made **loud** (not silently swallowed) after the original bug that caused #272 in the first place

The underlying feature logic (`process_phase_schedules` CLI command, `_process_due_scheduled_transitions()`, the migrations, the admin countdown/edit/cancel UI) was untouched — only this operational registration was lost.

## Risk if left unfixed

Redeploying `main` as it currently stands (to staging or prod) would silently stop scheduled phase transitions from ever firing again, with no error — the exact original #272 bug, regressed.

## Fix

Restored the three pieces verbatim from the verified `e791be3` commit. `deploy.sh` diffs empty against that version (confirmed via `diff`).

## Verification

- `deploy.sh` byte-identical to the version already verified live on staging today.
- `jobs.yaml` / `v2/bin/phase-scheduler.sh` not gitignored — confirms they were dropped by the reconciliation, not deliberately excluded.
- Re-deploying this branch to staging should be a no-op for everything except re-registering the cron job — safe to verify with `toolforge jobs load ~/wiki-polis/jobs.yaml` + `toolforge jobs list` after deploy.

Closes the regression noted in #272 (reopened).

🤖 Generated with [Claude Code](https://claude.com/claude-code)