### PR TITLE
fix(phase6): persist informed votes across reload, bind identity, correct vote sign

### DIFF
--- a/v2/.gitignore
+++ b/v2/.gitignore
@@ -1,2 +1,5 @@
 # Internal Claude planning/working files — never commit
 .claude/
+
+# Run-log written by ops/migrate_phase6_vote_signs.py (per-machine runtime state)
+ops/phase6_sign_fix.applied.log

--- a/v2/app.py
+++ b/v2/app.py
@@ -3851,6 +3851,19 @@ def conversation(slug):
         ordered_ids = set(participation.phase6_card_order)
         ordered += [fs for fs in p6_stmts if fs.id not in ordered_ids]
 
+        # Restore the participant's prior Phase 6 votes so a reload shows their choices
+        # (#votes-persist). Read from Polis — the single source of truth — resolving their
+        # pid via the trusted-sub identity they voted under (particiapi_users). Keyed by
+        # phase6 tid; converted from Polis sign (-1=agree) back to the button convention
+        # (1=agree) so it matches data-vote in the template. Empty/None on no votes or PG down.
+        my_p6_votes: dict[int, int] = {}
+        _xid = session.get('xid')
+        if _xid and current_app.config.get('PARTICIAPI_SUB_SECRET'):
+            _raw = _polis_server_client().get_personal_votes_by_subject(
+                conv.phase6_polis_conversation_id, _conversation_subject(_xid, conv))
+            if _raw:
+                my_p6_votes = {tid: -vote for tid, vote in _raw.items()}
+
         for fs in ordered:
             text = fs.statement_text or ''
             if not text:
@@ -3868,7 +3881,16 @@ def conversation(slug):
                 'pro': pro,
                 'con': con,
                 'phase6_stmt_id': fs.phase6_polis_statement_id,
+                # Prior vote in button convention (1=agree, 0=pass, -1=disagree), or None
+                # if not yet voted — drives the server-rendered selected state on reload.
+                'my_vote': my_p6_votes.get(fs.phase6_polis_statement_id),
             })
+
+    # Whether every card already has a vote — so a reload after completing the round
+    # re-shows the "You've completed informed voting" screen (client sets this on the
+    # final vote; this preserves it across reload).
+    phase6_all_voted = bool(phase6_data) and all(
+        d['my_vote'] is not None for d in phase6_data)
 
     # Phase 6 results — built when the results tab is visible or Phase 6 is active.
     # Surface A (preliminary) is shown inside the results tab while the round is live.
@@ -3893,6 +3915,7 @@ def conversation(slug):
                            new_stmt_max=conv.argument_vote_data.get('new_stmt_max', 3) if conv.argument_vote_data else 3,
                            new_stmt_ids=participation.new_stmt_ids if participation else [],
                            phase6_data=phase6_data,
+                           phase6_all_voted=phase6_all_voted,
                            phase6_results=phase6_results,
                            output_items=_output_items(conv),
                            moderation_log_count=moderation_log_count)
@@ -4362,16 +4385,46 @@ def phase6_vote(slug):
     tid           = fs.phase6_polis_statement_id
 
     # Ensure a stable Polis session and CSRF token before voting.
-    # Mirrors the exact pattern used in conversation_statement_new.
+    #
+    # Bind the participant's stable per-conversation identity to Particiapi the same way
+    # the conversation-scoped proxy does (#246): assert X-Particiapi-Sub on the session
+    # bootstrap so the vote lands under the participant's real Polis uid rather than a
+    # fresh anonymous one. Without this a Phase 6 vote fragments the tally (a new uid per
+    # session) and can never be read back to restore the participant's choice on reload.
+    # The subject is keyed by conv.id, so it matches the participant's Phase-2 uid — their
+    # initial and informed votes share one uid (see _conversation_subject).
     pa_cookie = request.cookies.get('pa_session')
     base = current_app.config['PARTICIAPI_BASE']
