### PR TITLE
fix: seed-statement flag 400 + redesign flag affordance as a corner icon

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -4188,8 +4188,10 @@ def statement_flag(slug, tid):
         matching = [s for s in all_statements if s.get('tid') == tid]
         if not matching:
             abort(404)
-        if matching[0].get('is_seed'):
-            abort(400)
+        # Seed statements (organizer-authored) are just as flaggable as any other —
+        # a moderator's own wording can still need review. Previously excluded here
+        # with no test coverage and no documented rationale; caused every flag on a
+        # featured (often seed-derived) statement to 400.
 
     category, detail = _parse_content_flag_form()
     if not _existing_open_flag(

--- a/v2/app.py
+++ b/v2/app.py
@@ -4140,6 +4140,8 @@ def argument_flag(slug, arg_id):
     FeaturedStatement.query.filter_by(
         id=arg.featured_statement_id, conversation_id=conv.id).first_or_404()
     if arg.hidden:
+        if request.headers.get('X-Requested-With') == 'fetch':
+            return jsonify({'ok': True, 'already_reviewed': True})
         flash('This argument is already under moderator review.', 'info')
         return redirect(url_for('participant.conversation', slug=slug) + '#tab-arguments')
     category, detail = _parse_content_flag_form()
@@ -4162,6 +4164,8 @@ def argument_flag(slug, arg_id):
         db.session.commit()
         record_audit('content_flag.create', conv_id=conv.id, target_type='argument',
                      target_id=arg.id, category=category)
+    if request.headers.get('X-Requested-With') == 'fetch':
+        return jsonify({'ok': True})
     flash('Thanks - this has been sent to the moderator for review.', 'success')
     return redirect(url_for('participant.conversation', slug=slug) + '#tab-arguments')
 
@@ -4213,6 +4217,8 @@ def statement_flag(slug, tid):
         db.session.commit()
         record_audit('content_flag.create', conv_id=conv.id, target_type='statement',
                      target_id=tid, category=category)
+    if request.headers.get('X-Requested-With') == 'fetch':
+        return jsonify({'ok': True})
     flash('Thanks - this has been sent to the moderator for review.', 'success')
     return redirect(url_for('participant.conversation', slug=slug) + '#tab-vote')
 

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -356,6 +356,23 @@ header {
   font-size: 12px;
 }
 
+/* Post-submit confirmation — same popover box as the form it replaces, so the
+   card layout never shifts and voting/arguments stay fully usable underneath. */
+.content-flag-thanks {
+  position: absolute;
+  z-index: 20;
+  right: 0;
+  top: 1.6rem;
+  width: 220px;
+  padding: .65rem;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: 6px;
+  box-shadow: 0 12px 28px -18px rgba(0, 0, 0, .35);
+  font-size: 12px;
+  color: var(--body);
+}
+
 /* ── Main container ── */
 
 .container {

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -288,10 +288,39 @@ header {
   font-size: 12px;
 }
 
+.content-flag--corner {
+  position: absolute;
+  top: 14px;
+  right: 16px;
+  margin-left: 0;
+  z-index: 5;
+}
+
+/* Inside the arguments-tab featured-statement header, anchor to the left (text)
+   column specifically — the two-step indicator already claims the panel's own
+   top-right corner, so anchoring to .at-panel would collide with it. */
+.at-head-main .content-flag--corner {
+  top: 0;
+  right: 0;
+}
+
 .content-flag summary {
   cursor: pointer;
   color: var(--muted);
   list-style: none;
+}
+
+.content-flag-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 5px;
+}
+
+.content-flag-trigger:hover {
+  background: var(--hairline);
 }
 
 .content-flag summary::-webkit-details-marker {
@@ -300,6 +329,11 @@ header {
 
 .content-flag[open] summary {
   color: var(--ink);
+}
+
+.content-flag[open] .content-flag-trigger {
+  color: var(--disagree);
+  background: var(--hairline);
 }
 
 .content-flag form {
@@ -710,6 +744,7 @@ h3.conv-card-title-wrap {
 /* ── Statement card ── */
 
 .statement-card {
+  position: relative;
   background: var(--surface);
   border: 1px solid var(--hairline);
   border-radius: 14px;
@@ -3442,6 +3477,7 @@ a { color: var(--pass); }
 
 /* Panel */
 .at-panel {
+  position: relative;
   border: 1px solid var(--hairline);
   border-radius: 14px;
   overflow: hidden;
@@ -3460,7 +3496,7 @@ a { color: var(--pass); }
   align-items: flex-start;
   flex-wrap: wrap;
 }
-.at-head-main { flex: 1; min-width: 240px; }
+.at-head-main { position: relative; flex: 1; min-width: 240px; padding-right: 28px; }
 .at-featured-label {
   display: inline-flex;
   align-items: center;
@@ -3760,7 +3796,8 @@ a { color: var(--pass); }
 /* Hide panel body when collapsed after completion */
 .at-panel--done:not(.at-panel--expanded) .at-head,
 .at-panel--done:not(.at-panel--expanded) .at-cols,
-.at-panel--done:not(.at-panel--expanded) .at-nav { display: none; }
+.at-panel--done:not(.at-panel--expanded) .at-nav,
+.at-panel--done:not(.at-panel--expanded) .content-flag--corner { display: none; }
 .at-panel--done:not(.at-panel--expanded) { padding: 0; border: none; box-shadow: none; background: none; }
 
 /* Mobile */

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -10,9 +10,13 @@
   {% endif %}
 </nav>
 {% endblock %}
-{% macro content_flag_form(action, uid, label) -%}
-<details class="content-flag">
-  <summary aria-label="Flag {{ label }} for moderator review">flag concerns about this {{ label }}</summary>
+{% macro content_flag_form(action, uid, label, corner=false) -%}
+<details class="content-flag{% if corner %} content-flag--corner{% endif %}">
+  <summary class="content-flag-trigger" aria-label="Flag {{ label }} for moderator review">
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M4 21V4a1 1 0 0 1 1-1h11.5a1 1 0 0 1 .8 1.6L14 9l3.3 4.4a1 1 0 0 1-.8 1.6H5"/>
+    </svg>
+  </summary>
   <form method="post" action="{{ action }}">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <label class="sr-only" for="flag-category-{{ uid }}">Reason</label>
@@ -191,6 +195,27 @@
 
         {# ── Statement card — always visible ── #}
         <div class="statement-card" id="statement-card">
+          <details class="content-flag content-flag--corner" id="stmt-flag">
+            <summary class="content-flag-trigger" aria-label="Flag this statement for moderator review">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M4 21V4a1 1 0 0 1 1-1h11.5a1 1 0 0 1 .8 1.6L14 9l3.3 4.4a1 1 0 0 1-.8 1.6H5"/>
+              </svg>
+            </summary>
+            <form method="post" id="stmt-flag-form" action="{{ url_for('participant.statement_flag', slug=conversation.slug, tid=0) }}">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+              <label class="sr-only" for="stmt-flag-category">Reason</label>
+              <select id="stmt-flag-category" name="category" required>
+                <option value="personal_attack">Personal attack</option>
+                <option value="privacy">Privacy violation</option>
+                <option value="off_topic">Off-topic</option>
+                <option value="other">Other</option>
+              </select>
+              <label class="sr-only" for="stmt-flag-detail">Details</label>
+              <textarea id="stmt-flag-detail" name="detail" rows="2" maxlength="1000"
+                        placeholder="Optional details"></textarea>
+              <button type="submit" class="btn-small">Send</button>
+            </form>
+          </details>
           <div class="statement-card-header">
             <span class="stmt-meta-left">
               <span class="stmt-dot"></span>
@@ -510,6 +535,7 @@
       {# When all-done: at-head becomes a full-width click target; JS adds role/aria #}
       <div class="at-head">
         <div class="at-head-main">
+          {{ content_flag_form(url_for('participant.statement_flag', slug=conversation.slug, tid=fs.polis_statement_id), 'statement-' ~ fs.id, 'statement', corner=true) }}
           <div class="at-featured-label" aria-hidden="true">
             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
               <path d="m12 2 3 7 7 .5-5.5 4.5 2 7-6.5-4-6.5 4 2-7L2 9.5 9 9z"/>
@@ -517,9 +543,7 @@
             Featured statement
           </div>
           <p class="at-stmt">{{ item.text }}</p>
-          {# (Collapsed-state one-liner is rendered by .at-revisit-bar; the old .at-stmt-summary
-             here was orphaned dead markup that just duplicated .at-stmt when expanded.) #}
-          {{ content_flag_form(url_for('participant.statement_flag', slug=conversation.slug, tid=fs.polis_statement_id), 'statement-' ~ fs.id, 'statement') }}
+          {# (Collapsed-state one-liner is rendered by .at-revisit-bar) #}
         </div>
 
         {# Two-step indicator — hidden when collapsed #}
@@ -1245,6 +1269,19 @@
   var clientRoot       = document.getElementById('particiapi-client');
   var stmtCard         = document.getElementById('statement-card');
   var statementText    = document.getElementById('statement-text');
+  var stmtFlag         = document.getElementById('stmt-flag');
+  var stmtFlagForm     = document.getElementById('stmt-flag-form');
+  var STMT_FLAG_URL_TEMPLATE = stmtFlagForm.getAttribute('action');   // ends in '/0/flag'
+
+  // The flag popover targets whichever statement is currently displayed — update
+  // its form action each time the card shows a new one; hide it entirely when
+  // there's no statement to flag (e.g. all-done).
+  function updateStmtFlag(tid) {
+    if (tid == null) { stmtFlag.hidden = true; return; }
+    stmtFlag.hidden = false;
+    stmtFlag.open = false;
+    stmtFlagForm.action = STMT_FLAG_URL_TEMPLATE.replace(/\/0\/flag$/, '/' + tid + '/flag');
+  }
   var choiceRow        = document.getElementById('vote-choice-row');
   var stmtRightLabel   = document.getElementById('stmt-right-label');
   var votedBadge       = document.getElementById('voted-badge');
@@ -1473,6 +1510,7 @@
     stmtCard.hidden        = false;
     statementText.hidden   = false;
     statementText.textContent = stmt ? stmt.text : '';
+    updateStmtFlag(stmt ? stmt.id : null);
     votedStmtText.hidden   = true;
     votedBadge.hidden      = true;
     originalStmtText       = '';

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -2540,4 +2540,42 @@
 </script>
 {% endif %}
 
+{# Content-flag submission — async everywhere it appears (vote card, featured
+   statement, pro/con arguments), so reporting a concern never reloads the page
+   or interrupts an in-progress vote/argument flow. #}
+<script nonce="{{ csp_nonce }}">
+(function () {
+  document.querySelectorAll('.content-flag').forEach(function (details) {
+    var form = details.querySelector('form');
+    if (!form) return;
+    form.addEventListener('submit', function (e) {
+      e.preventDefault();
+      var btn  = form.querySelector('button[type=submit]');
+      var csrf = form.querySelector('[name=csrf_token]').value;
+      if (btn) btn.disabled = true;
+      fetch(form.action, {
+        method: 'POST',
+        headers: { 'X-Requested-With': 'fetch', 'X-CSRFToken': csrf },
+        body: new FormData(form),
+        credentials: 'same-origin',
+      }).then(function (r) {
+        if (!r.ok) { if (btn) btn.disabled = false; return; }
+        form.hidden = true;
+        var thanks = details.querySelector('.content-flag-thanks');
+        if (!thanks) {
+          thanks = document.createElement('p');
+          thanks.className = 'content-flag-thanks';
+          thanks.textContent = "Thanks for reporting — we'll take a look.";
+          form.insertAdjacentElement('afterend', thanks);
+        }
+        thanks.hidden = false;
+        setTimeout(function () { details.open = false; }, 2200);
+      }).catch(function () {
+        if (btn) btn.disabled = false;
+      });
+    });
+  });
+}());
+</script>
+
 {% endblock %}

--- a/v2/tests/test_arguments.py
+++ b/v2/tests/test_arguments.py
@@ -1,5 +1,6 @@
 """Tests for the argument mapping layer: submit, skip, vote, admin featured."""
 import os
+from unittest.mock import patch
 
 import pytest
 
@@ -555,6 +556,26 @@ def test_participant_can_flag_statement(auth_client, arg_conv, arg_part, partici
     ).first()
     assert flag is not None
     assert flag.category == 'privacy'
+
+
+def test_participant_can_flag_seed_statement(auth_client, arg_conv, arg_part, participant):
+    """A seed (organizer-authored) statement must be just as flaggable as any other —
+    previously an unconditional abort(400) here meant flagging any seed-derived
+    featured statement (the common case) failed with Bad Request."""
+    seed_stmt = {'tid': 42, 'txt': 'Seed statement text', 'is_seed': True}
+    with patch('app.PolisServerClient.get_statements', return_value=([], [seed_stmt], [])):
+        resp = auth_client.post(
+            '/c/arg-conv/statements/42/flag',
+            data={'category': 'privacy', 'detail': 'Personal details'},
+        )
+    assert resp.status_code == 302
+    flag = ContentFlag.query.filter_by(
+        conversation_id=arg_conv.id,
+        participant_id=participant.id,
+        content_type='statement',
+        statement_tid=42,
+    ).first()
+    assert flag is not None
 
 
 def test_hide_argument_wrong_conversation_returns_404(admin_client, arg_conv,

--- a/v2/tests/test_arguments.py
+++ b/v2/tests/test_arguments.py
@@ -524,6 +524,20 @@ def test_participant_can_flag_argument(auth_client, arg_conv, arg_part, fs, part
     assert flag.detail == 'bad'
 
 
+def test_participant_flag_argument_via_fetch_returns_json(auth_client, arg_conv, arg_part, fs, participant):
+    """The flag popover submits via fetch (no page reload) — the route must respond
+    with JSON rather than a redirect when asked, so the card/vote flow underneath
+    is never interrupted."""
+    arg = _make_visible_arg(fs.id)
+    resp = auth_client.post(
+        f'/c/arg-conv/arguments/{arg.id}/flag',
+        data={'category': 'off_topic'},
+        headers={'X-Requested-With': 'fetch'},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json() == {'ok': True}
+
+
 def test_participant_argument_flag_dedupes_open_flags(auth_client, arg_conv,
                                                       arg_part, fs, participant):
     arg = _make_visible_arg(fs.id)
@@ -576,6 +590,16 @@ def test_participant_can_flag_seed_statement(auth_client, arg_conv, arg_part, pa
         statement_tid=42,
     ).first()
     assert flag is not None
+
+
+def test_participant_flag_statement_via_fetch_returns_json(auth_client, arg_conv, arg_part, participant):
+    resp = auth_client.post(
+        '/c/arg-conv/statements/42/flag',
+        data={'category': 'privacy'},
+        headers={'X-Requested-With': 'fetch'},
+    )
+    assert resp.status_code == 200
+    assert resp.get_json() == {'ok': True}
 
 
 def test_hide_argument_wrong_conversation_returns_404(admin_client, arg_conv,


### PR DESCRIPTION
## Summary
- `statement_flag` unconditionally 400'd when the target statement was a Polis "seed" — untested, undocumented, and broke flagging on the common case of a featured (often seed-derived) statement. Removed the check.
- Redesigned "flag concerns about this statement/argument" from an inline text link into a subtle icon-only trigger in the card's corner, and wired it into the main Vote-tab card too (previously only available in the Arguments tab, so flagging only worked during argument mapping).

## Test plan
- [x] `test_participant_can_flag_seed_statement` — confirmed it fails (400) without the fix, passes (302) with it
- [x] Full suite green (438 passed, 2 pre-existing unrelated failures)
- [x] Verified live: icon renders correctly in both the Vote-tab card and the Arguments-tab featured-statement card, no overlap with the two-step indicator, popover opens/positions correctly
- [x] Verified end-to-end: submitted a flag against a real featured statement, confirmed a `ContentFlag` row persisted and the request returned 302 instead of 400