### PR TITLE
docs: add missing wiki-polis clone step for VPS ops scripts

### DIFF
--- a/v2/guide_deployment.md
+++ b/v2/guide_deployment.md
@@ -204,6 +204,14 @@ curl -s -o /dev/null -w "%{http_code}" http://<private-ip>:8000/
 chmod 600 ~/particiapp-docker/.env
 ```
 
+**Clone the wiki-polis ops scripts** — the `docker exec` helper scripts referenced below (`v2/ops/*.sh`) live in the wiki-polis repo itself, not in `particiapp-docker`. This VPS needs its own checkout:
+
+```bash
+git clone https://github.com/lgelauff/wiki-polis.git ~/wiki-polis
+```
+
+Run `cd ~/wiki-polis && git pull` after future deploys to pick up ops-script changes.
+
 **Create a read-only Postgres role** for the Flask admin connection — do not use the `polis` superuser for external connections:
 
 ```bash


### PR DESCRIPTION
## Summary
- `guide_deployment.md` documented cloning `particiapp-docker` onto the VPS but never instructed cloning `wiki-polis` itself, even though it references `~/wiki-polis/v2/ops/*.sh` helper scripts (e.g. `grant_polis_worker_tasks.sh`, the backup cron scripts).
- Found via issue #199 follow-up: `~/wiki-polis` was in fact missing entirely on the prod/staging VPS host, so the referenced grant script couldn't be run until it was cloned manually.
- Adds a short "Clone the wiki-polis ops scripts" step in the Security hardening section, right before the first `v2/ops/*.sh` reference.

## Test plan
- N/A — documentation-only change.
- Manually verified on the actual VPS during the #199 investigation: cloning `~/wiki-polis` there and then running `v2/ops/grant_polis_worker_tasks.sh` against both `particiapp-docker_postgres_1` (prod) and `wiki-polis-staging_postgres_1` (staging) worked as documented.

Follow-up to #199.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hmg6Av3eycUrDxad5Rze7t)_