-    forwarded = {'session': pa_cookie} if pa_cookie else {}
+
+    _xid        = session.get('xid')
+    _sub_secret = current_app.config.get('PARTICIAPI_SUB_SECRET')
+    _sub        = _conversation_subject(_xid, conv) if _xid else None
+    _bind       = bool(_sub) and bool(_sub_secret)
+    if _bind and not _is_secure_pa_transport(base):
+        current_app.logger.warning(
+            'PARTICIAPI_SUB_SECRET is being sent over a cleartext non-loopback transport '
+            '(%s); encrypt the Toolforge<->VPS hop (WireGuard/TLS)', base)
+
+    sess_headers: dict = {}
+    sess_params:  dict = {}
+    # On a bind, deliberately do NOT forward an existing (possibly anonymous) session
+    # cookie — it would make Particiapi skip the bind and pin the user to a throwaway uid.
+    forwarded: dict = {}
+    if _bind:
+        sess_headers['X-Particiapi-Sub']        = _sub
+        sess_headers['X-Particiapi-Sub-Secret'] = _sub_secret
+    elif pa_cookie:
+        forwarded['session'] = pa_cookie
+    else:
+        sess_params['create'] = 'true'
+
     new_pa_cookie = None
     try:
         sess_resp = requests.post(
             f'{base}/api/session',
             cookies=forwarded,
-            params={'create': 'true'},
+            params=sess_params,
+            headers=sess_headers,
             timeout=5,
         )
         if not sess_resp.ok:
@@ -4386,11 +4439,17 @@ def phase6_vote(slug):
 
     vote_cookies = {'session': new_pa_cookie or pa_cookie} if (new_pa_cookie or pa_cookie) else {}
 
