### PR TITLE
rebrand: wiki-polis → ProtoWiki, user-visible text (Layer A of #289)

### DIFF
--- a/v2/templates/accept.html
+++ b/v2/templates/accept.html
@@ -108,7 +108,7 @@
     <div class="accept-section" id="accept-privacy-note">
       <h3>Privacy summary</h3>
       <p>
-        Public records use your pseudonym. wiki-polis keeps the username link
+        Public records use your pseudonym. ProtoWiki keeps the username link
         internally for login, access checks, notifications, moderation, and
         privacy controls.
       </p>
@@ -146,7 +146,7 @@
              aria-required="true">
       <span>
         I understand my votes and arguments are recorded with this pseudonym,
-        and wiki-polis keeps an internal username link while this consultation runs.
+        and ProtoWiki keeps an internal username link while this consultation runs.
       </span>
     </label>
 

--- a/v2/templates/admin.html
+++ b/v2/templates/admin.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Admin panel — wiki-polis{% endblock %}
+{% block title %}Admin panel — ProtoWiki{% endblock %}
 {% block header_crumb %}
 <nav class="header-crumb" aria-label="Admin breadcrumb">
   <span class="header-crumb-sep">/</span>

--- a/v2/templates/admin_conversation.html
+++ b/v2/templates/admin_conversation.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Manage {{ conversation.title }} — wiki-polis{% endblock %}
+{% block title %}Manage {{ conversation.title }} — ProtoWiki{% endblock %}
 {% block header_crumb %}
 <nav class="header-crumb" aria-label="Admin breadcrumb">
   <span class="header-crumb-sep">/</span>
@@ -685,7 +685,7 @@
     });
     var df = document.getElementById('delete-conversation-form');
     if (df) df.addEventListener('submit', function (e) {
-      if (!confirm('Delete this consultation?\n\nThis removes local wiki-polis records after hiding the Polis conversation. This cannot be undone.')) e.preventDefault();
+      if (!confirm('Delete this consultation?\n\nThis removes local ProtoWiki records after hiding the Polis conversation. This cannot be undone.')) e.preventDefault();
     });
   </script>
   {% endif %}{# is_admin #}

--- a/v2/templates/admin_featured.html
+++ b/v2/templates/admin_featured.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Featured statements — {{ conversation.title }} — wiki-polis{% endblock %}
+{% block title %}Featured statements — {{ conversation.title }} — ProtoWiki{% endblock %}
 {% block header_crumb %}
 <nav class="header-crumb" aria-label="Admin breadcrumb">
   <span class="header-crumb-sep">/</span>

--- a/v2/templates/admin_flags.html
+++ b/v2/templates/admin_flags.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Moderation queue — {{ conversation.title }} — wiki-polis{% endblock %}
+{% block title %}Moderation queue — {{ conversation.title }} — ProtoWiki{% endblock %}
 {% block header_crumb %}
 <nav class="header-crumb" aria-label="Admin breadcrumb">
   <span class="header-crumb-sep">/</span>

--- a/v2/templates/admin_invites.html
+++ b/v2/templates/admin_invites.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Invites — {{ conversation.title }} — wiki-polis{% endblock %}
+{% block title %}Invites — {{ conversation.title }} — ProtoWiki{% endblock %}
 {% block header_crumb %}
 <nav class="header-crumb" aria-label="Admin breadcrumb">
   <span class="header-crumb-sep">/</span>

--- a/v2/templates/admin_participants.html
+++ b/v2/templates/admin_participants.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Participants — {{ conversation.title }} — wiki-polis{% endblock %}
+{% block title %}Participants — {{ conversation.title }} — ProtoWiki{% endblock %}
 {% block header_crumb %}
 <nav class="header-crumb" aria-label="Admin breadcrumb">
   <span class="header-crumb-sep">/</span>

--- a/v2/templates/admin_statements.html
+++ b/v2/templates/admin_statements.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Statements — {{ conversation.title }} — wiki-polis{% endblock %}
+{% block title %}Statements — {{ conversation.title }} — ProtoWiki{% endblock %}
 {% block header_crumb %}
 <nav class="header-crumb" aria-label="Admin breadcrumb">
   <span class="header-crumb-sep">/</span>

--- a/v2/templates/base.html
+++ b/v2/templates/base.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% block title %}wiki-polis{% endblock %}</title>
+  <title>{% block title %}ProtoWiki{% endblock %}</title>
   <link rel="icon" href="data:,">
   <link rel="stylesheet" href="{{ url_for('static', filename='fonts/fonts.css') }}?v={{ git_version }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v={{ git_version }}">
@@ -22,7 +22,7 @@
             <ellipse cx="12" cy="12" rx="9" ry="3.5"/>
             <ellipse cx="12" cy="12" rx="3.5" ry="9"/>
           </svg>
