### PR TITLE
fix(#296): wording suggestions exempt from new-statement quota + absorb AOI prior-art doc

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@
 
 ## Start here — by who you are
 
-- **Organizer** — you run a consultation on the platform: create conversations, seed statements, sequence the phases, read the results. [Organizer guide](../guidance/guide_organizer.md) (AI draft); background research in [`research/`](research/).
+- **Organizer** — you run a consultation on the platform: create conversations, seed statements, sequence the phases, read the results. [Organizer guide](../guidance/guide_organizer.md) (AI draft); background research in [`research/`](research/), including [prior art: Wikimedia's All Our Ideas experiment](research/07-prior-art-all-our-ideas.md) (context only — did not inform this project's design).
 - **Maintainer** — the technical role: you build, deploy, *and* operate wiki-polis. _(For this project "developer," "contributor," "engineer," and "operator" are the same person — there is no separate ops team.)_ [local development](../v2/guide_local-dev.md) · [architecture](../v2/spec_architecture.md) · [functional design](../v2/spec_functional-design.md) · [data-model reference](../v2/ref_data-model.md) · [deployment](../v2/guide_deployment.md) · [operator runbook](../v2/guide_runbook.md) · [roadmap](../v2/plan_roadmap.md) · [build log](../v2/log_changelog.md) · [doc plan](../v2/docs/plan_doc-improvement.md) · [standards](../v2/docs/documentation-standards.md) · [ADRs](../v2/adr/). _Coming: CONTRIBUTING + testing (N9)._
 
 ## Participant-facing material

--- a/docs/research/07-prior-art-all-our-ideas.md
+++ b/docs/research/07-prior-art-all-our-ideas.md
@@ -1,0 +1,286 @@
+> **⚠️ Not fact-checked by this project. Did not inform wiki-polis / ProtoWiki's design.**
+> This document reproduces an external research dossier about **All Our Ideas (AOI)**, an
+> earlier and unrelated Wikimedia experiment in community deliberation tooling
+> (2011, then piloted again in 2014). It was compiled independently by a third party
+> ("Hermes Agent," for Andrew Lih) and is absorbed here **purely as historical context /
+> prior art** — a precedent for "Wikimedia tries a third-party deliberation/prioritization
+> tool," not as a source that shaped any decision in this repository. wiki-polis was not
+> designed with knowledge of this dossier, and no claim below has been independently
+> verified against primary sources by this project. Treat it as background reading on how
+> a structurally similar effort played out, not as a reference to cite.
+
+---
+
+# Wikimedia's Use of All Our Ideas (AOI) — Comprehensive Research Dossier
+
+> Research compiled July 14, 2026 by Hermes Agent for Andrew Lih
+
+## Executive Summary
+
+**All Our Ideas (AOI)** is an open-source pairwise wiki survey platform developed at Princeton University by **Matthew J. Salganik & Karen E.C. Levy**. Wikimedia used it in two phases:
+
+1. **December 2011** — Fundraiser banner challenge (crowdsourcing new banner ideas)
+2. **December 2014** — Pilot product survey of English & Spanish Wikipedia communities to prioritize tools/gadgets for improvement
+
+The platform presents users with random pairs of ideas and asks them to choose one, then uses statistical modeling to produce a ranked list from all pairwise comparisons.
+
+### Why It Was Chosen
+
+The WMF reviewed five candidate systems (AOI, Consider It, Deliberatorium, IdeaScale, Synapp) against criteria including multi-language support, open-source licensing, ability to rank ideas, robustness against gaming, and proven scaling. AOI was selected as a pilot.
+
+### What Happened
+
+The December 2014 survey ran for two weeks on English and Spanish Wikipedias, attracting thousands of responses. The top English result was Citation Bot (score: 81), and top Spanish result was Corrector ortográfico/Spell Checker (score: 69). Between October 2015 and early 2016, the newly-formed Community Tech team worked through the top 10 results from each survey, completing fixes for Citation Bot, HotCat, FlickrFree, RevisionJumper, and others. However, the AOI process was superseded by the Community Wishlist Survey launched in November 2015, which became the permanent community input mechanism.
+
+### Why It Was Dismissed
+
+Five key factors:
+
+1. **Always a pilot** — The AOI survey was explicitly framed as a "pilot" — a bridge until a permanent cross-project process could be established
+2. **Community Tech team formation** — The formation of the Community Tech team in mid-2015 created a natural opportunity to design a new, more wiki-native process (the Community Wishlist Survey)
+3. **Overwhelmingly negative community feedback** — Users described it as "frankly idiotic," "torture," and a "never-ending series of comparisons"
+4. **Technical limitations** — 140-character idea descriptions, no hyperlinks, inability to fix translations once entered, and confusing/possibly incorrect real-time statistics
+5. **Cultural mismatch** — The AOI was an external third-party service, which conflicted with community values around on-wiki transparency, discussion, and consensus-building
+
+### Overall Assessment
+
+AOI succeeded as a lightweight data-collection instrument and yielded actionable results that Community Tech delivered on. It failed as a community engagement tool because its design philosophy (statistical robustness through pairwise comparison) clashed with Wikimedian expectations of transparency, deliberation, and a sense of completion. The experience directly informed the design of the Community Wishlist Survey, which addressed these shortcomings by being wiki-native, discussion-rich, and transparently scored.
+
+---
+
+## Survey Results
+
+### English Wikipedia Top 10
+
+| Rank | Tool | Score |
+|------|------|-------|
+| 1 | Citation Bot | 81 |
+| 2 | Reflinks | 75 |
+| 3 | CopyVios | 69 |
+| 4 | Cite4Wiki | 69 |
+| 5 | RevisionJumper | 67 |
+| 6 | Checklinks | 65 |
+| 7 | Page stats | 65 |
+| 8 | Twinkle | 64 |
+| 9 | Dab Solver | 63 |
+| 10 | Syntax highlighter | 63 |
+
+40 total ideas. 16,862+ votes cast.
+
+### Spanish Wikipedia Top 10
+
+| Rank | Tool | Score |
+|------|------|-------|
+| 1 | Corrector ortográfico / Spell Checker | 69 |
+| 2 | HotCat | 66 |
+| 3 | Twinkle | 62 |
+| 4 | FlickrFree | 60 |
+| 5 | Localizar imágenes | 60 |
+| 6 | CopyVios | 60 |
+| 7 | RevisionJumper | 57 |
+| 8 | Navigation Popups | 56 |
+| 9 | QuickIntersection | 54 |
+| 10 | Reflinks | 54 |
+
+---
+
+## What Was Actually Delivered
+
+Between October 2015 and March 2016, the Community Tech team delivered on several AOI survey requests:
+
+| Request | Status |
+|---------|--------|
+| **Citation Bot** | Fixed — had been completely broken for 3 months; fixed gadget code, API, security fixes, simplified code |
+| **HotCat** | Fixed on 100+ wikis |
+| **FlickrFree** | Improved search results, fixed thumbnail display |
+| **RevisionJumper** | Firefox bug resolved |
+| **Dab Solver** | Maintainer access restored |
+| Turnitin integration | In progress |
+| Pageview stats tool | Backlogged |
+
+---
+
+## Constructive vs. Non-Constructive Feedback
+
+### ✅ Constructive (Positive + Improvement-Focused)
+
+| Source | Feedback |
+|--------|----------|
+| **WMF staff** (Whatamidoing, Rdicerb, Quiddity) | Defended pairwise comparison on voting-theory grounds; resistant to gaming |
+| **WMF Analytics** | Results "well received"; could identify and filter gaming attempts |
+| **Wikimedia-l** (2 posts + IRC/private) | Positive feedback through informal channels |
+| **Erik Moeller** (2011) | "It's good to experiment with new tools instead of locking ourselves into MediaWiki's feature set" |
+| **Noyster** | Provided systematic improvement suggestions: limit to 20, fixed list, comparable descriptions |
+| **Rdicerb (WMF)** (post-survey) | Acknowledged limitations candidly: 140-char limit, no hyperlinks, translation difficulties. Created comprehensive list of issues for AOI team |
+
+### ❌ Non-Constructive (Negative + Hostile)
+
+| Source | Feedback |
+|--------|----------|
+| **NeilN** (power editor) | "Who chose this frankly idiotic way of gathering feedback? No way of prioritizing requests. No links to get more info about each tool. No indication of what would be improved for each tool. Just click, click, click." |
+| **Fram** (power editor) | Statistical analysis showing data anomalies — early ideas had 1200–1400 completed contests vs 300–400 for later ones. "Yet another excuse-building effort" |
+| **Technical 13** | Gaming vulnerability: "makes this type of survey entirely useless" |
+| **Ca2james** | "Infinite clicking… not knowing whether an end actually exists" |
+| **Ganímedes** (es.wp) | "It is a torture to do this survey" + poor translations |
+| **NaBUru38** | "It would have been much easier if the poll was a sortable list" |
+| **Noyster** | Criticized that more votes from one user drives their preferred tool's score toward 100%: "A strange way to run a survey!" |
+| **Elitre** (2011) | "Will you please remind us why the heck you are using an external site for matters that belong to Meta?" |
+| **Rogol Domedonfors** | "Either demonstrate success or admit failure. No more excuses, no more delays, no more vagueness." |
+| **Didcot power station** | "This is a sham, and by that I mean that Community Tech is a conscious and deliberate deception, designed and implemented to give the impression that WMF takes community technical input seriously when in fact it has nothing but contempt for the volunteer population." |
+
+---
+
+## Who Was Favorable vs. Unfavorable
+
+| Favorable | Unfavorable |
+|-----------|-------------|
+| WMF staff (insiders who designed/ran it) | Experienced Wikipedians / power editors |
+| Academically-oriented participants | Non-English communities (poor translations) |
+| IRC / private email respondents | Users expecting wiki-native features |
+| Analytics team (loved the data) | Technically sophisticated skeptics |
+
+**The divide:** WMF staff defended AOI on methodological grounds; volunteers judged it on user experience and cultural fit. The methodology was statistically sound — it just wasn't *wiki*.
+
+---
+
+## Key Text Extracts
+
+> "Who chose this frankly idiotic way of gathering feedback? No way of prioritizing requests. No links to get more info about each tool. No indication of what would be improved for each tool. Just click, click, click."
+> — **NeilN**, 4 Dec 2014
+
+> "Technical limitations: Significant technical limitations in the system meant that descriptions were limited to 140 characters, without any external links. This meant that users were sometimes presented with choices that they did not recognize and could not easily get more information about."
+> — **Product Surveys page** (WMF's own assessment)
+
+> "We also completed work on long-tail small issues. Example: fixing the citation bot. #1 request from 2014 all our ideas survey; it had actually been completely broken for 3 months… The community was very happy about that."
+> — **Kaldari**, Jan 2016 Quarterly Review
+
+> "This is a sham, and by that I mean that Community Tech is a conscious and deliberate deception, designed and implemented to give the impression that WMF takes community technical input seriously when in fact it has nothing but contempt for the volunteer population."
+> — **Didcot power station**, 17 Jun 2015
+
+> "While preparations are being made for a cross-project technical request survey, the Community Tech team will begin working on the requests identified by the community as high priority in the All Our Ideas survey."
+> — **AOI Process page** (the bridge statement)
+
+> "It is a torture to do this survey."
+> — **Ganímedes** (Spanish Wikipedia), 23 Dec 2014
+
+---
+
+## Timeline
+
+| Date | Event |
+|------|-------|
+| **Dec 2011** | First AOI use: Wikimedia fundraiser banner challenge. Zack Exley announces on Diff blog |
+| **Nov 12, 2014** | Product Surveys page created on Meta-Wiki by Rdicerb (WMF), outlining AOI pilot plan |
+| **Dec 3–17, 2014** | AOI pilot survey runs on English Wikipedia. 40 ideas, 16,862+ votes |
+| **Dec 4–22, 2014** | AOI pilot survey runs on Spanish Wikipedia |
+| **Dec 2014 – Aug 2015** | Intense community discussion on Talk:Community Liaisons/Product Surveys. Overwhelmingly critical |
+| **Mar 10, 2015** | Whatamidoing (WMF) adds survey update noting top results, technical limitations, methodology criticism |
+| **May 20, 2015** | Salganik & Levy publish "Wiki Surveys: Open and Quantifiable Social Data Collection" in PLOS ONE |
+| **Jun 3, 2015** | Whatamidoing references AOI survey in Community Tech project ideas discussion |
+| **Sep 11, 2015** | Quiddity (WMF) adds final pointer update to Product Surveys page |
+| **Oct 20, 2015** | Community Tech/All Our Ideas page created by DannyH (WMF) to track AOI follow-up work |
+| **Nov 2015** | First Community Wishlist Survey launches, effectively replacing AOI |
+| **Dec 2015 – Mar 2016** | Community Tech completes work on Citation Bot, HotCat (100+ wikis), FlickrFree, RevisionJumper, Dab Solver |
+| **Jan 2016** | Quarterly review: Kaldari reports AOI survey follow-up to Lila Tretikov. Community "very happy" about Citation Bot fix |
+| **Apr 15, 2016** | Last substantive edit to Community Tech/All Our Ideas page |
+| **2023** | Global Data and Insights team still using AOI for Equity Landscape title voting (niche continued use) |
+| **Jun 2024** | Minor/vandalism edits — page is historical |
+
+---
+
+## Phabricator Tasks
+
+Phabricator tasks created as a result of the AOI survey:
+
+| Task ID | Description |
+|---------|-------------|
+| T108412 | Fix or replace Citation Bot |
+| T108422 | Add i18n support to Copyvio Detector |
+| T108424 | Fix RevisionJumper Firefox bug |
+| T108425 | Turn RevisionJumper into an extension |
+| T108426 | Make Twinkle localizable to any wiki |
+| T108628 | Related to AOI survey outcomes |
+| T108630 | Related to AOI survey outcomes |
+| T108631 | Improve FlickrFree search results |
+| T108633 | Related to AOI survey outcomes |
+| T108636 | Related to AOI survey outcomes |
+| T108637 | Quick Intersection tool documentation |
+| T109370 | Fix thumbnail display in FlickrFree |
+| T109796 | Get Hovercards to feature parity with Navigation Pop-ups |
+| T101246 | Syntax highlighter |
+| T103285 | Fix HotCat/VE bug |
+| T110124 | Add i18n support to Copyvio Detector |
+| T110144 | Integrate Turnitin into Copyvio Detector |
+| T110147 | Add page view statistics to page information pages |
+| T110148 | Make Twinkle localizable to any wiki |
+| T110149 | Fix HotCat on wikis where it is broken |
+| T110156 | Add spell-checking option to LanguageTool WikiCheck |
+| T110159 | Fix RevisionJumper Firefox bug |
+| T110160 | Turn RevisionJumper into an extension |
+| T110162 | Create documentation for Quick Intersection tool |
+| T115681 | Related to AOI survey outcomes |
+| T149635 | Related to AOI survey outcomes |
+| T153063 | Related to AOI survey outcomes |
+
+---
+
+## Key Documentation URLs
+
+### Primary Meta-Wiki Pages
+
+| Page | Description |
+|------|-------------|
+| [Community Tech/All Our Ideas](https://meta.wikimedia.org/wiki/Community_Tech/All_Our_Ideas) | Work tracking — Completed, In Progress, Backlogged, Declined items |
+| [Community Tech/All Our Ideas/Process](https://meta.wikimedia.org/wiki/Community_Tech/All_Our_Ideas/Process) | 4-step workflow: Selection, Investigation, Analysis, Development |
+| [Community Liaisons/Product Surveys](https://meta.wikimedia.org/wiki/Community_Liaisons/Product_Surveys) | Methodology, 9 selection criteria, 5 candidate systems, FAQ, Legal |
+| [Talk:Community Liaisons/Product Surveys](https://meta.wikimedia.org/wiki/Talk:Community_Liaisons/Product_Surveys) | **The motherlode of feedback (~40 comments)** |
+| [Talk:Community Liaisons/Product Surveys/Ideas](https://meta.wikimedia.org/wiki/Talk:Community_Liaisons/Product_Surveys/Ideas) | Specific tool/gadget discussions |
+| [Talk:Community Tech/Project ideas](https://meta.wikimedia.org/wiki/Talk:Community_Tech/Project_ideas) | Broad community frustration — includes "This is a sham" |
+| [Quarterly Review Jan 2016](https://meta.wikimedia.org/wiki/Wikimedia_monthly_activities_meetings/Quarterly_reviews/Reading_and_Community_Tech,_January_2016) | Kaldari reports AOI follow-up outcomes |
+| [Community Liaisons/Process ideas](https://meta.wikimedia.org/wiki/Community_Liaisons/Process_ideas) | Brainstorming: 27 process improvement ideas |
+| [Community Tech/Pageview stats tool/Notes](https://meta.wikimedia.org/wiki/Community_Tech/Pageview_stats_tool/Notes) | Meeting notes from AOI-derived request |
+| [Community Tech](https://meta.wikimedia.org/wiki/Community_Tech) | Main page — now marked "historical" |
+| [Community Wishlist](https://meta.wikimedia.org/wiki/Community_Wishlist) | Current process that replaced AOI |
+| [Global Data and Insights/Equity Landscape](https://meta.wikimedia.org/wiki/Global_Data_and_Insights/Movement_Data/Equity_Landscape/Pilot_%26_Consultation/Design_Considerations) | 2023: AOI still in niche use |
+
+### External
+
+| URL | Description |
+|-----|-------------|
+| [AOI English results](http://www.allourideas.org/wikimediagadgets/results) | Still live — Citation Bot #1 (81) |
+| [AOI Spanish results](http://www.allourideas.org/wikimediaaccesorios/results?locale=es) | Still live — Spell Checker #1 (69) |
+| [AOI Homepage](http://www.allourideas.org/) | 27,620 wiki surveys, 60.8M votes hosted |
+| [Diff Blog (2011)](https://diff.wikimedia.org/2011/12/19/all-our-ideas-in-the-wikimedia-fundraiser/) | Zack Exley announces first AOI use |
+| [AOI GitHub](https://github.com/allourideas) | Open-source Ruby on Rails platform |
+
+### Academic
+
+| Reference | Details |
+|-----------|---------|
+| [Salganik & Levy (2015)](https://doi.org/10.1371/journal.pone.0123483) | "Wiki Surveys: Open and Quantifiable Social Data Collection" — PLOS ONE |
+
+---
+
+## Reasons for Dismissal — Full Analysis
+
+AOI was not abruptly "dismissed" but was designed as a pilot and naturally superseded by the Community Wishlist Survey. The transition happened through several reinforcing factors:
+
+| Factor | Detail |
+|--------|--------|
+| **Always a pilot** | Explicitly framed as a "pilot" from the start: "Should this prove effective, the Foundation will launch a broad scale to ask all communities." A two-week test on two wikis, not a permanent process |
+| **Community Tech team formation** | The Community Tech team was formed in mid-2015 as a direct response to the WMF "Call to Action" for better community input. The team needed its own process and designed the Community Wishlist Survey (launched November 2015), which rendered AOI redundant |
+| **Community hostility to the interface** | Overwhelmingly negative feedback made it politically untenable to continue. Terms like "frankly idiotic," "torture," "sham," and "deception" appeared in on-wiki discussions |
+| **Technical limitations** | 140-character limit, no hyperlinks, inability to fix translations post-launch, and questions about data reliability (Fram's statistical analysis showing anomalies) |
+| **Cultural mismatch with wiki values** | Wikimedians expect transparency (you can see all votes), editability (you can fix mistakes), and discussion (you can talk about the choices). AOI's black-box algorithm and external hosting conflicted with these norms. Elitre's 2011 criticism — "why use an external site for matters that belong to Meta?" — was prescient |
+| **Slow follow-through** | Survey closed Dec 2014. WMF didn't begin acting on results until Oct 2015 (~10 months later) due to staffing delays and reorganization. Community trust was eroded |
+| **The Wishlist was better** | The Community Wishlist Survey addressed most of AOI's shortcomings: wiki-native, allowed detailed proposals with links, supported discussion on talk pages, used straightforward voting (support/oppose), and produced transparent results. The 2015 survey received 107 proposals with hundreds of participants |
+
+---
+
+## Bottom Line
+
+AOI was a methodologically sound but culturally mismatched experiment. It succeeded as a lightweight data-collection instrument and produced concrete improvements (Citation Bot, HotCat, etc.), but failed as a community engagement tool. The experience directly informed the Community Wishlist Survey, which addressed nearly every AOI shortcoming by being wiki-native, discussion-rich, and transparently scored. The AOI results pages remain accessible online a decade later — a quiet monument to a brief, turbulent chapter in Wikimedia's quest to listen to its communities.
+
+---
+
+*Research completed July 14, 2026, by Hermes Agent for Andrew Lih. Absorbed into this repository as prior-art context — see the disclaimer at the top of this document.*

--- a/v2/app.py
+++ b/v2/app.py
@@ -2013,17 +2013,21 @@ def conversation_statement_new(slug):
     ).with_for_update().first_or_404()
     _abort_if_banned(conv, participant)
 
-    new_stmt_max = conv.argument_vote_data.get('new_stmt_max', 3) if conv.argument_vote_data else 3
-    if len(part.new_stmt_ids or []) >= new_stmt_max:
-        return jsonify({'error': 'quota_exceeded'}), 403
-
     body = request.get_json(silent=True) or {}
     text = (body.get('text') or '').strip()
-    if not text or len(text) > 280:
-        abort(400)
     derived_from = body.get('derived_from')
     if derived_from in ('', None):
         derived_from = None
+
+    # Wording suggestions (derived_from set) are exempt from the new-statement
+    # quota — only genuinely new statements consume it (spec_functional-design.md).
+    if derived_from is None:
+        new_stmt_max = conv.argument_vote_data.get('new_stmt_max', 3) if conv.argument_vote_data else 3
+        if len(part.new_stmt_ids or []) >= new_stmt_max:
+            return jsonify({'error': 'quota_exceeded'}), 403
+
+    if not text or len(text) > 280:
+        abort(400)
     if derived_from is not None and not isinstance(derived_from, int):
         abort(400)
     parent_text = None
@@ -2081,10 +2085,11 @@ def conversation_statement_new(slug):
     if stmt_resp.status_code == 201:
         stmt_id = stmt_resp.json().get('id')
         if stmt_id is not None:
-            ids = list(part.new_stmt_ids or [])
-            ids.append(stmt_id)
-            part.new_stmt_ids = ids
-            if derived_from is not None:
+            if derived_from is None:
+                ids = list(part.new_stmt_ids or [])
+                ids.append(stmt_id)
+                part.new_stmt_ids = ids
+            else:
                 record_statement_provenance(conv.id, stmt_id, derived_from,
                                             parent_text=parent_text, new_text=text)
         _touch_last_engagement(part)

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -1622,7 +1622,7 @@
         resp.json().then(noteSubmittedStatement);
         composerEl.hidden = true;
         proposeSubmitted.hidden = false;
-        NEW_STMT_USED++;
+        if (derivedFrom == null) NEW_STMT_USED++;
         updateNewstmtCard();
         afterSuccess();
       } else {

--- a/v2/tests/test_proxy_blueprint.py
+++ b/v2/tests/test_proxy_blueprint.py
@@ -245,6 +245,37 @@ def test_statement_new_happy_path_records_polis_id(auth_client, participant):
                for c in resp.headers.getlist('Set-Cookie'))
 
 
+def test_statement_new_wording_suggestion_exempt_from_quota(auth_client, participant):
+    """Wording suggestions (derived_from set) must not be blocked by, or count
+    against, the new-statement quota (#296)."""
+    conv = Conversation(slug='q2', polis_id='q2xxxxxxxx', title='Q2', active=True,
+                        access_policy='public', phase_submission=True,
+                        argument_vote_data={'new_stmt_max': 1})
+    db.session.add(conv)
+    db.session.commit()
+    db.session.add(Participation(participant_id=participant.id,
+                                 conversation_id=conv.id, pseudonym='p',
+                                 new_stmt_ids=[101]))  # already at the cap of 1
+    db.session.commit()
+
+    sess_resp = _fake_upstream(cookies={'session': 'NEWPA'})
+    sess_resp.ok = True
+    sess_resp.json = lambda: {'csrf_token': 'TOK'}
+    stmt_resp = _fake_upstream(status_code=201, content=b'{"id":888}')
+    stmt_resp.json = lambda: {'id': 888}
+
+    with patch('app._statement_text_map', return_value={101: 'original wording'}), \
+         patch('app.requests.post', side_effect=[sess_resp, stmt_resp]):
+        resp = auth_client.post('/c/q2/statements/new',
+                                headers={'Sec-Fetch-Site': 'same-origin'},
+                                json={'text': 'original wording, rephrased',
+                                      'derived_from': 101})
+
+    assert resp.status_code == 201  # not 403 quota_exceeded — wording suggestions are unlimited
+    part = Participation.query.filter_by(conversation_id=conv.id).first()
+    assert part.new_stmt_ids == [101]  # unchanged — derivative id must NOT be appended
+
+
 def test_statement_new_requires_csrf_when_csrf_enabled(csrf_enabled_app):
     client = csrf_enabled_app.test_client()
     p = Participant(mw_user_id=10101, mw_username='csrfuser', xid='c' * 64)


### PR DESCRIPTION
## Summary

- **Fix #296**: "Suggest different wording" was sharing the same submission pipeline and quota counter as "Propose a new statement," so participants could exhaust their wording-suggestion allowance after 3 submissions — contradicting `spec_functional-design.md`'s stated behavior that wording suggestions are unlimited. The quota check and `Participation.new_stmt_ids` append now both skip derivative (`derived_from` set) submissions; client-side `NEW_STMT_USED` only increments for genuinely new statements. All other validation (text length, `derived_from` type, unknown-parent, similarity threshold) keeps its original order — no behavior change for existing paths.
- **Docs**: absorbed an external research dossier on Wikimedia's earlier *All Our Ideas* (AOI) deliberation-tool experiment (2011, 2014) into `docs/research/` as prior-art context, with a prominent disclaimer that it did not inform wiki-polis/ProtoWiki's design.

## Test plan

- [x] New test `test_statement_new_wording_suggestion_exempt_from_quota` (`v2/tests/test_proxy_blueprint.py`): asserts a derivative submission succeeds (201, not 403) even when the plain-statement quota is exhausted, and that `new_stmt_ids` is unchanged.
- [x] Full test suite passes: `445 passed`.
- [x] `ruff check .` — all checks passed.
- [x] Existing quota tests (`test_statement_new_enforces_quota`, `test_statement_new_happy_path_records_polis_id`) unchanged and still passing, confirming non-derivative behavior is untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Vids9SdTwYpgsqweVGGPpz)_