+    # Sign convention: the Phase 6 buttons use the app convention (1=agree, -1=disagree,
+    # 0=pass), but Polis stores the opposite sign (-1=agree, +1=disagree, 0=pass) — the
+    # same raw sign the Phase-2 web component writes and that the vote-count SQL assumes.
+    # Negate so the informed-vote tally is consistent with Phase 2 (pass is unchanged).
+    polis_value = -vote
+
     # Particiapi vote endpoint: PUT /api/conversations/{id}/votes/{tid} with {value: N}.
     try:
         upstream = requests.put(
             f'{base}/api/conversations/{polis_conv_id}/votes/{tid}',
-            json={'value': vote},
+            json={'value': polis_value},
             cookies=vote_cookies,
             headers={'X-CSRF-Token': csrf_token},
             timeout=10,
@@ -4403,8 +4462,10 @@ def phase6_vote(slug):
     if upstream.ok:
         _touch_last_engagement(participation, commit=True)
     if new_pa_cookie:
-        resp.set_cookie('pa_session', new_pa_cookie, httponly=True,
-                        samesite='Lax', secure=not current_app.debug)
+        # Path-scope to this conversation's Phase 6 routes so the session is reused across
+        # informed-vote calls and never collides with the proxy's own pa_session cookie.
+        resp.set_cookie('pa_session', new_pa_cookie, path=f'/c/{conv.slug}/phase6',
+                        httponly=True, samesite='Lax', secure=not current_app.debug)
     return resp
 
 

--- a/v2/docker-compose.wiki-polis.local.yaml
+++ b/v2/docker-compose.wiki-polis.local.yaml
@@ -9,9 +9,17 @@ services:
       - "${WIKI_POLIS_DIR:?set WIKI_POLIS_DIR to the wiki-polis checkout}/v2/tmp/postgres-backups:/backups"
 
   particiapi:
+    # Upstream :latest lacks trusted-sub identity binding; use the feature build so the
+    # proxy's X-Particiapi-Sub headers are honoured (matches the pinned particiapi submodule).
+    image: "${PARTICIAPI_IMAGE:-ghcr.io/lgelauff/particiapi:trusted-sub}"
     environment:
       PARTICIAPI_AUTHENTICATION_DISABLED: "True"
       PARTICIAPI_CORS_ORIGINS: "http://127.0.0.1:${FLASK_HOST_PORT:-5001}"
+      # Enables trusted-sub identity binding locally so the wiki-polis proxy's
+      # X-Particiapi-Sub / X-Particiapi-Sub-Secret headers are honoured (maps
+      # subject → uid in particiapi_users → stable per-participant uid). Must
+      # match the Flask side's PARTICIAPI_SUB_SECRET. Dev-only value; export to override.
+      PARTICIAPI_TRUSTED_SUB_SECRET: "${PARTICIAPI_TRUSTED_SUB_SECRET:-wiki-polis-local-dev}"
     ports: !override
       - "127.0.0.1:${PARTICIAPI_HOST_PORT:-8002}:5000"
 

--- a/v2/ops/migrate_phase6_vote_signs.py
+++ b/v2/ops/migrate_phase6_vote_signs.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""One-off remediation: negate the sign of existing Phase 6 (informed voting) votes
+in the Polis database so they match the corrected Polis-native convention.
+
+Background
+----------
+Before the phase6 vote fix, `phase6_vote` forwarded the app's button sign (1=agree)
+to Polis verbatim, but Polis stores the opposite (-1=agree, +1=disagree, 0=pass).
+So every Phase 6 vote cast before the fix is sign-inverted relative to Phase 2 and
+to the vote-count SQL, making informed-vote counts swap agree/disagree. This script
+flips the sign of those pre-fix votes (pass, 0, is left unchanged).
+
+CRITICAL — run EXACTLY ONCE, during a voting freeze
+---------------------------------------------------
+Negation is its own inverse: running it twice re-inverts and silently corrupts the
+data. There is no way to tell a pre-fix (inverted) vote from a post-fix (correct)
+one by value alone, so:
+
+  * Phase 6 voting MUST be paused/closed while this runs, so that NO post-fix
+    (already-correct) votes exist to be wrongly re-inverted. Every remaining Phase 6
+    vote must be pre-fix.
+  * A local run-log (``--log-file``) records applied zids and refuses to re-apply
+    them without ``--force``. Keep that log; do not run on a second machine.
+
+Recommended operational sequence
+--------------------------------
+  1. Pause / close all Phase 6 rounds (no voting during the window).
+  2. Take a Polis database backup.
+  3. Dry-run this script and eyeball the affected conversations + counts.
+  4. Deploy the phase6 vote fix (so new votes store the correct sign).
+  5. Run with --apply.
+  6. Re-open the rounds.
+  (Steps 4 and 5 may swap: with voting frozen, all existing votes are pre-fix either
+  way. What must not happen is new votes being cast between steps 1 and 5.)
+
+Note: this does not, and cannot, repair the *identity* of pre-fix votes — those were
+recorded under throwaway anonymous Polis uids and are not linkable to a participant.
+This only corrects their sign.
+
+Usage
+-----
+  # dry run (default) — reports affected conversations + vote counts, changes nothing
+  uv run python ops/migrate_phase6_vote_signs.py --polis-db "$POLIS_DATABASE_URL"
+
+  # apply
+  uv run python ops/migrate_phase6_vote_signs.py --polis-db "$POLIS_DATABASE_URL" --apply
+
+  # restrict to explicit zinvites instead of auto-discovering from the wiki-polis DB
+  uv run python ops/migrate_phase6_vote_signs.py --polis-db "$POLIS_DATABASE_URL" \
+      --zinvites 7yhhfecxzy,abcd123456
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+import psycopg2
+
+
+def _discover_phase6_zinvites() -> tuple[list[str], dict[str, str]]:
+    """Phase 6 conversation zinvites + a {zinvite: slug} label map, from the wiki-polis
+    DB (the only source that knows which Polis conversations are Phase 6). Uses the
+    module-level app so create_app runs once (a second call collides on 'sessions')."""
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from app import app                          # noqa: E402  (module-level app)
+    from db import Conversation                  # noqa: E402
+    with app.app_context():
+        rows = (Conversation.query
+                .filter(Conversation.phase6_polis_conversation_id.isnot(None))
+                .with_entities(Conversation.slug,
+                               Conversation.phase6_polis_conversation_id)
+                .all())
+    return [z for _slug, z in rows], {z: slug for slug, z in rows}
+
+
+def _relkind(cur, relname: str) -> str | None:
+    cur.execute("SELECT relkind FROM pg_class WHERE relname = %s", (relname,))
+    row = cur.fetchone()
+    return row[0] if row else None
+
+
+def _load_log(path: str) -> set[str]:
+    if not path or not os.path.exists(path):
+        return set()
+    with open(path) as f:
+        return {rec['zinvite'] for rec in (json.loads(l) for l in f if l.strip())}
+
+
+def _append_log(path: str, zinvite: str, n: int) -> None:
+    if not path:
+        return
+    with open(path, 'a') as f:
+        f.write(json.dumps({
+            'zinvite': zinvite, 'flipped': n,
+            'at': datetime.now(timezone.utc).isoformat(),
+        }) + '\n')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--polis-db', default=os.environ.get('POLIS_DATABASE_URL', ''),
+                        help='Polis Postgres connection URL (or POLIS_DATABASE_URL).')
+    parser.add_argument('--zinvites', default='',
+                        help='Comma-separated zinvites to limit to; default: '
+                             'auto-discover all Phase 6 conversations from wiki-polis.')
+    parser.add_argument('--apply', action='store_true',
+                        help='Actually negate signs. Without this, dry-run only.')
+    parser.add_argument('--force', action='store_true',
+                        help='Re-apply even to zinvites already in the run-log. '
+                             'DANGEROUS — re-inverts. Only with a fresh backup.')
+    parser.add_argument('--log-file',
+                        default=os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                             'phase6_sign_fix.applied.log'),
+                        help='Run-log guarding against double-application.')
+    args = parser.parse_args()
+
+    if not args.polis_db:
+        print('ERROR: --polis-db (or POLIS_DATABASE_URL) is required.', file=sys.stderr)
+        return 2
+
+    slug_by_zinvite: dict[str, str] = {}
+    if args.zinvites:
+        zinvites = [z.strip() for z in args.zinvites.split(',') if z.strip()]
+    else:
+        zinvites, slug_by_zinvite = _discover_phase6_zinvites()
+    if not zinvites:
+        print('No Phase 6 conversations found — nothing to do.')
+        return 0
+
+    already = _load_log(args.log_file)
+    print(f'Mode: {"APPLY" if args.apply else "DRY-RUN"}   '
+          f'Phase 6 conversations: {len(zinvites)}')
+
+    conn = psycopg2.connect(args.polis_db)
+    conn.autocommit = False
+    total_flipped = 0
+    try:
+        with conn.cursor() as cur:
+            vlu_kind = _relkind(cur, 'votes_latest_unique')
+            # In this Polis build votes_latest_unique is an ordinary TABLE ('r'), NOT a
+            # view — the counts SQL and the readback both read it, so it must be negated
+            # alongside the append-only `votes` log or the correction won't be visible.
+            # ('v' view → reflects `votes` automatically; 'm' matview → refresh.)
+            _kinds = {'r': 'table (will be updated directly)',
+                      'v': 'view (reflects source automatically)',
+                      'm': 'materialized view (will be refreshed)'}
+            print(f'votes_latest_unique relkind: {vlu_kind!r} — '
+                  f'{_kinds.get(vlu_kind, "unknown — verify manually")}')
+
+            applied: list[tuple[str, int]] = []  # (zinvite, flipped) to log after commit
+            for z in zinvites:
+                label = slug_by_zinvite.get(z, z)
+                cur.execute('SELECT zid FROM zinvites WHERE zinvite = %s', (z,))
+                row = cur.fetchone()
+                if not row:
+                    print(f'  [skip] {label} ({z}): no such zinvite in Polis')
+                    continue
+                zid = row[0]
+                cur.execute('SELECT COUNT(*) FROM votes WHERE zid = %s AND vote <> 0', (zid,))
+                n = cur.fetchone()[0]
+
+                if z in already and not args.force:
+                    print(f'  [skip] {label} ({z}): already in run-log '
+                          f'({n} sign-bearing votes) — use --force to override')
+                    continue
+
+                print(f'  {label} ({z}, zid={zid}): {n} sign-bearing votes to flip')
+                if args.apply:
+                    # Negate the append-only log...
+                    cur.execute('UPDATE votes SET vote = -vote WHERE zid = %s AND vote <> 0',
+                                (zid,))
+                    total_flipped += cur.rowcount
+                    # ...and the read path. votes_latest_unique is a real table here, so
+                    # it must be negated directly (a view would follow `votes`; a matview
+                    # is refreshed instead).
+                    if vlu_kind == 'r':
+                        cur.execute('UPDATE votes_latest_unique SET vote = -vote '
+                                    'WHERE zid = %s AND vote <> 0', (zid,))
+                    elif vlu_kind == 'm':
+                        cur.execute('REFRESH MATERIALIZED VIEW votes_latest_unique')
+                    applied.append((z, n))
+
+            if args.apply:
+                conn.commit()
+                # Log only after a successful commit, only the zinvites actually flipped.
+                for z, n in applied:
+                    _append_log(args.log_file, z, n)
+                print(f'\nAPPLIED — flipped {total_flipped} vote rows across '
+                      f'{len(applied)} conversation(s). Run-log: {args.log_file}')
+                if vlu_kind not in ('v', 'm', 'r'):
+                    print('WARNING: votes_latest_unique has an unexpected kind; verify it '
+                          'reflects the update (a Polis math recompute may be needed).')
+            else:
+                print('\nDRY-RUN — no changes made. Re-run with --apply to execute.')
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/v2/polis_admin.py
+++ b/v2/polis_admin.py
@@ -169,6 +169,34 @@ _PERSONAL_VOTES_SQL = """
     WHERE v.zid = z.zid AND v.pid = %s
 """
 