-          <span class="header-title">wiki-polis</span>
+          <span class="header-title">ProtoWiki</span>
         </a>
         {% if request.blueprint == 'admin' %}
           <span class="header-mode-badge">Admin</span>
@@ -86,7 +86,7 @@
       el.appendChild(close);
       close.addEventListener('click', function () { dismiss(el); });
       container.appendChild(el);
-      console.error('[wiki-polis] ' + category + ': ' + message);
+      console.error('[ProtoWiki] ' + category + ': ' + message);
       // 'sticky' category \u2014 stays until user dismisses; no auto-timeout.
       if (category === 'sticky') { el._timer = null; return; }
       var t = setTimeout(function () { dismiss(el); }, DURATIONS[category] || 6000);

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ conversation.title }} — wiki-polis{% endblock %}
+{% block title %}{{ conversation.title }} — ProtoWiki{% endblock %}
 
 {% block header_crumb %}
 <nav class="header-crumb" aria-label="Conversation context">

--- a/v2/templates/forbidden_eligibility.html
+++ b/v2/templates/forbidden_eligibility.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Not eligible — {{ conversation.title }} — wiki-polis{% endblock %}
+{% block title %}Not eligible — {{ conversation.title }} — ProtoWiki{% endblock %}
 {% block content %}
 
 <div class="container">

--- a/v2/templates/forbidden_invite_only.html
+++ b/v2/templates/forbidden_invite_only.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Access restricted — wiki-polis{% endblock %}
+{% block title %}Access restricted — ProtoWiki{% endblock %}
 
 {% block content %}
 <div class="container" style="max-width:700px;padding-top:3rem">

--- a/v2/templates/guidance_argument.html
+++ b/v2/templates/guidance_argument.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Writing good arguments - wiki-polis{% endblock %}
+{% block title %}Writing good arguments - ProtoWiki{% endblock %}
 
 {% block header_crumb %}
 <span class="header-crumb">
@@ -15,7 +15,7 @@
       Writing good arguments
     </h1>
     <p class="muted">
-      Arguments are a wiki-polis feature. They explain why someone might support
+      Arguments are a ProtoWiki feature. They explain why someone might support
       or oppose a featured statement; they are read by people, not used by the
       clustering algorithm.
     </p>

--- a/v2/templates/guidance_statement.html
+++ b/v2/templates/guidance_statement.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Writing good statements - wiki-polis{% endblock %}
+{% block title %}Writing good statements - ProtoWiki{% endblock %}
 
 {% block header_crumb %}
 <span class="header-crumb">

--- a/v2/templates/home.html
+++ b/v2/templates/home.html
@@ -153,7 +153,7 @@
 
   {# ── Flow diagram ─────────────────────────────────────────────────────── #}
   <img src="{{ url_for('static', filename='wiki-polis-flow.svg') }}"
-       alt="How a wiki-polis conversation works"
+       alt="How a ProtoWiki conversation works"
        style="width:100%;max-width:900px;display:block;margin:0 auto 1.5rem">
 
   {# ── Phase journey legend ──────────────────────────────────────────────── #}

--- a/v2/templates/moderation_log.html
+++ b/v2/templates/moderation_log.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Moderation log — {{ conversation.title }} — wiki-polis{% endblock %}
+{% block title %}Moderation log — {{ conversation.title }} — ProtoWiki{% endblock %}
 {% block header_crumb %}
 <nav class="header-crumb" aria-label="Conversation context">
   <span class="header-crumb-sep">/</span>


### PR DESCRIPTION
Layer A of the wiki-polis → **ProtoWiki** rename (#289): the user-visible brand text only.

## What changed
Displayed brand name → **ProtoWiki** across all templates:
- header title + all 16 page `<title>`s
- prose mentions: consent copy (`accept.html`), argument guidance, delete-confirm dialog
- client-side console log prefix

16 files, 21 line changes, display strings only. No behavioral change.

## Deliberately NOT changed (Layer B/C — gated on hosting #286 + cutover timing)
These are infra identifiers wired to external systems; they must flip as a unit when the domain does:
- `wiki-polis-flow.svg` asset filename, `lgelauff/wiki-polis` repo URL
- `*.toolforge.org` hostnames (tests hard-code these), User-Agent strings
- secret paths, the logging `service` label, Toolforge tool-account / ToolsDB names

## Testing
`cd v2 && uv run pytest` → **444 passed**. The 3 failing tests (`test_admin`, `test_phase_stats`) are pre-existing env-sensitivity failures unrelated to this change — verified by re-running them with these template edits stashed on clean `origin/main` (identical failures).

Note: displayed name becomes ProtoWiki while hosting stays `wiki-polis.toolforge.org` for now — an intended interim mismatch (decision confirmed), resolved when Layer B/C lands.

Refs #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)
