### PR TITLE
fix: grey out the disabled statement-rewording submit button

### DIFF
--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -1011,6 +1011,7 @@ h3.conv-card-title-wrap {
   cursor: pointer;
 }
 .propose-submit-btn:hover { background: var(--accent); }
+.propose-submit-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 
 /* State C: submitted — spot/amber (not agree green) */
 /* ── All done message ── */

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -1012,6 +1012,7 @@ h3.conv-card-title-wrap {
 }
 .propose-submit-btn:hover { background: var(--accent); }
 .propose-submit-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.propose-submit-btn:disabled:hover { background: var(--surface2); }
 
 /* State C: submitted — spot/amber (not agree green) */
 /* ── All done message ── */


### PR DESCRIPTION
## Summary
- The "Suggest different wording" / new-statement composer's submit button (`.propose-submit-btn`) starts `disabled` and its JS correctly toggles the attribute, but the class had no `:disabled` CSS rule — so a disabled button looked fully active and appeared to silently do nothing when clicked.
- Adds `.propose-submit-btn:disabled { opacity: 0.4; cursor: not-allowed; }`, matching the existing pattern used elsewhere (`.btn-primary:disabled`, `.p6-navbtn:disabled`).

## Test plan
- [x] Verified visually: disabled button now renders greyed out vs. the enabled black button (screenshot taken during review)
- [x] No JS/behavior change — CSS-only fix