+# Issuer namespace wiki-polis asserts to Particiapi's trusted-sub identity (must match
+# the literal used by Particiapi's get_or_create_uid on the X-Particiapi-Sub path).
+PARTICIAPI_ISSUER = 'wiki-polis'
+
+# Personal votes resolved by trusted-sub SUBJECT rather than a pre-known pid. This is how
+# wiki-polis identity actually maps to a Polis uid: the proxy/phase6 vote assert
+# X-Particiapi-Sub = subject, which Particiapi records in particiapi_users(subject → uid).
+# (The legacy `xids` table is NOT populated by trusted-sub, so it can't be used here.)
+# Resolves subject → uid → this conversation's pid, then returns that pid's latest votes.
+# Raw vote sign: -1 = agree, +1 = disagree, 0 = pass (Polis convention).
+_PERSONAL_VOTES_BY_SUBJECT_SQL = """
+    WITH z AS (SELECT zid FROM zinvites WHERE zinvite = %s),
+    u AS (
+        SELECT pu.uid
+        FROM particiapi_users pu
+        JOIN particiapi_issuers i ON i.issid = pu.issid
+        WHERE i.issuer = %s AND pu.subject = %s
+    ),
+    p AS (
+        SELECT part.pid
+        FROM participants part, z, u
+        WHERE part.zid = z.zid AND part.uid = u.uid
+    )
+    SELECT v.tid, v.vote
+    FROM votes_latest_unique v, z, p
+    WHERE v.zid = z.zid AND v.pid = p.pid
+"""
+
 _POLIS_STATS_SQL = """
     WITH z AS (SELECT zid FROM zinvites WHERE zinvite = %s),
     vd AS (
@@ -739,6 +767,34 @@ class PolisServerClient:
             _PERSONAL_VOTES_SQL,
             (zinvite, polis_pid),
             'get_personal_votes',
+        )
+        if rows is None:
+            return None
+        return {int(r[0]): int(r[1]) for r in rows}
+
+    def get_personal_votes_by_subject(
+        self,
+        zinvite: str,
+        subject: str,
+        issuer: str = PARTICIAPI_ISSUER,
+    ) -> dict[int, int] | None:
+        """Return the participant's own votes in a conversation keyed by tid, resolving
+        their Polis pid from the trusted-sub identity map (particiapi_users) rather than a
+        pre-known pid.
+
+        subject: the X-Particiapi-Sub value wiki-polis binds for this participant in this
+                 conversation (see app._conversation_subject) — Particiapi maps it to a
+                 stable uid, which resolves to the conversation's pid.
+
+        Returns dict[tid → vote] (raw Polis sign: -1 agree, +1 disagree, 0 pass), an empty
+        dict if the participant has no votes/identity here, or None if Postgres is down.
+        """
+        if not self._db_url or not _SAFE_ZINVITE.match(zinvite or '') or not subject:
+            return None
+        rows = self._pg_query(
+            _PERSONAL_VOTES_BY_SUBJECT_SQL,
+            (zinvite, issuer, subject),
+            'get_personal_votes_by_subject',
         )
         if rows is None:
             return None

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -882,7 +882,11 @@
     {% endif %}
 
     {% for item in phase6_data %}
-    <div class="p6-card{% if not loop.first %} p6-card--hidden{% endif %}" data-fs-id="{{ item.fs.id }}">
+    {# Prior vote (button convention: 1=agree, 0=pass, -1=disagree) restored from Polis so
+       a reload shows the participant's earlier choice. item.my_vote is None if not voted. #}
+    {% set v_label = {1: 'Agreed', 0: 'Passed', -1: 'Disagreed'}.get(item.my_vote) %}
+    {% set v_cls   = {1: 'agree',  0: 'pass',   -1: 'disagree'}.get(item.my_vote) %}
+    <div class="p6-card{% if not loop.first %} p6-card--hidden{% endif %}{% if item.my_vote is not none %} p6-card--voted{% endif %}" data-fs-id="{{ item.fs.id }}">
       <div tabindex="-1" data-focus-anchor class="sr-only"></div>
 
       {# Card header: progress + post-vote badge #}
@@ -891,7 +895,7 @@
           <span class="stmt-dot"></span>
           INFORMED VOTE &middot; {{ loop.index }} of {{ phase6_data | length }}
         </span>
-        <span class="p6-voted-badge" role="alert" hidden></span>
+        <span class="p6-voted-badge{% if v_cls %} p6-voted-badge--{{ v_cls }}{% endif %}" role="alert"{% if item.my_vote is none %} hidden{% endif %}>{% if v_label %}<span aria-hidden="true">&check;</span> {{ v_label }}{% endif %}</span>
       </div>
 
       <div class="p6-card-inner">
@@ -902,13 +906,13 @@
 
           {% if item.phase6_stmt_id is not none %}
           <div class="vote-choice-row p6-vote-row">
-            <button class="vote-choice btn-p6-vote" data-vote="1">
+            <button class="vote-choice btn-p6-vote{% if item.my_vote == 1 %} p6-voted{% endif %}" data-vote="1">
               <span class="vote-dot vote-dot--agree"></span>Agree
             </button>
-            <button class="vote-choice btn-p6-vote" data-vote="0">
+            <button class="vote-choice btn-p6-vote{% if item.my_vote == 0 %} p6-voted{% endif %}" data-vote="0">
               <span class="vote-dot vote-dot--pass"></span>Pass
             </button>
-            <button class="vote-choice btn-p6-vote" data-vote="-1">
+            <button class="vote-choice btn-p6-vote{% if item.my_vote == -1 %} p6-voted{% endif %}" data-vote="-1">
               <span class="vote-dot vote-dot--disagree"></span>Disagree
             </button>
           </div>
@@ -969,8 +973,10 @@
     </div>{# end p6-card #}
     {% endfor %}
 
-  {# Done screen — shown when all cards are voted or skipped #}
-  <div class="p6-done" hidden>
+  {# Done screen — shown when all cards are voted or skipped. Server-rendered visible when
+     the participant already completed the round, so it survives a reload; otherwise the
+     client reveals it after the final vote. #}
+  <div class="p6-done"{% if not phase6_all_voted %} hidden{% endif %}>
     <h2 class="p6-done-heading">You've completed informed voting.</h2>
     {% if conversation.phase_public_results and phase6_results and phase6_results.statements %}
     <p class="p6-done-text">See the <a href="#" onclick="document.querySelector('[data-tab=tab-p6-results]').click();return false;">Preliminary results</a> tab for the full comparison.</p>

--- a/v2/tests/test_phase6_vote.py
+++ b/v2/tests/test_phase6_vote.py
@@ -1,0 +1,142 @@
+"""Phase 6 (informed voting) vote submission and readback.
+
+Covers the three defects fixed together:
+  - identity binding: a Phase 6 vote asserts the participant's stable per-conversation
+    subject (X-Particiapi-Sub) so it lands under their real Polis uid, not a throwaway;
+  - Polis-native sign: the app's button convention (1=agree) is converted to Polis's
+    (-1=agree) on write, so informed-vote counts match Phase 2;
+  - readback: prior votes are restored from Polis (resolved via particiapi_users) so a
+    reload shows the participant's choices.
+"""
+import hashlib
+import hmac
+import re
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from db import Conversation, FeaturedStatement, Participation, db
+from polis_admin import PolisServerClient
+
+_SECRET = 'sub-secret-test'
+
+
+def _fake_resp(status_code=200, cookies=None, csrf='TOK', ok=True):
+    m = MagicMock()
+    m.status_code = status_code
+    m.ok = ok
+    m.cookies = cookies or {}
+    m.json = lambda: {'csrf_token': csrf}
+    return m
+
+
+def _setup_phase6(participant, *, p6_conv='p6conv0001', p6_tid=7):
+    conv = Conversation(slug='p6', polis_id='p6main0001', title='P6', active=True,
+                        access_policy='public', phase_informed_voting=True,
+                        phase6_polis_conversation_id=p6_conv)
+    db.session.add(conv)
+    db.session.commit()
+    fs = FeaturedStatement(conversation_id=conv.id, polis_statement_id=5,
+                           confirmed_by_admin=True, statement_text='A statement',
+                           phase6_polis_statement_id=p6_tid)
+    db.session.add(fs)
+    db.session.add(Participation(participant_id=participant.id,
+                                 conversation_id=conv.id, pseudonym='p'))
+    db.session.commit()
+    return conv, fs
+
+
+def _expected_subject(xid, conv_id):
+    """Re-derive the conversation-scoped subject independently, so a change to the
+    keying scheme in app.py breaks this test rather than silently passing."""
+    return hmac.new(_SECRET.encode(), f'{xid}:{conv_id}'.encode(),
+                    hashlib.sha256).hexdigest()
+
+
+# ── Bug B: identity binding ─────────────────────────────────────────────────────
+
+def test_phase6_vote_binds_participant_identity(app, auth_client, participant):
+    app.config['PARTICIAPI_SUB_SECRET'] = _SECRET
+    conv, fs = _setup_phase6(participant)
+    with patch('app.requests.post', return_value=_fake_resp(cookies={'session': 'PA'})) as post, \
+         patch('app.requests.put', return_value=_fake_resp()):
+        resp = auth_client.post('/c/p6/phase6/vote', json={'fs_id': fs.id, 'vote': 1})
+    assert resp.status_code == 200
+    headers = post.call_args.kwargs['headers']
+    assert headers['X-Particiapi-Sub'] == _expected_subject(participant.xid, conv.id)
+    assert headers['X-Particiapi-Sub-Secret'] == _SECRET
+    # the asserted subject must never be the bare xid, and a bind must not forward a
+    # stale session cookie (which would make Particiapi skip the bind).
+    assert headers['X-Particiapi-Sub'] != participant.xid
+    assert post.call_args.kwargs['cookies'] == {}
+
+
+def test_phase6_vote_no_secret_does_not_bind(app, auth_client, participant):
+    app.config['PARTICIAPI_SUB_SECRET'] = ''
+    conv, fs = _setup_phase6(participant)
+    with patch('app.requests.post', return_value=_fake_resp(cookies={'session': 'PA'})) as post, \
+         patch('app.requests.put', return_value=_fake_resp()):
+        resp = auth_client.post('/c/p6/phase6/vote', json={'fs_id': fs.id, 'vote': 1})
+    assert resp.status_code == 200
+    assert 'X-Particiapi-Sub' not in post.call_args.kwargs.get('headers', {})
+    assert post.call_args.kwargs['params'] == {'create': 'true'}
+
+
+# ── Bug C: Polis-native sign on write ───────────────────────────────────────────
+
+@pytest.mark.parametrize('button_vote,polis_value', [(1, -1), (-1, 1), (0, 0)])
+def test_phase6_vote_converts_to_polis_sign(app, auth_client, participant,
+                                            button_vote, polis_value):
+    """Agree(1) -> -1, Disagree(-1) -> +1, Pass(0) -> 0 (Polis convention, matching
+    Phase 2 so the informed-vote counts are not inverted)."""
+    app.config['PARTICIAPI_SUB_SECRET'] = _SECRET
+    conv, fs = _setup_phase6(participant)
+    with patch('app.requests.post', return_value=_fake_resp(cookies={'session': 'PA'})), \
+         patch('app.requests.put', return_value=_fake_resp()) as put:
+        resp = auth_client.post('/c/p6/phase6/vote',
+                                json={'fs_id': fs.id, 'vote': button_vote})
+    assert resp.status_code == 200
+    assert put.call_args.kwargs['json'] == {'value': polis_value}
+
+
+# ── Bug A: readback ─────────────────────────────────────────────────────────────
+
+def test_get_personal_votes_by_subject_resolves_via_particiapi_users():
+    client = PolisServerClient('http://x', 'e', 'p', db_url='postgresql://x')
+    with patch.object(client, '_pg_query', return_value=[(7, -1), (9, 0)]) as q:
+        out = client.get_personal_votes_by_subject('p6conv0001', 'subj123')
+    assert out == {7: -1, 9: 0}
+    # resolved by (zinvite, issuer, subject) against the trusted-sub identity map
+    assert q.call_args.args[1] == ('p6conv0001', 'wiki-polis', 'subj123')
+
+
+def test_phase6_card_renders_restored_vote(app, auth_client, participant):
+    """A prior Agree vote (Polis -1 on the card's tid) renders the card as voted with
+    the Agree option selected — so a reload shows the participant's earlier choice."""
+    app.config['PARTICIAPI_SUB_SECRET'] = _SECRET
+    conv, fs = _setup_phase6(participant, p6_tid=7)
+    server = MagicMock()
+    server.get_personal_votes_by_subject.return_value = {7: -1}  # tid 7 -> agree
+    with patch('app._polis_server_client', return_value=server), \
+         patch('app._build_phase6_results', return_value=None):
+        html = auth_client.get('/c/p6').get_data(as_text=True)
+    # Assert on server-rendered markup, not substrings that also occur in the page JS:
+    # the card div carries p6-card--voted, and the badge modifier class p6-voted-badge--agree
+    # (built dynamically in JS, so its literal only appears in server-rendered voted state).
+    assert re.search(r'class="p6-card[^"]*p6-card--voted', html)
+    assert 'p6-voted-badge--agree' in html
+    # resolver was queried for the phase6 conversation
+    server.get_personal_votes_by_subject.assert_called_once()
+    assert server.get_personal_votes_by_subject.call_args.args[0] == 'p6conv0001'
+
+
+def test_phase6_card_unvoted_when_no_prior_vote(app, auth_client, participant):
+    app.config['PARTICIAPI_SUB_SECRET'] = _SECRET
+    conv, fs = _setup_phase6(participant, p6_tid=7)
+    server = MagicMock()
+    server.get_personal_votes_by_subject.return_value = {}
+    with patch('app._polis_server_client', return_value=server), \
+         patch('app._build_phase6_results', return_value=None):
+        html = auth_client.get('/c/p6').get_data(as_text=True)
+    assert not re.search(r'class="p6-card[^"]*p6-card--voted', html)
+    assert 'p6-voted-badge--agree' not in html


### PR DESCRIPTION
## Problem

Phase 6 ("Informed vote") had three compounding bugs, all confirmed by live
reproduction against a local full stack:

1. **Votes don't persist across reload.** After voting on a card, reloading the
   conversation reset every card to unvoted. The vote reached Polis, but the render
   never read it back.
2. **Votes recorded under throwaway anonymous identities.** `phase6_vote` bootstrapped
   its own Particiapi session without the `X-Particiapi-Sub` identity binding the rest
   of the proxy uses, so each vote landed under a fresh anonymous uid, decoupled from
   the participant — corrupting the tally and making per-participant readback impossible.
3. **Vote sign stored inverted.** The endpoint forwarded the button value (1=agree)
   verbatim, but Polis is `-1=agree`, so counts read backwards.

## Root cause

`phase6_data` (render) had no vote-restoration logic; `phase6_vote` (submit) neither
bound identity nor scoped its session cookie consistently, and passed the app-native
sign straight through. The intended per-participant readback was stubbed out
(`app.py` TODO) because it was blocked on identity resolution — bug 2.

Notably, trusted-sub identity lives in Particiapi's `particiapi_users` table
(`subject -> uid`), not Polis's `xids` table that the old stub assumed.

## Fix

- **Bind identity** in `phase6_vote` using the same conversation-scoped subject as the
  Phase 2 proxy, so a participant keeps one stable uid across Phase 2 and Phase 6 (by
  design — initial and informed votes share a pseudonym).
- **Read votes back** on render via `subject -> particiapi_users.uid -> participants ->
  votes`, and render the selected state server-side.
- **Store the Polis-native sign** (negate on submit) so counts are correct.

## Verification

- Unit suite: 452 passed, 8 new tests for the fix; the only failures are 3 pre-existing,
  unrelated ones.
- Live e2e (local full stack): vote persists across reload, lands under the participant's
  bound uid, and is stored as `-1=agree`.

## Migration — production action required

Phase 6 rounds that ran before this fix stored inverted, anonymous-uid votes. A one-off
ops script (`v2/ops/migrate_phase6_vote_signs.py`) negates the sign of existing Phase 6
votes in the Polis DB. It is **not** an Alembic migration (Phase 6 votes live in Polis,
not wiki-polis) and must be run manually, exactly once, during a voting freeze:

1. Pause/close Phase 6 voting
2. Back up the Polis DB
3. Dry-run, review affected conversations
4. Deploy this fix, then run with `--apply`
5. Re-open voting

The script only corrects the *sign*; it cannot retroactively re-attach pre-fix votes to
participant identities (they were recorded anonymously).

## Follow-ups (out of scope, filed separately)

- Home-page "statements remaining" is silently dead under trusted-sub (`xids`-based query).
- `conversation_statement_new` has the same non-binding session bootstrap.
- The results-tab personal-vote stub can now be enabled with the new resolver.

---
🤖 Authored by Claude (Claude Code) on the repository owner's behalf.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
