### PR TITLE
feat(sim): add --phase6 to the local simulator (+ repair two stale-sim bugs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ tmp/
 .dev-session
 audit/
 
+# Analysis exporters + notebook, and the de-identified export bundles they
+# produce. Local-only: bundles can contain participant-authored statement text.
+private/
+
 # Design handoff (local reference only)
 design_handoff_propose_and_arguments/
 

--- a/v2/guide_deployment.md
+++ b/v2/guide_deployment.md
@@ -688,7 +688,20 @@ To export an envvar to the shell:
 export SECRET_KEY=$(toolforge envvars show SECRET_KEY | tail -1 | awk '{print $NF}')
 ```
 
-`deploy.sh --migrate` does this automatically — it loads **all** Toolforge envvars dynamically (the full `toolforge envvars list`), so every required variable is present with no hard-coded list to maintain.
+**This only works on the bastion.** `toolforge` is not installed inside `toolforge webservice python3.13 shell` (confirmed 2026-08 — `bash: toolforge: command not found`), and `/run/secrets/wiki-polis/<name>` is also **not** mounted in that debug shell (despite being what `_read_secret()` in `app.py` reads from at runtime — that mount exists in the actual serving pod, not this ad-hoc shell). So the pattern above cannot be run from inside the webservice shell itself.
+
+If you need a secret value inside the webservice shell (e.g. to run a one-off script that isn't wired into `flask --app app.py ...`), fetch it on the bastion first, then pass it in without echoing it to the screen or shell history:
+
+```bash
+# On the bastion:
+toolforge envvars show DATABASE_URL   # note the value
+
+# Inside the webservice shell:
+read -rs DATABASE_URL   # paste the value at the hidden prompt, press Enter
+export DATABASE_URL
+```
+
+`deploy.sh --migrate` does this automatically — it loads **all** Toolforge envvars dynamically (the full `toolforge envvars list`), so every required variable is present with no hard-coded list to maintain. `flask --app app db upgrade`, run via `deploy.sh --migrate`, is the supported path precisely because it avoids this gap.
 
 ---
 
@@ -702,6 +715,8 @@ export SECRET_KEY=$(toolforge envvars show SECRET_KEY | tail -1 | awk '{print $N
 | No SQLite CLI on Toolforge | Use `python3 -c 'import sqlite3; ...'` if needed |
 | Replica DBs unavailable locally | `get_polis_stats()` already handles missing `POLIS_DATABASE_URL` gracefully |
 | "lseek: Illegal seek" in logs | uWSGI stdout rotation noise — safe to ignore |
+| `toolforge: command not found` / secrets missing inside `toolforge webservice python3.13 shell` | That debug shell has neither the `toolforge` CLI nor the `/run/secrets/wiki-polis/` mount the serving pod has. Fetch values on the bastion and pass them in via `read -rs VARNAME` (see "Exporting envvars manually" above), or run the work as a job, which *does* get the tool's envvars injected |
+| Envvars empty in a script (`$DATABASE_URL` unset) | An interactive **bastion** shell gets no injected envvars — only jobs and the webservice do. Run one-off work with `toolforge jobs run … --wait`, as `v2/bin/phase-scheduler.sh` does |
 
 ---
 

--- a/v2/guide_local-dev.md
+++ b/v2/guide_local-dev.md
@@ -196,6 +196,46 @@ uv run python simulate_cats_vs_dogs.py --particiapi-url http://127.0.0.1:8012
 
 The script also reads `PARTICIAPI_BASE_URL` from `v2/.env`.
 
+### Derivative statements
+
+`--derivatives N` makes N of the mid-run submissions **rewordings of an existing
+statement**, each recorded in `statement_provenance` via the app's own
+`record_statement_provenance()` — the same function the `/statements/new` route uses,
+so the rows and their similarity scores are the real thing. Simulated voters vote a
+rewording the way they voted its parent, so a lineage looks like a lineage in the
+vote matrix.
+
+```bash
+uv run python simulate_cats_vs_dogs.py --derivatives 6
+```
+
+Needed by anything that reads provenance: the derivative-statement analysis, the
+lineage-collapse counterfactual, and the near-duplicate grouping. Requires Flask
+registration, so it is skipped under `--skip-flask`.
+
+### Stable participant identity
+
+By default every simulated voter opens a fresh anonymous Particiapi session, so each
+one becomes a **different** Polis `uid`. That is fine for a single round, but it means
+a Phase 2 participant and a Phase 6 participant can never be recognised as the same
+person — which is exactly what a before/after comparison needs.
+
+Set `PARTICIAPI_SUB_SECRET` (matching Particiapi's `TRUSTED_SUB_SECRET`) and the
+simulator asserts a stable subject per synthetic person, the way Flask's proxy does in
+production — see [`ref_cross-device-identity.md`](ref_cross-device-identity.md).
+
+The script probes this at startup and says which mode it is in:
+
+```
+[identity] trusted-sub honoured — participants keep one uid across rounds
+[identity] trusted-sub NOT honoured (secret mismatch, or a Particiapi image
+           predating the feature) — participants will be anonymous
+```
+
+It asks the database rather than trusting the response, because an unset secret, a
+mismatched secret and an image without the feature all look identical from the
+client side: a session that silently falls back to anonymous.
+
 ## Dev Test Users
 
 Three generic test accounts let you switch between user identities without going through Wikimedia OAuth. Enable them by setting `DEV_FAKE_LOGIN=1` in `v2/.env`.

--- a/v2/ref_polis-data-model.md
+++ b/v2/ref_polis-data-model.md
@@ -28,9 +28,14 @@ vote SMALLINT   -- -1 = Agree, 1 = Disagree, 0 = Pass/Unsure
 This is **opposite to the intuitive sign**. The CSV export negates every vote so that
 Agree = +1 in exports, but the raw table and the vote API use -1 = Agree.
 
-wiki-polis sends `value: 1` for Agree and `value: -1` for Disagree via Particiapi's
-`PUT /api/conversations/{id}/votes/{tid}`. Particiapi translates these before writing to
-Polis. Verify Particiapi's translation if vote data looks inverted.
+wiki-polis sends the raw Polis signs unchanged via Particiapi's
+`PUT /api/conversations/{id}/votes/{tid}` — `value: -1` for Agree, `1` for Disagree, `0`
+for Pass. **Particiapi passes the value straight through; there is no translation step.**
+`polis_admin.py` counts `-1` as agree, which only reconciles under pass-through.
+
+The one exception today is the Phase 6 informed-vote route (`app.py`, the second
+`polis_values` map), which sends the inverted sign — agree as `+1`. That is a known bug,
+not a convention: it disagrees with the explore path in the same file.
 
 ### tid and pid start at 0
 
@@ -45,9 +50,14 @@ checked for presence.
 
 ### Submitting a statement casts a vote
 
-Submitting a statement writes a `votes` row for the author: an **agree (`-1`)** on their
-own `tid`, from the author's own `pid`. No client asks for it, and nothing in wiki-polis
-casts it — Polis records it as part of accepting the statement.
+Submitting a statement through the participant endpoint
+(`POST /api/conversations/{id}/statements/`) writes a `votes` row for the author: an
+**agree (`-1`)** on their own `tid`, from the author's own `pid`. No client asks for it,
+and nothing in wiki-polis casts it — Polis records it as part of accepting the statement.
+
+Whether the **moderator seed path** (`add_seed_return_id` → `/api/v3/comments`, used by
+`_init_phase6`) does the same is **unverified** — it sends an explicit `'vote': 0`, which
+suggests it may not. Confirm before relying on either behaviour for seeded statements.
 
 So a conversation's vote count is *participant votes + one per statement*, and every
 statement starts with one agree it did not earn. Any count, tally or turnout figure

--- a/v2/ref_polis-data-model.md
+++ b/v2/ref_polis-data-model.md
@@ -55,20 +55,36 @@ Submitting a statement through the participant endpoint
 **agree (`-1`)** on their own `tid`, from the author's own `pid`. No client asks for it,
 and nothing in wiki-polis casts it — Polis records it as part of accepting the statement.
 
-Whether the **moderator seed path** (`add_seed_return_id` → `/api/v3/comments`, used by
-`_init_phase6`) does the same is **unverified** — it sends an explicit `'vote': 0`, which
-suggests it may not. Confirm before relying on either behaviour for seeded statements.
+The **moderator seed path** (`add_seed_return_id` → `/api/v3/comments`, used by
+`_init_phase6`) also writes an author row, but a **pass (`0`)** rather than an agree —
+its explicit `'vote': 0` takes effect. So the two paths differ:
 
-So a conversation's vote count is *participant votes + one per statement*, and every
+| path | author row |
+|------|------------|
+| participant `POST …/statements/` | agree (`-1`) |
+| moderator `add_seed_return_id` | pass (`0`) |
+
+Both leave one row per statement from the author's own `pid`. So a conversation's vote
+count is *participant votes + one per statement*, and on the participant path every
 statement starts with one agree it did not earn. Any count, tally or turnout figure
 derived from `votes` has to decide whether to exclude author votes; a per-participant
-average silently includes them.
+average silently includes them. Identify them by joining `comments` on `(zid, tid)` and
+comparing `pid` — there is no flag.
 
 Reproduced on the local stack (2026-09-02): a fresh conversation with 0 votes, one
 statement submitted through `POST /api/conversations/{id}/statements/` and no vote call
 made, leaves exactly one row — `pid=0, tid=0, vote=-1` — whose `pid` equals the author's
 in `comments`. This is also why a simulated Phase 6 round of 30 voters over 5 statements
 lands 155 rows in `votes`, not 150.
+
+The moderator half was confirmed on production the same day: the one Phase 6 round there
+carried exactly 11 author rows, one per seeded statement, every one `pid=0, vote=0`.
+
+**This is a live divergence between the simulator and production.**
+`simulate_cats_vs_dogs.py --phase6` seeds Phase 6 through the *participant* endpoint
+(it has no Polis admin credentials), so local Phase 6 statements carry `-1` author rows
+where production carries `0`. Anything counting or clustering over a simulated Phase 6
+round sees agrees that production would not have.
 
 ### zinvite vs zid
 

--- a/v2/ref_polis-data-model.md
+++ b/v2/ref_polis-data-model.md
@@ -43,6 +43,23 @@ wiki-polis fix: template guards use `{% if item.phase6_stmt_id is not none %}` n
 `{% if item.phase6_stmt_id %}`. The same care applies anywhere a Polis integer ID is
 checked for presence.
 
+### Submitting a statement casts a vote
+
+Submitting a statement writes a `votes` row for the author: an **agree (`-1`)** on their
+own `tid`, from the author's own `pid`. No client asks for it, and nothing in wiki-polis
+casts it — Polis records it as part of accepting the statement.
+
+So a conversation's vote count is *participant votes + one per statement*, and every
+statement starts with one agree it did not earn. Any count, tally or turnout figure
+derived from `votes` has to decide whether to exclude author votes; a per-participant
+average silently includes them.
+
+Reproduced on the local stack (2026-09-02): a fresh conversation with 0 votes, one
+statement submitted through `POST /api/conversations/{id}/statements/` and no vote call
+made, leaves exactly one row — `pid=0, tid=0, vote=-1` — whose `pid` equals the author's
+in `comments`. This is also why a simulated Phase 6 round of 30 voters over 5 statements
+lands 155 rows in `votes`, not 150.
+
 ### zinvite vs zid
 
 wiki-polis stores and uses the `zinvite` (the opaque string like `6tpsckec8u`), not the

--- a/v2/simulate_cats_vs_dogs.py
+++ b/v2/simulate_cats_vs_dogs.py
@@ -20,6 +20,7 @@ Usage (from v2/ directory):
   uv run python simulate_cats_vs_dogs.py --conversation-id <existing_zinvite>
   uv run python simulate_cats_vs_dogs.py --particiapi-url http://127.0.0.1:8002
   uv run python simulate_cats_vs_dogs.py --skip-flask
+  uv run python simulate_cats_vs_dogs.py --phase6   # also advance into informed voting
 """
 
 import argparse
@@ -447,6 +448,78 @@ def run_simulation(conv_id: str) -> None:
     return text_to_tid
 
 
+INFORMED_VOTERS = 30
+
+
+def _cast_informed_votes(p6_zinvite: str, tids: list[int]) -> None:
+    """Cast a batch of grouped informed votes on the Phase 6 statements so the round
+    has real cluster structure. Uses Polis-native signs directly (-1=agree, +1=disagree,
+    0=pass) — the same signs the app's phase6_vote route writes after its `-vote`
+    negation, so the resulting `votes` rows match production."""
+    cast = 0
+    for v in range(INFORMED_VOTERS):
+        g = v % 3                         # three synthetic opinion groups
+        cookie, csrf = new_session()
+        for j, tid in enumerate(tids):
+            if g == 2:                    # group 2 is noisy/undecided
+                val = 0 if random.random() < 0.5 else random.choice((-1, 1))
+            else:                         # groups 0/1 take opposite stances per statement
+                base = -1 if ((j % 2 == 0) == (g == 0)) else 1
+                val = add_noise(base)
+            if cast_vote(cookie, csrf, p6_zinvite, tid, val):
+                cast += 1
+    print(f"  Cast {cast} informed votes across {INFORMED_VOTERS} participants")
+
+
+def advance_to_phase6(conv_id: str) -> None:
+    """Advance the conversation into Phase 6 (informed voting).
+
+    Creates the dedicated Phase 6 Polis conversation, seeds it with the confirmed
+    featured statements (recording each phase6 tid onto the FeaturedStatement row),
+    wires the id onto the conversation, flips `phase_informed_voting`, and casts a
+    batch of informed votes. Mirrors the app's `_init_phase6` but via the same
+    raw-SQL + HTTP path the rest of this simulator uses, so it needs no Polis admin
+    credentials (which the local dev stack does not set)."""
+    from app import create_app
+    from db import Conversation, FeaturedStatement, db as flask_db
+
+    app = create_app()
+    with app.app_context():
+        conv = Conversation.query.filter_by(polis_id=conv_id).first()
+        if conv is None:
+            print("  [skip] conversation not found in Flask DB")
+            return
+        featured = (FeaturedStatement.query
+                    .filter_by(conversation_id=conv.id, confirmed_by_admin=True)
+                    .all())
+        if not featured:
+            print("  [skip] no confirmed featured statements to seed into Phase 6")
+            return
+
+        p6_zinvite = create_polis_conversation(
+            f"{conv.title} — Informed Voting",
+            "Informed voting round on the featured statements.")
+        print(f"  Phase 6 Polis conversation: {p6_zinvite}")
+
+        admin_cookie, admin_csrf = new_session()
+        p6_tids: list[int] = []
+        for fs in featured:
+            tid = submit_statement(admin_cookie, admin_csrf, p6_zinvite, fs.statement_text)
+            if tid is None:
+                print(f"  [warn] could not seed featured statement fs={fs.id}")
+                continue
+            fs.phase6_polis_statement_id = tid
+            p6_tids.append(tid)
+
+        conv.phase6_polis_conversation_id = p6_zinvite
+        conv.phase_informed_voting = True
+        flask_db.session.commit()
+        print(f"  Seeded {len(p6_tids)} statement(s); phase_informed_voting=True")
+
+        if p6_tids:
+            _cast_informed_votes(p6_zinvite, p6_tids)
+
+
 def main():
     global FLASK, PARTICIAPI
 
@@ -456,6 +529,10 @@ def main():
                         help="Use an existing Polis conversation instead of creating one")
     parser.add_argument("--skip-flask", action="store_true",
                         help="Skip wiki-polis Flask DB registration")
+    parser.add_argument("--phase6", action="store_true",
+                        help="Also advance into Phase 6 (informed voting): create the "
+                             "dedicated Polis conversation, seed featured statements, flip "
+                             "the phase, and cast informed votes. Requires Flask registration.")
     parser.add_argument("--flask-url", metavar="URL", default=FLASK,
                         help=f"Base URL of the wiki-polis Flask app (default: {FLASK})")
     parser.add_argument("--particiapi-url", metavar="URL", default=PARTICIAPI,
@@ -499,6 +576,15 @@ def main():
             seed_featured_statements(conv_id, text_to_tid)
         except Exception as e:
             print(f"  Featured statement seeding failed: {e} (continuing anyway)")
+
+        if args.phase6:
+            print("\nAdvancing into Phase 6 (informed voting)...")
+            try:
+                advance_to_phase6(conv_id)
+            except Exception as e:
+                print(f"  Phase 6 setup failed: {e} (continuing anyway)")
+    elif args.phase6:
+        print("\n[skip] --phase6 requires Flask registration (drop --skip-flask)")
 
 
 if __name__ == "__main__":

--- a/v2/simulate_cats_vs_dogs.py
+++ b/v2/simulate_cats_vs_dogs.py
@@ -39,7 +39,9 @@ load_dotenv(Path(__file__).with_name(".env"))
 
 PARTICIAPI  = os.environ.get("PARTICIAPI_BASE_URL", "http://127.0.0.1:8002").rstrip("/")
 FLASK       = os.environ.get("WIKI_POLIS_FLASK_URL", "http://127.0.0.1:5001").rstrip("/")
-DB_CONTAINER = "particiapp-docker-postgres-1"
+# Overridable: container names collide across stacks on a shared host, and psql()
+# below writes. Pin it explicitly rather than trusting the default to be local.
+DB_CONTAINER = os.environ.get("POLIS_DB_CONTAINER", "particiapp-docker-postgres-1")
 
 # Trusted-subject secret. When set (and honoured by the Particiapi image), each
 # simulated person keeps ONE Polis uid across sessions and across the Phase 2 and
@@ -267,11 +269,19 @@ def add_noise(vote: int, flip_prob: float = 0.12, pass_prob: float = 0.08) -> in
     return vote
 
 
-def psql(sql: str) -> str:
-    """Run a SQL statement in the Polis PostgreSQL container. Returns first result row."""
+def psql(sql: str, **params: str) -> str:
+    """Run a SQL statement in the Polis PostgreSQL container. Returns first result row.
+
+    Pass caller-supplied values as keyword arguments and reference them as :\'name\'
+    in `sql`; psql quotes them itself, so text that arrived on the command line never
+    has to be trusted (`--conversation-id` reaches this function).
+    """
+    var_args: list[str] = []
+    for name, value in params.items():
+        var_args += ["-v", f"{name}={value}"]
     r = subprocess.run(
         ["docker", "exec", DB_CONTAINER,
-         "psql", "-U", "polis", "polis", "-t", "-c", sql],
+         "psql", "-U", "polis", "polis", "-t", *var_args, "-c", sql],
         capture_output=True, text=True,
     )
     if r.returncode != 0:
@@ -281,7 +291,7 @@ def psql(sql: str) -> str:
     return lines[0] if lines else ""
 
 
-def probe_stable_identity(conv_id: str) -> bool:
+def probe_stable_identity() -> bool:
     """Check whether this Particiapi honours X-Particiapi-Sub, and set STABLE_IDENTITY.
 
     Opens one session with a throwaway subject and looks for the resulting
@@ -296,12 +306,16 @@ def probe_stable_identity(conv_id: str) -> bool:
         STABLE_IDENTITY = False
         return False
 
-    probe = f"sim-{conv_id}-probe"
+    # Fixed, not per-conversation: the probe casts no votes, so a per-run subject
+    # would leave one orphan row per run in the table the Phase 2 / Phase 6
+    # identity join reads, each looking like a participant who never voted.
+    probe = "sim-identity-probe"
     try:
         requests.post(f"{PARTICIAPI}/api/session?create=true",
                       headers={"X-Particiapi-Sub": probe,
                                "X-Particiapi-Sub-Secret": SUB_SECRET}).raise_for_status()
-        found = psql(f"SELECT COUNT(*) FROM particiapi_users WHERE subject = '{probe}';")
+        found = psql("SELECT COUNT(*) FROM particiapi_users WHERE subject = :'s';",
+                     s=probe)
         STABLE_IDENTITY = found.strip() not in ("", "0")
     except Exception as e:
         print(f"  [identity] probe failed ({e}) — falling back to anonymous sessions")
@@ -578,9 +592,17 @@ INFORMED_VOTERS = 30
 
 def _cast_informed_votes(p6_zinvite: str, tids: list[int], phase2_conv_id: str) -> None:
     """Cast a batch of grouped informed votes on the Phase 6 statements so the round
-    has real cluster structure. Uses Polis-native signs directly (-1=agree, +1=disagree,
-    0=pass) — the same signs the app's phase6_vote route writes after its `-vote`
-    negation, so the resulting `votes` rows match production."""
+    has real cluster structure.
+
+    Writes Polis-native signs directly (-1=agree, +1=disagree, 0=pass): the convention
+    every other vote in the system uses, and the one `polis_admin.py` counts as agree.
+
+    The app's own informed-vote route currently writes the OPPOSITE sign — `app.py`
+    maps agree to +1 and nothing negates it downstream. That inversion is the bug
+    PR #328 fixes. Until #328 lands, a round cast here and a round cast by clicking
+    in the app disagree, which makes this a useful oracle rather than a trap: once
+    the fix is in, the two should match.
+    """
     cast = 0
     for v in range(INFORMED_VOTERS):
         g = v % 3                         # three synthetic opinion groups
@@ -698,7 +720,7 @@ def main():
         print("\n[skip] --derivatives needs the Flask DB for provenance (drop --skip-flask)")
         n_derivatives = 0
 
-    probe_stable_identity(conv_id)
+    probe_stable_identity()
 
     try:
         text_to_tid = run_simulation(conv_id, n_derivatives=n_derivatives)

--- a/v2/simulate_cats_vs_dogs.py
+++ b/v2/simulate_cats_vs_dogs.py
@@ -29,6 +29,7 @@ import random
 import re
 import string
 import subprocess
+import uuid
 import sys
 from pathlib import Path
 
@@ -273,8 +274,10 @@ def psql(sql: str, **params: str) -> str:
     """Run a SQL statement in the Polis PostgreSQL container. Returns first result row.
 
     Pass caller-supplied values as keyword arguments and reference them as :\'name\'
-    in `sql`; psql quotes them itself, so text that arrived on the command line never
-    has to be trusted (`--conversation-id` reaches this function).
+    in `sql`; psql quotes them itself. The text that actually needs this is the
+    conversation topic and description below — under --phase6 the topic is built
+    from `conv.title`, which an admin edits, and a `$$` in it would otherwise
+    terminate the dollar quote it used to be pasted into.
     """
     var_args: list[str] = []
     for name, value in params.items():
@@ -282,9 +285,16 @@ def psql(sql: str, **params: str) -> str:
     # The SQL goes in on stdin, not as -c: psql only interpolates :\'name\' while
     # lexing input it reads, and silently does not do it for -c (which fails with
     # "syntax error at or near \":\"" instead).
+    #
+    # ON_ERROR_STOP is what makes reading from stdin safe. Without it psql reports
+    # a failed statement on stderr and still exits 0, so the returncode check below
+    # never fires and the caller reads "" as though it were a value. Measured
+    # against postgres:18-trixie: a bad statement via -c exits 1, via stdin exits
+    # 0, via stdin with ON_ERROR_STOP exits 3. It goes ahead of *var_args so a
+    # caller's parameter cannot shadow it.
     r = subprocess.run(
         ["docker", "exec", "-i", DB_CONTAINER,
-         "psql", "-U", "polis", "polis", "-t", *var_args],
+         "psql", "-U", "polis", "polis", "-t", "-v", "ON_ERROR_STOP=1", *var_args],
         input=sql, capture_output=True, text=True,
     )
     if r.returncode != 0:
@@ -309,10 +319,13 @@ def probe_stable_identity() -> bool:
         STABLE_IDENTITY = False
         return False
 
-    # Fixed, not per-conversation: the probe casts no votes, so a per-run subject
-    # would leave one orphan row per run in the table the Phase 2 / Phase 6
-    # identity join reads, each looking like a participant who never voted.
-    probe = "sim-identity-probe"
+    # Unique per run. A fixed subject is satisfied by a row that some earlier run
+    # left behind, so the probe would keep reporting success after the secret was
+    # rotated or the image swapped for one without trusted-sub — and since a
+    # mismatched secret degrades to an anonymous session with a 200, nothing else
+    # would catch it either. The row this leaves behind has no participants or
+    # votes rows, so it joins to nothing.
+    probe = f"sim-identity-probe-{uuid.uuid4().hex[:12]}"
     try:
         requests.post(f"{PARTICIAPI}/api/session?create=true",
                       headers={"X-Particiapi-Sub": probe,
@@ -363,9 +376,12 @@ def create_polis_conversation(topic: str, description: str) -> str:
     zid = psql(
         "INSERT INTO conversations "
         "(topic, description, owner, is_active, is_public, write_type, vis_type) "
-        "VALUES ($$%s$$, $$%s$$, 1, true, true, 1, 1) RETURNING zid;" % (topic, description)
-    )
-    psql(f"INSERT INTO zinvites (zid, zinvite) VALUES ({zid}, '{zinvite}');")
+        "VALUES (:'topic', :'descr', 1, true, true, 1, 1) RETURNING zid;",
+        topic=topic, descr=description)
+    if not zid:
+        raise RuntimeError("conversation insert returned no zid")
+    psql("INSERT INTO zinvites (zid, zinvite) VALUES (:'zid', :'zinvite');",
+         zid=zid, zinvite=zinvite)
     return zinvite
 
 
@@ -621,6 +637,14 @@ def _cast_informed_votes(p6_zinvite: str, tids: list[int], phase2_conv_id: str) 
             if cast_vote(cookie, csrf, p6_zinvite, tid, val):
                 cast += 1
     print(f"  Cast {cast} informed votes across {INFORMED_VOTERS} participants")
+    # Say this on stdout, not only in a docstring the operator never opens: anyone
+    # comparing this round against one voted through the app needs to know the two
+    # currently disagree, or they will read the difference as a bug here.
+    print("  [signs] written Polis-native (-1=agree). The app's own Phase 6 route "
+          "writes +1 for agree, so a round cast here and one cast by clicking in "
+          "the app have OPPOSITE signs until that is fixed.")
+    print(f"  [counts] `votes` will hold {cast} rows plus one author agree per "
+          "statement — Polis adds those itself; see ref_polis-data-model.md.")
 
 
 def advance_to_phase6(conv_id: str) -> None:
@@ -696,6 +720,12 @@ def main():
 
     FLASK = args.flask_url.rstrip("/")
     PARTICIAPI = args.particiapi_url.rstrip("/")
+
+    # The default container name is whatever compose generated for *a*
+    # particiapp-docker checkout on this host, and POLIS_DB_CONTAINER can also come
+    # from v2/.env via load_dotenv. A run that writes into the wrong stack's Polis
+    # database otherwise looks identical on stdout to a correct one.
+    print(f"Polis DB container: {DB_CONTAINER}   ·   Particiapi: {PARTICIAPI}")
 
     conv_id = args.conversation_id
     if not conv_id:

--- a/v2/simulate_cats_vs_dogs.py
+++ b/v2/simulate_cats_vs_dogs.py
@@ -41,6 +41,15 @@ PARTICIAPI  = os.environ.get("PARTICIAPI_BASE_URL", "http://127.0.0.1:8002").rst
 FLASK       = os.environ.get("WIKI_POLIS_FLASK_URL", "http://127.0.0.1:5001").rstrip("/")
 DB_CONTAINER = "particiapp-docker-postgres-1"
 
+# Trusted-subject secret. When set (and honoured by the Particiapi image), each
+# simulated person keeps ONE Polis uid across sessions and across the Phase 2 and
+# Phase 6 conversations — which is what production does, and what any analysis
+# comparing the two rounds needs. Without it Particiapi mints a throwaway uid per
+# session and the two rounds cannot be linked. See ref_cross-device-identity.md.
+SUB_SECRET = (os.environ.get("PARTICIAPI_SUB_SECRET")
+              or os.environ.get("TRUSTED_SUB_SECRET") or "")
+STABLE_IDENTITY = False   # set by probe_stable_identity()
+
 # ── Statements ────────────────────────────────────────────────────────────────
 
 SEED_STATEMENTS = [
@@ -109,6 +118,20 @@ VOTES = [
 
 GROUP_SIZES = [35, 30, 10]   # cat people, dog people, neutral
 
+# ── Derivative statements (#143 provenance) ───────────────────────────────────
+# Rewordings of a seed statement, submitted mid-run as "an improvement on" their
+# parent. Each is (index into SEED_STATEMENTS, reworded text). They express the
+# same proposition as the parent, so simulated voters vote them the parent's way —
+# which is what makes a lineage look like a lineage in the vote matrix.
+DERIVATIVE_STATEMENTS = [
+    (0, "Cats make better companions than dogs for most households"),
+    (1, "Dogs show their loyalty more openly than cats do"),
+    (2, "Cats need less daily care than dogs"),
+    (3, "Dogs suit families with young children better than cats do"),
+    (4, "Cats keep themselves cleaner than dogs do"),
+    (8, "Cats adapt to apartment living better than dogs"),
+]
+
 # ── Seeded arguments for featured statements ──────────────────────────────────
 # Maps statement text → {'pro': [...], 'con': [...]}
 # proposer_id=None marks these as admin-seeded (not participant-authored).
@@ -170,13 +193,28 @@ FEATURED_ARGS = {
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
-def new_session() -> tuple[str, str]:
-    """Create a fresh anonymous Particiapi session. Returns (session_cookie, csrf_token).
+def subject_for(conv_id: str, person_idx: int) -> str:
+    """Stable synthetic subject for one simulated person, scoped to this run so
+    repeated runs don't merge into each other's participants."""
+    return f"sim-{conv_id}-p{person_idx}"
+
+
+def new_session(subject: str | None = None) -> tuple[str, str]:
+    """Create a Particiapi session. Returns (session_cookie, csrf_token).
+
+    With `subject` (and a working trusted-sub secret) Particiapi resolves the same
+    uid every time, the way Flask's proxy does in production. Otherwise it mints a
+    fresh anonymous uid, which is fine for single-round tests but leaves Phase 2 and
+    Phase 6 participants unlinkable.
 
     requests honours the Secure flag and won't send the cookie over plain HTTP,
     so we extract the raw value from Set-Cookie and pass it manually.
     """
-    r = requests.post(f"{PARTICIAPI}/api/session?create=true")
+    headers = {}
+    if subject and SUB_SECRET and STABLE_IDENTITY:
+        headers = {"X-Particiapi-Sub": subject,
+                   "X-Particiapi-Sub-Secret": SUB_SECRET}
+    r = requests.post(f"{PARTICIAPI}/api/session?create=true", headers=headers)
     r.raise_for_status()
     m = re.search(r'session=([^;]+)', r.headers.get('Set-Cookie', ''))
     if not m:
@@ -241,6 +279,65 @@ def psql(sql: str) -> str:
     # -t gives tuples-only output: value lines come first, then status like "INSERT 0 1"
     lines = [l.strip() for l in r.stdout.splitlines() if l.strip() and not l.strip().startswith(("INSERT", "UPDATE", "DELETE", "SELECT"))]
     return lines[0] if lines else ""
+
+
+def probe_stable_identity(conv_id: str) -> bool:
+    """Check whether this Particiapi honours X-Particiapi-Sub, and set STABLE_IDENTITY.
+
+    Opens one session with a throwaway subject and looks for the resulting
+    `particiapi_users` row. A `TRUSTED_SUB_SECRET` that is unset, mismatched, or
+    absent from the running image all present the same way — a silently anonymous
+    session — so this asks the database rather than trusting the response.
+    """
+    global STABLE_IDENTITY
+    if not SUB_SECRET:
+        print("  [identity] PARTICIAPI_SUB_SECRET unset — participants will be "
+              "anonymous and Phase 2/Phase 6 cannot be linked")
+        STABLE_IDENTITY = False
+        return False
+
+    probe = f"sim-{conv_id}-probe"
+    try:
+        requests.post(f"{PARTICIAPI}/api/session?create=true",
+                      headers={"X-Particiapi-Sub": probe,
+                               "X-Particiapi-Sub-Secret": SUB_SECRET}).raise_for_status()
+        found = psql(f"SELECT COUNT(*) FROM particiapi_users WHERE subject = '{probe}';")
+        STABLE_IDENTITY = found.strip() not in ("", "0")
+    except Exception as e:
+        print(f"  [identity] probe failed ({e}) — falling back to anonymous sessions")
+        STABLE_IDENTITY = False
+        return False
+
+    if STABLE_IDENTITY:
+        print("  [identity] trusted-sub honoured — participants keep one uid across rounds")
+    else:
+        print("  [identity] trusted-sub NOT honoured (secret mismatch, or a Particiapi "
+              "image predating the feature) — participants will be anonymous")
+    return STABLE_IDENTITY
+
+
+def record_provenance(conv_id: str, new_tid: int, parent_tid: int,
+                      new_text: str, parent_text: str) -> bool:
+    """Record `new_tid` as a declared improvement on `parent_tid` in the Flask DB.
+
+    Calls the app's own `record_statement_provenance`, so the row and its similarity
+    scores are written by exactly the code the /statements/new route uses. (The route
+    itself needs an OAuth session and CSRF, which this simulator has no way to hold.)
+    """
+    try:
+        from app import app, record_statement_provenance
+        from db import Conversation
+        with app.app_context():
+            conv = Conversation.query.filter_by(polis_id=conv_id).first()
+            if conv is None:
+                return False
+            row = record_statement_provenance(
+                conv.id, new_tid, parent_tid,
+                parent_text=parent_text, new_text=new_text)
+            return row is not None
+    except Exception as e:
+        print(f"    [warn] provenance write failed for tid={new_tid}: {e}")
+        return False
 
 
 def create_polis_conversation(topic: str, description: str) -> str:
@@ -333,7 +430,7 @@ def register_in_flask(zinvite: str) -> None:
 
 # ── Main simulation ───────────────────────────────────────────────────────────
 
-def run_simulation(conv_id: str) -> None:
+def run_simulation(conv_id: str, n_derivatives: int = 0) -> None:
     """
     Realistic rolling simulation:
 
@@ -343,6 +440,8 @@ def run_simulation(conv_id: str) -> None:
        - Votes on all of them in a random order with group-consistent noise.
        - If assigned as a "submitter", inserts their follow-up at a random mid-vote
          point; the statement then becomes visible to all subsequent participants.
+       - Some submitters instead post a *derivative*: a reworded version of an
+         existing statement, linked to its parent in `statement_provenance`.
     """
     N = sum(GROUP_SIZES)
     print(f"\nConversation: {conv_id}")
@@ -359,6 +458,8 @@ def run_simulation(conv_id: str) -> None:
             pool.append((tid, i))
             print(f"  tid={tid}  {text}")
     print(f"  → {len(pool)} seed statements in pool")
+    tid_by_seed_idx = {votes_idx: tid for tid, votes_idx in pool}
+    derivative_tids: set[int] = set()
 
     # ── Step 2: rolling participants ──────────────────────────────────────────
     print(f"\n[2/2] Running {N} participants "
@@ -368,54 +469,75 @@ def run_simulation(conv_id: str) -> None:
     groups = [0]*GROUP_SIZES[0] + [1]*GROUP_SIZES[1] + [2]*GROUP_SIZES[2]
     random.shuffle(groups)
 
-    # Randomly assign 15 participant slots as submitters (one follow-up each)
-    submitter_slots = sorted(random.sample(range(N), len(FOLLOWUP_STATEMENTS)))
-    followup_for: dict[int, int] = {slot: idx for idx, slot in enumerate(submitter_slots)}
+    # Randomly assign submitter slots: one follow-up each, plus n_derivatives slots
+    # that post a reworded version of an existing statement instead.
+    n_derivatives = max(0, min(n_derivatives, len(DERIVATIVE_STATEMENTS)))
+    slots = random.sample(range(N), len(FOLLOWUP_STATEMENTS) + n_derivatives)
+    followup_for: dict[int, int] = {
+        slot: idx for idx, slot in enumerate(sorted(slots[:len(FOLLOWUP_STATEMENTS)]))}
+    derivative_for: dict[int, int] = {
+        slot: idx for idx, slot in enumerate(sorted(slots[len(FOLLOWUP_STATEMENTS):]))}
 
     total_votes   = 0
     total_skipped = 0
+    total_linked  = 0
 
     for p_idx in range(N):
         group_idx    = groups[p_idx]
-        cookie, csrf = new_session()
+        cookie, csrf = new_session(subject_for(conv_id, p_idx))
         snapshot     = list(pool)          # statements visible on arrival
+
+        # What this participant submits mid-vote, if anything:
+        #   (text, votes_row_index, parent_tid | None, parent_text | None)
+        submission = None
         followup_idx = followup_for.get(p_idx)
-
+        derivative_idx = derivative_for.get(p_idx)
         if followup_idx is not None:
-            # Split snapshot at a random point; submit the follow-up between the halves
-            random.shuffle(snapshot)
-            split   = random.randint(0, len(snapshot))
-            batch1  = snapshot[:split]
-            batch2  = snapshot[split:]
+            submission = (FOLLOWUP_STATEMENTS[followup_idx],
+                          len(SEED_STATEMENTS) + followup_idx, None, None)
+        elif derivative_idx is not None:
+            parent_seed_idx, text = DERIVATIVE_STATEMENTS[derivative_idx]
+            parent_tid = tid_by_seed_idx.get(parent_seed_idx)
+            if parent_tid is not None:
+                # A derivative restates its parent, so it inherits the parent's
+                # voting row — later arrivals vote on both the same way.
+                submission = (text, parent_seed_idx, parent_tid,
+                              SEED_STATEMENTS[parent_seed_idx])
 
-            for tid, votes_idx in batch1:
-                raw  = VOTES[votes_idx][group_idx] if votes_idx < len(VOTES) else 0
+        def vote_batch(batch):
+            nonlocal total_votes, total_skipped
+            for tid, votes_idx in batch:
+                raw = VOTES[votes_idx][group_idx] if votes_idx < len(VOTES) else 0
                 if cast_vote(cookie, csrf, conv_id, tid, add_noise(raw)):
                     total_votes += 1
                 else:
                     total_skipped += 1
 
-            text    = FOLLOWUP_STATEMENTS[followup_idx]
+        random.shuffle(snapshot)
+        if submission is None:
+            vote_batch(snapshot)
+        else:
+            # Split the snapshot at a random point and submit between the halves, so
+            # the new statement only exists for participants who arrive later.
+            text, votes_idx, parent_tid, parent_text = submission
+            split = random.randint(0, len(snapshot))
+            vote_batch(snapshot[:split])
+
             new_tid = submit_statement(cookie, csrf, conv_id, text)
             if new_tid is not None:
-                pool.append((new_tid, 10 + followup_idx))
-                print(f"  [p{p_idx+1:02d}] submitted tid={new_tid}  {text[:55]}")
-
-            for tid, votes_idx in batch2:
-                raw  = VOTES[votes_idx][group_idx] if votes_idx < len(VOTES) else 0
-                if cast_vote(cookie, csrf, conv_id, tid, add_noise(raw)):
-                    total_votes += 1
+                pool.append((new_tid, votes_idx))
+                if parent_tid is None:
+                    print(f"  [p{p_idx+1:02d}] submitted tid={new_tid}  {text[:55]}")
                 else:
-                    total_skipped += 1
+                    derivative_tids.add(new_tid)
+                    linked = record_provenance(conv_id, new_tid, parent_tid,
+                                               text, parent_text)
+                    total_linked += bool(linked)
+                    mark = "linked" if linked else "UNLINKED"
+                    print(f"  [p{p_idx+1:02d}] improved tid={parent_tid} → tid={new_tid} "
+                          f"({mark})  {text[:45]}")
 
-        else:
-            random.shuffle(snapshot)
-            for tid, votes_idx in snapshot:
-                raw  = VOTES[votes_idx][group_idx] if votes_idx < len(VOTES) else 0
-                if cast_vote(cookie, csrf, conv_id, tid, add_noise(raw)):
-                    total_votes += 1
-                else:
-                    total_skipped += 1
+            vote_batch(snapshot[split:])
 
         if (p_idx + 1) % 15 == 0:
             pct = (p_idx + 1) / N * 100
@@ -425,6 +547,9 @@ def run_simulation(conv_id: str) -> None:
     print(f"\n  → {total_votes} votes cast"
           + (f", {total_skipped} skipped" if total_skipped else "")
           + f", {len(pool)} statements total")
+    if derivative_tids:
+        print(f"  → {len(derivative_tids)} derivative statement(s), "
+              f"{total_linked} linked to a parent in statement_provenance")
 
     print(f"\n{'=' * 62}")
     print("Simulation complete.")
@@ -433,8 +558,12 @@ def run_simulation(conv_id: str) -> None:
     print("  (Polis math runs in the background — typically 30–60 s)")
 
     # Build text → tid mapping for the caller (used by seed_featured_statements).
+    # Derivatives share their parent's votes_idx, so they are skipped here — otherwise
+    # a derivative would claim its parent's text and get featured in its place.
     text_to_tid = {}
     for tid, votes_idx in pool:
+        if tid in derivative_tids:
+            continue
         if votes_idx < len(SEED_STATEMENTS):
             text_to_tid[SEED_STATEMENTS[votes_idx]] = tid
         else:
@@ -447,7 +576,7 @@ def run_simulation(conv_id: str) -> None:
 INFORMED_VOTERS = 30
 
 
-def _cast_informed_votes(p6_zinvite: str, tids: list[int]) -> None:
+def _cast_informed_votes(p6_zinvite: str, tids: list[int], phase2_conv_id: str) -> None:
     """Cast a batch of grouped informed votes on the Phase 6 statements so the round
     has real cluster structure. Uses Polis-native signs directly (-1=agree, +1=disagree,
     0=pass) — the same signs the app's phase6_vote route writes after its `-vote`
@@ -455,7 +584,9 @@ def _cast_informed_votes(p6_zinvite: str, tids: list[int]) -> None:
     cast = 0
     for v in range(INFORMED_VOTERS):
         g = v % 3                         # three synthetic opinion groups
-        cookie, csrf = new_session()
+        # The informed round is voted by the FIRST INFORMED_VOTERS people from Phase 2
+        # (same subjects → same uid), so the two rounds can be linked per person.
+        cookie, csrf = new_session(subject_for(phase2_conv_id, v))
         for j, tid in enumerate(tids):
             if g == 2:                    # group 2 is noisy/undecided
                 val = 0 if random.random() < 0.5 else random.choice((-1, 1))
@@ -511,7 +642,7 @@ def advance_to_phase6(conv_id: str) -> None:
         print(f"  Seeded {len(p6_tids)} statement(s); phase_informed_voting=True")
 
         if p6_tids:
-            _cast_informed_votes(p6_zinvite, p6_tids)
+            _cast_informed_votes(p6_zinvite, p6_tids, conv_id)
 
 
 def main():
@@ -531,6 +662,11 @@ def main():
                         help=f"Base URL of the wiki-polis Flask app (default: {FLASK})")
     parser.add_argument("--particiapi-url", metavar="URL", default=PARTICIAPI,
                         help=f"Base URL of Particiapi (default: {PARTICIAPI})")
+    parser.add_argument("--derivatives", type=int, default=0,
+                        metavar="N",
+                        help="Submit N statements as declared improvements on an existing "
+                             "statement, recording each in statement_provenance "
+                             f"(max {len(DERIVATIVE_STATEMENTS)}). Requires Flask registration.")
     args = parser.parse_args()
 
     FLASK = args.flask_url.rstrip("/")
@@ -557,8 +693,15 @@ def main():
             except Exception as e:
                 print(f"  Flask registration failed: {e} (continuing anyway)")
 
+    n_derivatives = args.derivatives
+    if n_derivatives and args.skip_flask:
+        print("\n[skip] --derivatives needs the Flask DB for provenance (drop --skip-flask)")
+        n_derivatives = 0
+
+    probe_stable_identity(conv_id)
+
     try:
-        text_to_tid = run_simulation(conv_id)
+        text_to_tid = run_simulation(conv_id, n_derivatives=n_derivatives)
     except requests.ConnectionError:
         print(f"Error: cannot reach Particiapi at {PARTICIAPI}")
         print("Is the particiapp-docker stack running?  docker compose up")

--- a/v2/simulate_cats_vs_dogs.py
+++ b/v2/simulate_cats_vs_dogs.py
@@ -653,9 +653,16 @@ def advance_to_phase6(conv_id: str) -> None:
     Creates the dedicated Phase 6 Polis conversation, seeds it with the confirmed
     featured statements (recording each phase6 tid onto the FeaturedStatement row),
     wires the id onto the conversation, flips `phase_informed_voting`, and casts a
-    batch of informed votes. Mirrors the app's `_init_phase6` but via the same
-    raw-SQL + HTTP path the rest of this simulator uses, so it needs no Polis admin
-    credentials (which the local dev stack does not set)."""
+    batch of informed votes. Follows the app's `_init_phase6` in outline, but via the
+    same raw-SQL + HTTP path the rest of this simulator uses, so it needs no Polis
+    admin credentials (which the local dev stack does not set).
+
+    That substitution has one measured consequence. `_init_phase6` seeds through the
+    moderator path (`add_seed_return_id`), which leaves a `vote: 0` author row per
+    statement; seeding through the participant endpoint as this does leaves a `-1`
+    (agree) instead. So a simulated Phase 6 round carries author agrees that
+    production does not — confirmed on production 2026-09-02, where the sole Phase 6
+    round held 11 author rows, all `vote=0`. See ref_polis-data-model.md."""
     from app import app
     from db import Conversation, FeaturedStatement, db as flask_db
     with app.app_context():

--- a/v2/simulate_cats_vs_dogs.py
+++ b/v2/simulate_cats_vs_dogs.py
@@ -257,10 +257,8 @@ def create_polis_conversation(topic: str, description: str) -> str:
 
 def seed_featured_statements(conv_id: str, text_to_tid: dict) -> None:
     """Create FeaturedStatement + seeded Argument records in the Flask DB."""
-    from app import create_app
+    from app import app
     from db import Argument, Conversation, FeaturedStatement, db as flask_db
-
-    app = create_app()
     with app.app_context():
         conv = Conversation.query.filter_by(polis_id=conv_id).first()
         if not conv:
@@ -294,7 +292,7 @@ def seed_featured_statements(conv_id: str, text_to_tid: dict) -> None:
                     if not exists:
                         flask_db.session.add(Argument(
                             featured_statement_id=fs.id,
-                            proposer_id=None,
+                            proposer_pseudonym=None,   # NULL = admin-seeded
                             body=body,
                             side=side,
                         ))
@@ -306,10 +304,8 @@ def seed_featured_statements(conv_id: str, text_to_tid: dict) -> None:
 
 def register_in_flask(zinvite: str) -> None:
     """Register the conversation in the wiki-polis Flask DB directly via SQLAlchemy."""
-    from app import create_app
+    from app import app
     from db import Conversation, db as flask_db
-
-    app = create_app()
     base_slug = f"cats-vs-dogs-{zinvite[:6]}"
     with app.app_context():
         slug = base_slug
@@ -480,10 +476,8 @@ def advance_to_phase6(conv_id: str) -> None:
     batch of informed votes. Mirrors the app's `_init_phase6` but via the same
     raw-SQL + HTTP path the rest of this simulator uses, so it needs no Polis admin
     credentials (which the local dev stack does not set)."""
-    from app import create_app
+    from app import app
     from db import Conversation, FeaturedStatement, db as flask_db
-
-    app = create_app()
     with app.app_context():
         conv = Conversation.query.filter_by(polis_id=conv_id).first()
         if conv is None:

--- a/v2/simulate_cats_vs_dogs.py
+++ b/v2/simulate_cats_vs_dogs.py
@@ -279,10 +279,13 @@ def psql(sql: str, **params: str) -> str:
     var_args: list[str] = []
     for name, value in params.items():
         var_args += ["-v", f"{name}={value}"]
+    # The SQL goes in on stdin, not as -c: psql only interpolates :\'name\' while
+    # lexing input it reads, and silently does not do it for -c (which fails with
+    # "syntax error at or near \":\"" instead).
     r = subprocess.run(
-        ["docker", "exec", DB_CONTAINER,
-         "psql", "-U", "polis", "polis", "-t", *var_args, "-c", sql],
-        capture_output=True, text=True,
+        ["docker", "exec", "-i", DB_CONTAINER,
+         "psql", "-U", "polis", "polis", "-t", *var_args],
+        input=sql, capture_output=True, text=True,
     )
     if r.returncode != 0:
         raise RuntimeError(r.stderr.strip())


### PR DESCRIPTION
Adds a `--phase6` step to the local simulator and repairs two pre-existing breakages that stopped it running against the current codebase. Refs #301.

## Why

There was no low-friction way to get a **votable Phase-6 (informed voting)** conversation on the local stack — needed to verify vote-sensitive changes (e.g. the #285 vote-sign path) end to end. The simulator built a mature Phase-2 → results conversation but stopped short of Phase 6.

## Changes

- **`--phase6`** (opt-in): after seeding featured statements, create the dedicated Phase 6 Polis conversation, seed it with the confirmed featured statements (recording each `phase6_polis_statement_id`), set `phase_informed_voting`, and cast a batch of grouped informed votes. Mirrors the app's `_init_phase6` but via the same raw-SQL + HTTP path the rest of the simulator already uses, so it needs **no Polis admin credentials** (which the local dev stack doesn't set).
- **Fix: `create_app()` double-registration** — the simulator called `create_app()` a second time (the module already builds one at import), re-registering flask-session's `sessions` table → *"Table already defined"*, which broke Flask registration and featured-statement seeding. Now reuses the module-level `app` in the three DB-touching helpers.
- **Fix: stale `Argument` field** — `Argument(proposer_id=…)` → `proposer_pseudonym` (the model was renamed; `NULL` = admin-seeded).

## Verification (local end-to-end)

Ran `uv run python simulate_cats_vs_dogs.py --phase6 --particiapi-url http://127.0.0.1:8002` against the full Docker stack:

- Registered `/c/cats-vs-dogs-…`, 1361 Phase-2 votes, 25 statements.
- Seeded 5 featured statements + 20 arguments.
- Phase 6: created the Polis conversation, seeded 5 statements, `phase_informed_voting=True`, cast 150 informed votes across 30 participants.
- **Postgres check** on the Phase-6 conversation's `votes`: `-1` (agree) 55, `+1` (disagree) 57, `0` (pass) 43 — i.e. stored in Polis-native sign convention, verbatim. 31 distinct pids × 5 tids.

No app code changed — this is dev-tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
