### PR TITLE
Track the analysis pipeline, and fix the person_key join between the two export halves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,18 @@ tmp/
 .dev-session
 audit/
 
+# Analysis pipeline. The code is tracked so the reported numbers can be
+# re-derived and checked; nothing it reads or writes is. Bundles and built
+# reports carry participant-authored statement text, and the export salt and
+# sub-secret are credentials.
+private/*
+!private/analysis/
+private/analysis/*
+!private/analysis/*.py
+!private/analysis/*.ipynb
+!private/analysis/*.md
+!private/analysis/*.sh
+
 # Design handoff (local reference only)
 design_handoff_propose_and_arguments/
 

--- a/private/analysis/CALCULATIONS.md
+++ b/private/analysis/CALCULATIONS.md
@@ -1,0 +1,164 @@
+# How every number is calculated
+
+Written so the figures can be checked rather than believed. For each statistic: what
+it means, exactly how it is computed, which population it runs over, and where the
+code is. Every threshold named here is declared at the top of `pipeline.py` under
+"Thresholds" — none is buried in a function.
+
+To reproduce anything below:
+
+```bash
+./.venv/bin/python -c "
+import sys; sys.path.insert(0,'.')
+import pipeline as P, methods as M
+b = P.load_bundles('2026-nlwiki-arbcom_bundle'); C = b.conversations[0]
+print(P.participation_funnel(b, C))"
+```
+
+---
+
+## Who is counted
+
+**`machine_participants()` — `pipeline.py`.** A participant is machine-made when
+*every* vote it cast landed within `MACHINE_LAG_MS` (2000 ms) of that statement being
+created. Observed lags for the flagged accounts are 5–51 ms; the fastest human vote in
+the data is orders of magnitude slower. Deliberately behavioural rather than based on
+`identity_linked`, so a real person missing an identity record is not silently deleted.
+Cross-check: the behavioural test flagged exactly the same 17 accounts as the identity
+join, from independent evidence.
+
+**Filtering.** `Bundles.phase()` drops them from every read by default. The only caller
+that passes `include_machine=True` is `reproduction_gate()`, which must feed the replica
+the same population the server had or it would be comparing two different things.
+
+**Analysis population.** People with at least `POLIS_VOTE_THRESHOLD` (7) votes —
+Polis's own clustering cutoff, `min(7, n_statements)` in `conversation.clj`. 22 people
+here.
+
+## Vote matrix
+
+**`build_matrix()` — `pipeline.py`.** Rows are participants, columns statements, cells
+raw Polis votes (`-1` agree, `+1` disagree, `0` pass, `NaN` did not vote).
+
+- `mod_out='zero'` sets the *whole column* of a moderated-out statement to 0, including
+  for people who never voted on it. This matches `named_matrix/zero-out-columns` in the
+  engine. **It inflates the non-null count**, which is why in-conv must not be derived
+  from this matrix — see below.
+- `drop_unvoted=True` removes columns nobody voted on (43 of 107 here). These are
+  all-`NaN`, contribute nothing to the PCA, and only make the statement count overstate
+  what was deliberated.
+
+**In-conv.** `replica_labels(..., vote_counts=…)` supplies real vote counts separately,
+because `run_replica` otherwise counts non-null cells — and after zeroing, everybody
+would clear the threshold. The engine computes `:in-conv` from `user-vote-counts`
+(`conversation.clj:243`) while zeroing applies only to `:rating-mat`
+(`conversation.clj:205`). Getting this wrong produced 46 clustered participants against
+the server's 34.
+
+## Agreement between two people
+
+**`agreement_graph()` — `methods.py`.** For each pair, over statements *both* voted on
+decisively (passes excluded — skipping is not agreeing):
+
+```
+agreement = mean(vote_i == vote_j)                     over shared decisive votes
+weight    = max(0, (agreement - 0.5) * 2)              rescaled to [0, 1]
+```
+
+Pairs sharing fewer than `MIN_PAIR_OVERLAP` (5) statements get no edge. A pair agreeing
+at or below chance gets weight 0, so the graph encodes attraction only.
+
+## Group quality
+
+| statistic | what it means | computed by |
+|---|---|---|
+| **silhouette** | how much closer a person sits to their own group than the nearest other, −1 to +1 | `polis_replica.silhouette`, the engine's own definition over base-cluster centres |
+| **modularity** | how much more densely connected a group is than chance predicts, given the degree distribution. **≤ 0 means no community structure**; a single community scores exactly 0 by definition | `igraph`'s `Graph.modularity`, via `leidenalg` |
+| **adjusted Rand index** | agreement between two groupings: 1.0 identical, 0.0 no better than chance | `sklearn.metrics.adjusted_rand_score`, over people labelled by both |
+
+**Multilayer modularity — the trap.** `leidenalg.find_partition_multiplex` returns
+`(membership, improvement)`. **The second value is the optimiser's improvement, not a
+modularity.** It is unbounded and not comparable with anything; an earlier version of
+this analysis reported it as 46.612. `multilayer_leiden()` now scores the joint
+partition by the modularity it achieves *in each layer* and reports the mean (0.101),
+which is directly comparable with the single-layer numbers.
+
+## Deduplication
+
+**`redundant_pairs()` — `methods.py`.** Three signals, in this order:
+
+1. **Normalised text equality** (`normalise_text`: lower-case, strip punctuation,
+   number words → digits). Two statements identical after normalising are the same
+   statement whatever the votes say. Catches `"2 weken"` / `"twee weken"`. Does *not*
+   merge different numbers: `duizend` → 1000, `vijfhonderd` → 500.
+2. **Vote concordance** — among people who voted decisively on both, the fraction
+   voting the same way. `≥ 0.9` with at least 5 such people → redundant.
+3. Otherwise **kept separate.** Preserving a real distinction is the safer error.
+
+Candidate pairs come from `similar_statement_groups()` at `SIMILARITY_THRESHOLD` (0.85)
+cosine similarity over `paraphrase-multilingual-mpnet-base-v2` embeddings — the same
+model the app's similarity sidecar uses.
+
+**Text similarity alone is not sufficient and gets this wrong.** In the nlwiki
+consultation, *"at least a thousand edits"* vs *"at least five hundred edits"* scores
+0.976, and a pair differing only in *"except when"* vs *"also when"* scores 0.993 —
+glossed from the Dutch here, since statement text stays in the bundle rather than in
+this repository. 36 pairs that look near-identical are ones participants demonstrably
+voted differently on.
+
+## Wording comparisons
+
+**`head_to_head()` / `wording_effect()` — `methods.py`.** Each rewrite is compared with
+its parent over people who voted decisively on *both*. Below
+`MIN_DECIDED_FOR_HEAD_TO_HEAD` (7) such people, no comparison is attempted.
+
+- per-pair test: exact binomial on the discordant pairs (`scipy.stats.binomtest`)
+- across pairs: Benjamini–Hochberg correction, because a family of *k* variants yields
+  *k(k−1)/2* comparisons over the same people — one family of 13 contributes 78
+- the ordering effect (whether the earlier wording wins) is reported **separately**,
+  because variants are compared in id order, so pooling the raw counts measures
+  earlier-versus-later and not wording
+
+**Counts of people, never counts of pairs.** `wording_participation()` reports how many
+distinct people voted differently on two wordings (16). Summing discordant pairs gives
+319, which is not a number of people — one person inside a 13-variant family can
+generate 42 discordances alone.
+
+## The refinement ladder
+
+**`method_ladder()` — `methods.py`.** Both methods at three cumulative levels, all
+starting from a matrix with unvoted statements already removed.
+
+- **naive** — the method as the tool applies it
+- **deduplicated** — redundant pairs merged as above, a participant's votes across
+  merged columns averaged
+- **layered** — statements split into topics by agglomerative clustering over
+  embeddings (cosine, average linkage); layers with fewer than 4 statements are
+  skipped. **Leiden uses true multilayer optimisation** (`multilayer_leiden`, one graph
+  per topic optimised jointly). **k-means uses consensus across layers** — a
+  co-classification matrix, then agglomerative clustering on `1 − co-occurrence`.
+
+Those two are not the same method and the table says so in the `quality is` column.
+Multilayer modularity is the direct approach for genuinely layered data; consensus
+clustering (Lancichinetti–Fortunato) is designed for combining repeated runs of one
+algorithm. k-means has no multilayer formulation, hence the difference.
+
+**Singletons.** `split_outliers()` separates one-person communities and reports them as
+`unplaced` rather than as groups — OSLOM's "homeless nodes", and Infomap refuses to emit
+singletons at all. Zero on this data. *(Open: outliers deserve their own treatment
+rather than only being excluded — see the note in `.claude/notes-clustering-findings.md`.)*
+
+## Is any of it real
+
+**`subset_search.py`.** Samples random subsets of statements at several sizes, records
+the best modularity Leiden finds, and repeats the whole search on data where each
+statement's votes have been shuffled across people — preserving that statement's
+agree/disagree balance while destroying any relationship *between* statements.
+
+Read the *distributions*, not the maxima: at 8 statements both real and shuffled reach
+high modularity by chance (medians 0.062 and 0.063). The informative comparison is at
+48 statements — 51 of 150 real subsets score above zero against 0 of 150 shuffled.
+
+**This null is not the standard one.** The literature would use a configuration model
+preserving both margins. Shuffle-within-statements preserves each statement's balance
+and each person's vote count but not the joint degree structure.

--- a/private/analysis/README.md
+++ b/private/analysis/README.md
@@ -1,0 +1,116 @@
+# wiki-polis analysis — runbook
+
+Two exporters run **on the servers** and produce a de-identified bundle; the notebook
+runs **locally** and never touches a database. That split is what lets real data be
+analysed without any personal information leaving the host.
+
+```
+Toolforge (app DB)  ──export_app_bundle.py──▶  app/     ─┐
+                                                         ├─▶  wiki_polis_analysis.ipynb
+VPS (Polis Postgres) ─export_polis_bundle.py─▶  polis/  ─┘
+```
+
+## Step 0 — the shared salt (once)
+
+Both bundles derive `person_key = HMAC(salt, xid)`. They only join if both hosts use
+the **same salt**, so generate it once and copy it to both:
+
+```bash
+openssl rand -hex 32 > ~/.wiki-polis-export-salt && chmod 600 ~/.wiki-polis-export-salt
+```
+
+Never commit it, never put it in a bundle. Each manifest records
+`salt_id = sha256(salt)[:8]`; the notebook refuses to run if the two disagree, so a
+mismatch fails loudly instead of silently producing an empty join.
+
+## Both steps run on Toolforge
+
+The tool already holds `POLIS_DATABASE_URL` — the VPS Polis Postgres, reached over the
+private network as the read-only `wiki_polis_ro` role, which has `SELECT` on every table
+in the public schema. So both halves can be exported from one host, and no VPS shell is
+needed. `psycopg2` is already installed there, because the admin stats panel uses it.
+
+Copy `bundle.py`, `export_app_bundle.py` and `export_polis_bundle.py` to the tool, then:
+
+## Step 1 — app database. Run this first.
+
+It also writes `conversations.tsv`, which step 2 needs.
+
+```bash
+python3 export_app_bundle.py \
+    --db-url "$DATABASE_URL" \
+    --slug 2026-nlwiki-arbcom \
+    --salt-file ~/.wiki-polis-export-salt \
+    --with-pseudonyms \
+    --env prod --out ./arbcom_export
+```
+
+Gives: conversation settings and phase flags, the featured-statement bridge, and
+**statement provenance** — which statement was submitted as an improvement on which
+other statement, plus the similarity score recorded at submission. This half exists
+nowhere else: no Polis export can produce it.
+
+Add `--with-arguments` for arguments and argument votes.
+
+## Step 2 — Polis database (still on Toolforge)
+
+```bash
+python3 export_polis_bundle.py \
+    --db-url "$POLIS_DATABASE_URL" \
+    --conversations ./arbcom_export/conversations.tsv \
+    --salt-file ~/.wiki-polis-export-salt \
+    --env prod --out ./arbcom_export
+```
+
+Then `scp` the `arbcom_export/` directory back.
+
+If you ever need to run this on the VPS itself instead (no psycopg2 there), swap the
+first flag for a psql pipe — it needs nothing but docker:
+
+```bash
+--psql-cmd 'docker compose exec -T postgres psql -U polis polis'
+```
+
+Gives: every current vote and the full vote history, statements with their moderation
+state, per-conversation pids, and `math_main` — **the server's own clustering output**,
+which the analysis treats as the headline result rather than recomputing it.
+
+Both exporters are read-only (SELECT only) and refuse to write anything if their PII
+self-check fails.
+
+## Step 3 — analyse (locally)
+
+```bash
+./.venv/bin/python -c "import pipeline; r = pipeline.run_all('arbcom_export'); \
+    [print(c) for c in r['checks']]"
+```
+
+or open `wiki_polis_analysis.ipynb` with the `.venv` kernel.
+
+## What is and is not in a bundle
+
+**In:** `person_key` (salted, per-export), per-conversation `pid`, `tid`, votes and
+timestamps, statement text (unless `--no-text`), moderation state, seed flags,
+provenance links, similarity scores, conversation settings, `math_main.data`.
+
+**Never:** `mw_user_id`, `mw_username`, `public_username`, `revealed_at`, `xid`,
+`particiapi_users.subject`, the Polis `users` table, invites, content flags, audit
+events, eligibility detail, notification preferences.
+
+**Never: statement and argument authorship.** `statements.csv` carries no author
+column and `arguments.csv` carries only `is_seeded`. The author `pid` is read from
+Polis and dropped before anything is staged. This is a *join* rule, not a column rule:
+an author key is harmless alone, but combined with `people.csv` it reconstructs who
+wrote what. See [`.claude/todo-pii-export-guard.md`](../../.claude/todo-pii-export-guard.md).
+
+**Pseudonyms: only with `--with-pseudonyms`.** Off by default. Writes `people.csv`
+(`person_key`, `pseudonym`) so a report can show which opinion group a pseudonym
+landed in and participants can find themselves. No username is exported in any mode,
+so the bundle cannot tie a pseudonym to a Wikimedia account on its own — but note that
+`people.csv` and `votes_latest.csv` share `person_key`, so a bundle exported this way
+does link a pseudonym to that person's individual votes.
+
+Statement text is included by default because the derivative analysis needs to compare
+a statement with its rewording. A bundle with text is participant-authored content:
+treat it as confidential and keep it out of anything public. `--no-text` on both
+exporters gives a purely structural bundle.

--- a/private/analysis/audit_bundle.py
+++ b/private/analysis/audit_bundle.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Audit a bundle for personal information — independently of the exporter.
+
+Deliberately does NOT import the exporter's own check. The exporter already passed
+its self-check on a bundle that reconstructed statement authorship through a join, so
+re-running that logic would only re-confirm the same blind spot. This walks the
+delivered files as a stranger would.
+
+    ./.venv/bin/python audit_bundle.py 2026-nlwiki-arbcom_bundle
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+# Columns that must never appear, whatever the manifest says.
+FORBIDDEN = {
+    'uid', 'xid', 'subject', 'mw_user_id', 'mw_username', 'public_username',
+    'revealed_at', 'email', 'hname', 'notify_email', 'notify_talk_page',
+    'eligibility_detail', 'ip', 'ip_address', 'referrer', 'parent_url',
+    'subscribe_email', 'owner', 'author_person_key', 'author_pid',
+    'proposer_person_key', 'proposer_pseudonym',
+}
+# Allowed only when the manifest says so, explicitly.
+CONDITIONAL = {'pseudonym'}
+
+EMAIL = re.compile(r'[\w.+-]+@[\w-]+\.[\w.]{2,}')
+HEX64 = re.compile(r'\b[0-9a-f]{64}\b')
+# A Wikimedia username in running text, e.g. [[User:Foo]] or @Foo
+USER_MARKUP = re.compile(r'\[\[\s*(?:User|Gebruiker)\s*:', re.I)
+
+PASS, FAIL, WARN = ' PASS ', ' FAIL ', ' WARN '
+
+
+def main() -> int:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else '.')
+    manifests = {p.stem.replace('manifest_', ''): json.loads(p.read_text())
+                 for p in sorted(root.glob('manifest_*.json'))}
+    allowed = set()
+    for m in manifests.values():
+        allowed |= {c.lower() for c in m.get('allowed_columns', [])}
+
+    print(f'auditing {root}')
+    print(f'  declared allowances: {sorted(allowed) or "none"}')
+    print(f'  salt ids: {[m["salt_id"] for m in manifests.values()]}')
+    print()
+
+    frames: dict[str, pd.DataFrame] = {}
+    for path in sorted(root.rglob('*.csv')):
+        frames[str(path.relative_to(root))] = pd.read_csv(path)
+
+    problems: list[str] = []
+
+    # ── 1. columns ───────────────────────────────────────────────────────────
+    print('1. columns present')
+    for name, df in frames.items():
+        bad = [c for c in df.columns if c.lower() in FORBIDDEN]
+        conditional = [c for c in df.columns if c.lower() in CONDITIONAL]
+        undeclared = [c for c in conditional if c.lower() not in allowed]
+        status = FAIL if (bad or undeclared) else PASS
+        print(f' {status} {name:<38} {len(df):>5} rows · {", ".join(df.columns)}')
+        for col in bad:
+            problems.append(f'{name}: forbidden column {col!r}')
+        for col in undeclared:
+            problems.append(f'{name}: {col!r} present but not declared in any manifest')
+
+    # ── 2. the join that leaked last time ────────────────────────────────────
+    print('\n2. re-identifying joins')
+    id_cols = {'person_key', 'pseudonym'}
+    carriers = {name: sorted(id_cols & set(df.columns))
+                for name, df in frames.items() if id_cols & set(df.columns)}
+    for name, cols in carriers.items():
+        print(f'      {name}: carries {", ".join(cols)}')
+
+    pseudonym_files = [n for n, c in carriers.items() if 'pseudonym' in c]
+    linkable = [n for n, c in carriers.items() if 'person_key' in c]
+
+    authorship = []
+    for name, df in frames.items():
+        lowered = {c.lower() for c in df.columns}
+        if lowered & {'author_person_key', 'proposer_person_key', 'author_pid'}:
+            authorship.append(name)
+    if authorship:
+        problems.append(f'authorship columns present in {authorship}')
+        print(f' {FAIL} statement/argument authorship is present: {authorship}')
+    else:
+        print(f' {PASS} no statement or argument authorship anywhere in the bundle')
+
+    if pseudonym_files and linkable:
+        others = [n for n in linkable if n not in pseudonym_files]
+        print(f' {WARN} pseudonyms in {pseudonym_files} share person_key with '
+              f'{len(others)} other file(s)')
+        print(f'        → a holder of this bundle can attach a pseudonym to that '
+              f"person's votes.")
+        print(f'        → they CANNOT attach it to a username (none exported) or to '
+              f'a statement (no authorship).')
+
+    # ── 3. value scan ────────────────────────────────────────────────────────
+    print('\n3. value scan across every cell')
+    hits = {'email': 0, 'hex64': 0, 'user markup': 0}
+    for name, df in frames.items():
+        for col in df.columns:
+            if df[col].dtype != object:
+                continue
+            for value in df[col].dropna().astype(str):
+                if EMAIL.search(value):
+                    hits['email'] += 1
+                    problems.append(f'{name}.{col}: email-shaped value')
+                if HEX64.search(value):
+                    hits['hex64'] += 1
+                    problems.append(f'{name}.{col}: 64-hex value (xid?)')
+                if USER_MARKUP.search(value):
+                    hits['user markup'] += 1
+                    problems.append(f'{name}.{col}: wiki user link in text')
+    for label, n in hits.items():
+        print(f' {FAIL if n else PASS} {label}: {n} occurrence(s)')
+
+    # ── 4. math_main ─────────────────────────────────────────────────────────
+    print('\n4. math_main payloads')
+    for path in sorted(root.rglob('math_main/*.json')):
+        payload = json.loads(path.read_text())
+        strings = [v for v in _leaves(payload) if isinstance(v, str)]
+        suspicious = [s for s in strings if EMAIL.search(s) or HEX64.search(s)]
+        print(f' {FAIL if suspicious else PASS} {path.name}: {len(strings)} string '
+              f'values, keys are {"numeric/structural" if not suspicious else "SUSPECT"}')
+        if suspicious:
+            problems.append(f'{path.name}: suspicious strings {suspicious[:3]}')
+
+    # ── 5. free text ─────────────────────────────────────────────────────────
+    print('\n5. free text (unavoidably participant-authored)')
+    for name, df in frames.items():
+        for col in ('txt', 'body', 'statement_text', 'title'):
+            if col in df.columns:
+                filled = int(df[col].notna().sum())
+                if filled:
+                    longest = df[col].dropna().astype(str).str.len().max()
+                    print(f'      {name}.{col}: {filled} values, longest {longest} chars')
+    print('      Statement text is the object of study and cannot be removed, but it is')
+    print('      participant-authored: treat the bundle as confidential, and re-read any')
+    print('      text before it is quoted publicly.')
+
+    # ── 6. named accounts ────────────────────────────────────────────────────
+    # Usernames are never exported as a column, but statement text is written by
+    # participants and can name people ("zoals X al zei"). Nothing structural
+    # prevents that, so it has to be looked for.
+    usernames = [u for u in sys.argv[2:] if not u.startswith('-')]
+    print('\n6. named accounts in any cell, including free text')
+    if not usernames:
+        print('      (none given — pass usernames as extra arguments to check them)')
+    for username in usernames:
+        needle = username.lower()
+        found = []
+        for name, df in frames.items():
+            for col in df.columns:
+                if df[col].dtype != object:
+                    continue
+                for i, value in df[col].dropna().astype(str).items():
+                    if needle in value.lower():
+                        found.append(f'{name}.{col} row {i}')
+        if found:
+            problems.append(f'username {username!r} appears in {found[:5]}')
+            print(f' {FAIL} {username}: {len(found)} occurrence(s) — {found[:3]}')
+        else:
+            print(f' {PASS} {username}: not present anywhere in the bundle')
+
+    # ── 7. pseudonyms leaking into other files ───────────────────────────────
+    print('\n7. pseudonyms appearing outside people.csv')
+    pseudonyms = set()
+    for name in pseudonym_files:
+        pseudonyms |= set(frames[name]['pseudonym'].dropna().astype(str))
+    leaked = []
+    for name, df in frames.items():
+        if name in pseudonym_files:
+            continue
+        for col in df.columns:
+            if df[col].dtype != object:
+                continue
+            for i, value in df[col].dropna().astype(str).items():
+                lowered = value.lower()
+                for pseudonym in pseudonyms:
+                    if len(pseudonym) > 4 and pseudonym.lower() in lowered:
+                        leaked.append(f'{name}.{col} row {i}: {pseudonym!r}')
+    if leaked:
+        problems.append(f'pseudonyms appear outside people.csv: {leaked[:3]}')
+        print(f' {FAIL} {len(leaked)} occurrence(s) — {leaked[:3]}')
+    else:
+        print(f' {PASS} none of the {len(pseudonyms)} pseudonyms appear in any other file')
+
+    print('\n' + '=' * 72)
+    if problems:
+        print(f'{len(problems)} PROBLEM(S):')
+        for p in problems[:25]:
+            print(f'  - {p}')
+        return 1
+    print('No personal information found. No usernames, no authorship, no raw identifiers.')
+    print('Residual, by design: pseudonym → that person\'s votes and opinion group.')
+    return 0
+
+
+def _leaves(node):
+    if isinstance(node, dict):
+        for v in node.values():
+            yield from _leaves(v)
+    elif isinstance(node, list):
+        for v in node:
+            yield from _leaves(v)
+    else:
+        yield node
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/private/analysis/build_notebook.py
+++ b/private/analysis/build_notebook.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""Regenerate wiki_polis_analysis.ipynb.
+
+The notebook is the deliverable; this builds it. Kept because the notebook is long
+and mostly prose — editing it as JSON by hand invites broken cells, and the prose is
+easier to review here.
+
+    ./.venv/bin/python build_notebook.py
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+NOTEBOOK = Path(__file__).with_name('wiki_polis_analysis.ipynb')
+PROVENANCE = Path(__file__).with_name('data_provenance.ipynb')
+
+
+def md(text: str) -> dict:
+    return {'cell_type': 'markdown', 'metadata': {},
+            'source': text.strip('\n').splitlines(keepends=True)}
+
+
+def code(text: str) -> dict:
+    return {'cell_type': 'code', 'metadata': {}, 'execution_count': None, 'outputs': [],
+            'source': text.strip('\n').splitlines(keepends=True)}
+
+
+PROVENANCE_CELLS = [
+    md('''
+# Where the data came from, and what was left out
+
+Companion to `wiki_polis_analysis.ipynb`. Nothing here is needed to read the
+findings — this is the audit trail: which queries pulled the data, what was
+deliberately excluded, and the checks that ran before any of it was analysed.
+'''),
+
+    md('''
+## Two databases
+
+wiki-polis splits its data by concern:
+
+| | Database | Holds |
+|---|---|---|
+| **App** | MariaDB on Toolforge | conversations, who joined, pseudonyms, and **statement provenance** — which statement was submitted as an improvement on which other |
+| **Polis** | PostgreSQL on the VPS | statements, every vote, and `math_main` — the clustering the Polis maths service computed |
+
+Neither is read directly. Two exporters run *on the servers* and write a
+de-identified bundle; only that bundle travels. The halves join on `person_key`, an
+HMAC of the participant's internal id under a salt that never leaves the server.
+
+The queries below are printed from the exporter modules, not copied, so what appears
+here is necessarily what ran.
+'''),
+
+    code('''
+import sys, textwrap
+sys.path.insert(0, '.')
+import export_polis_bundle as polis_export
+import export_app_bundle as app_export
+
+for name in ('Q_CONVERSATION', 'Q_COMMENTS', 'Q_VOTES_LATEST', 'Q_VOTES_HISTORY',
+             'Q_PARTICIPANTS', 'Q_IDENTITY', 'Q_MATH_MAIN'):
+    print(f'── {name} ' + '─' * (66 - len(name)))
+    print(textwrap.dedent(getattr(polis_export, name)).strip())
+    print()
+'''),
+
+    md('''
+Two notes.
+
+**`Q_VOTES_LATEST` reads `votes_latest_unique`, not `votes`.** Polis keeps `votes` as
+an append-only log — changing your mind inserts another row — and maintains
+`votes_latest_unique` as current state. Counting the log would count people twice.
+
+**`Q_IDENTITY` never reaches the bundle.** It maps each participant to the subject
+Particiapi knows them by; the exporter uses it in memory to derive `person_key` and
+discards it. Participants shown as `anon-…` have no such record and are deliberately
+*not* joinable rather than guessed at.
+
+`Q_COMMENTS` selects the author's `pid`, but the exporter drops it before writing. An
+author column is harmless alone; combined with the pseudonym table it would
+reconstruct who wrote what.
+'''),
+
+    code('''
+print('app-side columns written to the bundle:\\n')
+for name in ('CONVERSATION_COLUMNS', 'FEATURED_COLUMNS', 'PROVENANCE_COLUMNS',
+             'SIMILARITY_COLUMNS', 'PEOPLE_COLUMNS'):
+    print(f'  {name:<22} {", ".join(getattr(app_export, name))}')
+
+import bundle
+print('\\nnever exported in any mode:\\n')
+print(textwrap.fill(', '.join(sorted(bundle.DENIED_COLUMNS)), 78,
+                    initial_indent='  ', subsequent_indent='  '))
+'''),
+
+    md('''
+## Checks that ran before analysis
+
+These run identically on a synthetic test bundle, a local test conversation and real
+server data. A check that passes locally and fails here indicates a problem in the
+*data*, not in the analysis.
+
+The last one rebuilds "latest vote per person per statement" from the append-only log
+and compares it with the table Polis maintains for that purpose. Those can drift —
+the Polis schema ships a repair query for exactly this — and every vote count depends
+on them agreeing.
+'''),
+
+    code('''
+import warnings; warnings.filterwarnings('ignore')
+import pipeline as P
+
+b = P.load_bundles('2026-nlwiki-arbcom_bundle')
+for check in P.integrity_checks(b):
+    print(check)
+'''),
+
+    md('''
+## Personal information
+
+Audited independently of the exporter's own self-check — that check passed on an
+earlier bundle which reconstructed statement authorship through a join, so re-running
+it would only re-confirm the same blind spot.
+'''),
+
+    code('''
+!./.venv/bin/python audit_bundle.py 2026-nlwiki-arbcom_bundle effeietsanders ciell
+'''),
+]
+
+
+CELLS = [
+    md('''
+# nl.wikipedia arbitragecommissie — consultation analysis
+
+This notebook takes the raw votes and statements from a wiki-polis consultation and
+asks three questions:
+
+1. **Who actually took part?** The results page reports a single participant number.
+   That number is more ambiguous than it looks, and the groups shown alongside it are
+   drawn over a smaller set of people.
+2. **How much clustering is really there?** Polis always reports between two and five
+   opinion groups. It never reports "there are no groups". So a second, independent
+   method is needed to tell a real division from a tidy partition of noise.
+3. **Does phrasing change the answer?** Consultations accumulate near-duplicate
+   statements — one proposition in three wordings. For anyone choosing which phrasing
+   to put to a vote, the comparison between those variants *is* the decision.
+
+**How to read this.** Every section starts with plain prose saying what is being done
+and why. The code cells are thin: the work lives in `pipeline.py` and `methods.py`
+next to this file. Where a result is uncertain, the notebook says so rather than
+rounding it into a conclusion.
+
+No usernames were exported, and nothing here records who wrote which statement. For
+the export queries, the exclusions and the data checks, see the companion notebook
+`data_provenance.ipynb`.
+'''),
+
+    code('''
+import warnings; warnings.filterwarnings('ignore')
+import pandas as pd, numpy as np
+import pipeline as P, methods as M, report as R
+
+pd.set_option('display.width', 160)
+pd.set_option('display.max_colwidth', 70)
+
+BUNDLE = '2026-nlwiki-arbcom_bundle'   # ← the directory copied back from Toolforge
+CONV    = None                          # set below from the bundle itself
+
+b = P.load_bundles(BUNDLE)
+CONV = b.conversations[0]
+
+print(f'conversation : {CONV}')
+print(f'exported     : {b.manifest_polis["exported_at"]}  (env={b.manifest_polis["env"]})')
+print(f'salt id      : {b.manifest_polis["salt_id"]}  — matches across both halves')
+print(f'statement text included: {b.manifest_polis["with_text"]}')
+print(f'pseudonyms included    : {b.manifest_app.get("with_pseudonyms", False)}')
+for conv in b.manifest_polis['conversations']:
+    print(f'\\n  phase {conv["phase"]}: {conv["n_participants"]} participants, '
+          f'{conv["n_statements"]} statements, {conv["n_votes_latest"]:,} current votes, '
+          f'math_main={"yes" if conv["has_math_main"] else "MISSING"}')
+'''),
+
+    code('''
+checks = P.integrity_checks(b)
+failed = [c for c in checks if not c.passed]
+print(f'data checks: {len(checks) - len(failed)}/{len(checks)} passed'
+      + ('' if not failed else '  — see data_provenance.ipynb'))
+for check in failed:
+    print(' ', check)
+'''),
+
+    md('''
+## Who actually took part?
+
+The results page shows one number. It counts everyone with **at least one vote,
+passes included** — not everyone who joined, and not the people the clustering
+actually used.
+
+Polis only clusters participants who voted on at least `min(7, number of statements)`
+statements (topping up to 15 if too few qualify). Everyone below that line is present
+in the consultation but absent from the opinion groups. The funnel makes each step
+explicit.
+
+One step is missing and cannot be recovered: **how many people opened the page**.
+wiki-polis deliberately does not log passive page views, so "joined" is the earliest
+honest number.
+'''),
+
+    code('''
+funnel = P.participation_funnel(b, CONV)
+display(funnel)
+fig = R.plot_funnel(funnel)
+'''),
+
+    md('''
+## The opinion groups Polis found
+
+The headline result is **the server's own**, read straight out of `math_main` — the
+table the Polis math service writes. This notebook does not recompute it and does not
+substitute its own clustering for it.
+
+The map below is Polis's own geometry: the two-dimensional projection it computed,
+with each participant placed where Polis placed them.
+'''),
+
+    code('''
+server = P.server_labels(b, CONV, 2)
+if server['available']:
+    sizes = pd.Series(list(server['labels'].values())).value_counts().sort_index()
+    print(f'K = {server["K"]} opinion groups over {server["n_labelled"]} clustered participants')
+    for gid, n in sizes.items():
+        print(f'  group {gid + 1}: {n} participants')
+    print(f'\\nin-conv (met the vote threshold): {len(server["in_conv"])}')
+else:
+    print('no clustering available:', server['reason'])
+'''),
+
+    code('''
+fig = R.plot_opinion_map(b, CONV, server)
+'''),
+
+    md('''
+## Can we reproduce it?
+
+Before drawing any conclusion about *alternatives* to the server's clustering, we have
+to show we can reproduce the clustering itself. `polis_replica` is a line-by-line port
+of the Polis math service's own PCA and k-means code, pinned to a specific upstream
+commit. Running it on the same votes should return the same groups.
+
+If it does, the counterfactuals further down mean something. If it does not, this
+notebook reports the server's answer and stops — a model we cannot reproduce is not a
+model we can ask "what if" of.
+'''),
+
+    code('''
+gate = P.reproduction_gate(b, CONV, 2)
+print(f'reproduced : {"yes" if gate["passed"] else "NO — " + gate["reason"]}')
+print(f'  K         : server {gate["K_server"]}   replica {gate["K_replica"]}')
+print(f'  agreement : ARI {gate["ari"]:.3f} over {gate["n_common"]} participants '
+      f'(1.0 = identical grouping)')
+print(f'  matrix    : {gate["n_participants"]} people × {gate["n_statements"]} statements, '
+      f'{gate["density"]:.0%} filled')
+print(f'  in-conv   : {gate["n_in_conv"]}  →  the engine could have returned up to '
+      f'K={gate["max_k_allowed"]}')
+'''),
+
+    md('''
+That last line matters for reading K. The engine caps the number of groups at
+`min(5, 2 + in-conv ÷ 12)`. With very few participants that cap is 2 — and then
+"we found two groups" is a fact about the cap, not about the participants. The line
+above says which situation this consultation is in.
+'''),
+
+    md('''
+## How much clustering is really there?
+
+Polis partitions people into groups because that is what it is for. It does not report
+a confidence, and it has no way to say "these people don't really divide". So we ask a
+different method, built on a different principle, and see whether it recovers the same
+division.
+
+**Leiden community detection** works on a graph rather than a projection. Each
+participant is a node; two participants are linked when they voted the same way on the
+statements they both voted on. Passes are excluded — a pass is not an opinion — and
+pairs with too little overlap are not linked at all, because agreeing on two votes is
+not evidence of anything.
+
+Leiden's *resolution* parameter, not the data, decides how many communities come back.
+So a single run proves nothing. What is informative is the shape of the sweep: if the
+division is real, the number of communities should hold steady across a broad band of
+resolutions and agreement with Polis should be high across that band.
+'''),
+
+    code('''
+sweep = M.leiden_sweep(b, gate)
+print(f'graph: {sweep.attrs["n_nodes"]} people, {sweep.attrs["n_edges"]} links, '
+      f'median overlap {sweep.attrs["median_overlap"]:.0f} shared votes per pair\\n')
+display(sweep)
+'''),
+
+    md('''
+**Watch the median overlap.** In a consultation with many statements and modest
+turnout, two people may have voted on very few of the same statements, and then this
+whole graph rests on thin evidence. If that number is small, treat the Leiden result
+as a weak second opinion rather than a verdict, and lean on the reproduction gate
+above instead.
+'''),
+
+    code('''
+stability = M.cluster_stability(b, gate)
+if stability['available']:
+    print(f'{stability["n_runs"]} runs across resolutions and random seeds, '
+          f'{stability["n_people"]} people')
+    print(f'  pairs that land together (or apart) every single time: '
+          f'{stability["pairs_decided"]:.0%}')
+    print(f'  people sitting on a boundary between groups: {stability["n_on_boundary"]}')
+else:
+    print(stability['reason'])
+'''),
+
+    md('''
+The heatmap below is the visual form of that number. Every clustered participant
+appears on both axes; a cell is dark when those two people ended up in the same
+community in nearly every run, pale when they nearly never did.
+
+**Two solid dark blocks means the division is real** — the same people keep finding
+each other regardless of how the method is tuned. A washed-out or speckled square
+means the grouping is an artefact of the settings, and the two "opinion groups" should
+not be described as two camps.
+'''),
+
+    code('''
+fig = R.plot_stability_heatmap(stability, server)
+'''),
+
+    md('''
+## Where do people agree, and where do they split?
+
+Two different things get called "consensus", and they are worth separating:
+
+- **Broad agreement** — most people agree, and the opinion groups agree *with each
+  other*. These are the statements a proposal can safely build on.
+- **Division** — the groups disagree with each other. These are the real fault lines,
+  and they are what the consultation exists to surface.
+
+Each statement below is drawn once, showing how much each group agreed with it. The
+further apart the two marks, the more that statement divides the room.
+'''),
+
+    code('''
+divergence = R.statement_divergence(b, CONV, server)
+display(divergence.head(12))
+fig = R.plot_divergence(divergence)
+'''),
+
+    md('''
+## Near-duplicate statements — the head-to-head
+
+Participants can propose a rewording of an existing statement, and this consultation
+accumulated a good number of them. That creates sets of statements saying almost the
+same thing with one qualifier changed.
+
+This matters twice over:
+
+- **For the clustering**, near-duplicates are strongly correlated columns. A
+  proposition stated three ways carries three times the weight of one stated once, and
+  the axis it sits on gets pulled accordingly. That is a property of the wording, not
+  of what people think.
+- **For whoever writes the final text**, these are the actual decision. If one
+  phrasing draws noticeably more support than its near-twin, that is the phrasing to
+  put forward — and it is invisible on a results page that lists statements separately.
+
+Groups are formed two ways at once: statements a participant *declared* as an
+improvement on another (recorded at submission time), and statements the embedding
+model judges near-identical. Declared links are trusted outright; the model catches
+rewordings nobody flagged.
+'''),
+
+    code('''
+groups, pairs = M.similar_statement_groups(b, CONV, threshold=0.85)
+print(f'{len(groups)} near-duplicate group(s) found\\n')
+for g in groups:
+    print(f'group {g.group_id}: {len(g)} variants, {g.n_declared if hasattr(g, "n_declared") else len(g.declared_links)} declared as improvements')
+    for tid in g.tids:
+        print(f'   [{tid}] {g.texts[tid][:96]}')
+    print()
+'''),
+
+    md('''
+The similarity distribution is worth a look before trusting the threshold — it should
+show a clear gap between "same proposition, reworded" and "different proposition on a
+related topic". If there is no gap, the threshold is doing arbitrary work.
+'''),
+
+    code('''
+display(pairs.head(12)[['tid_a', 'tid_b', 'similarity', 'text_a', 'text_b']])
+fig = R.plot_similarity_distribution(pairs, threshold=0.85)
+'''),
+
+    code('''
+head_to_heads = [M.head_to_head(b, CONV, g) for g in groups]
+for h in head_to_heads:
+    print(f'══ group {h["group_id"]} ' + '═' * 60)
+    display(h['variants'])
+    if not h['comparisons'].empty:
+        display(h['comparisons'])
+'''),
+
+    md('''
+Read the **common voters** columns, not the raw agreement percentages. Different
+variants were submitted at different times, so they were seen by different numbers of
+people — comparing their overall agreement compares different populations. Restricting
+to people who voted on both makes each person their own control, and that comparison
+can carry a claim.
+'''),
+
+    code('''
+effect = M.wording_effect(head_to_heads)
+if effect['available']:
+    print(f'{effect["n_pairs_compared"]} variant pairs, '
+          f'{effect["n_discordant_votes"]} people voted differently on two wordings '
+          f'of the same proposition')
+    print(f'  median shift: {effect["median_abs_shift_pct_points"]} percentage points')
+    print(f'  largest shift: {effect["max_abs_shift_pct_points"]} percentage points')
+    print(f'  p = {effect["p_value"]}\\n')
+    print(effect['reading'])
+else:
+    print(effect['reason'])
+'''),
+
+    md('''
+## Which group did each pseudonym land in?
+
+Included so participants can find themselves. Pseudonyms only — no usernames are
+exported, and nothing here says who wrote which statement.
+
+Everyone who joined appears exactly once, including people the clustering did not
+place. Being unplaced is a normal outcome — it means fewer votes than the engine's
+threshold — not an omission.
+'''),
+
+    code('''
+roster = P.cluster_roster(b, CONV)
+if roster is None:
+    print('no pseudonyms in this bundle (exported without --with-pseudonyms)')
+else:
+    for placement, rows in roster.groupby('placement'):
+        print(f'{placement} — {len(rows)}')
+        print(textwrap.fill(', '.join(sorted(rows['pseudonym'])), 96,
+                            initial_indent='    ', subsequent_indent='    '))
+        print()
+'''),
+
+    md('''
+## What this analysis cannot tell you
+
+Stated plainly, because a report that only lists findings invites more weight than the
+data can carry.
+
+- **A consultation is not a poll.** Participants chose to take part. Nothing here
+  generalises to the wider community, no matter how clear a group split looks.
+- **Different people saw different statements.** Statements submitted later were seen
+  by fewer people. Agreement percentages across statements are therefore not directly
+  comparable, which is why the head-to-heads restrict to common voters.
+- **Group labels are not identities.** "Group 1" is a position on a set of statements
+  in this consultation, nothing more. The stability figure above says how firm even
+  that is.
+- **An inconclusive wording effect is not evidence that wording does not matter.** At
+  this number of participants, only a large effect would be detectable.
+'''),
+
+    md('''
+## Write the report
+
+Renders everything above as a single self-contained HTML file — no external files, no
+network — suitable for sharing with people who will not run this notebook.
+'''),
+
+    code('''
+path = R.write_report(
+    bundle=b, conv_key=CONV, checks=checks, funnel=funnel, server=server, gate=gate,
+    sweep=sweep, stability=stability, divergence=divergence, groups=groups,
+    pairs=pairs, head_to_heads=head_to_heads, effect=effect, roster=roster,
+    out='report_2026-nlwiki-arbcom.html')
+print(f'written: {path}')
+'''),
+]
+
+
+def main() -> int:
+    for path, cells in ((NOTEBOOK, CELLS), (PROVENANCE, PROVENANCE_CELLS)):
+        notebook = {
+            'cells': cells,
+            'metadata': {
+                'kernelspec': {'display_name': 'wiki-polis analysis',
+                               'language': 'python', 'name': 'wiki-polis-analysis'},
+                'language_info': {'name': 'python', 'pygments_lexer': 'ipython3'},
+            },
+            'nbformat': 4,
+            'nbformat_minor': 5,
+        }
+        path.write_text(json.dumps(notebook, indent=1) + '\n', encoding='utf-8')
+        n_md = sum(1 for c in cells if c['cell_type'] == 'markdown')
+        print(f'wrote {path.name}: {len(cells)} cells '
+              f'({n_md} markdown, {len(cells) - n_md} code)')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/private/analysis/build_reports.py
+++ b/private/analysis/build_reports.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Build both reports from a bundle. One command, so the numbers can be re-derived.
+
+    ./.venv/bin/python build_reports.py                       # default bundle
+    ./.venv/bin/python build_reports.py <bundle_dir> [--copy-to ~/Downloads]
+
+Every statistic it prints is documented in CALCULATIONS.md, with the function that
+computes it. Nothing here decides anything — it wires the analysis modules to the
+report writer and shows the headline numbers on the way past, so a wrong figure is
+visible in the terminal rather than only buried in 350 KB of HTML.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import shutil
+import sys
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+warnings.filterwarnings('ignore')
+
+import methods as M  # noqa: E402
+import pipeline as P  # noqa: E402
+import report as R  # noqa: E402
+
+DEFAULT_BUNDLE = '2026-nlwiki-arbcom_bundle'
+PERMUTATIONS = 100
+
+
+def deduplicated_matrix(base, matrix, redundant, eligible):
+    """Merge redundant statements into one column each, averaging a person's votes."""
+    mapping = M.deduplication_map(redundant, matrix.tids)
+    column = {t: j for j, t in enumerate(matrix.tids)}
+    merged: dict[int, list[int]] = {}
+    for tid in matrix.tids:
+        merged.setdefault(mapping[tid], []).append(column[tid])
+    keys = sorted(merged)
+    out = np.full((len(eligible), len(keys)), np.nan)
+    for j, key in enumerate(keys):
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            out[:, j] = np.nanmean(base[:, merged[key]], axis=1)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('bundle', nargs='?', default=DEFAULT_BUNDLE)
+    ap.add_argument('--copy-to', help='also copy both reports here')
+    ap.add_argument('--permutations', type=int, default=PERMUTATIONS)
+    args = ap.parse_args()
+
+    from analysis.polis_replica import run_replica
+    from sklearn.metrics import adjusted_rand_score
+
+    b = P.load_bundles(args.bundle)
+    conv = b.conversations[0]
+    print(f'{conv}: {len(b.phase("participants", conv, 2))} real participants, '
+          f'{len(b.phase("statements", conv, 2))} statements, '
+          f'{len(b.phase("votes_latest", conv, 2)):,} votes '
+          f'({len(b.machine.get((conv, 2), {}))} machine accounts excluded)')
+
+    checks = P.integrity_checks(b)
+    failed = [c for c in checks if not c.passed]
+    print(f'data checks: {len(checks) - len(failed)}/{len(checks)} passed')
+    for check in failed:
+        print(f'  {check}')
+
+    matrix = P.build_matrix(b, conv, 2)
+    counts = P.real_vote_counts(b, conv, 2)
+    eligible = [p for p in matrix.pids if counts.get(p, 0) >= P.POLIS_VOTE_THRESHOLD]
+    rows_idx = [i for i, p in enumerate(matrix.pids) if p in set(eligible)]
+    base = matrix.values[rows_idx, :]
+
+    groups, pairs = M.similar_statement_groups(b, conv)
+    redundant = M.redundant_pairs(b, conv, pairs)
+    dedup = deduplicated_matrix(base, matrix, redundant, eligible)
+    print(f'statements: {matrix.values.shape[1]} voted-on, {dedup.shape[1]} after '
+          f'merging {int(redundant["verdict"].str.startswith("redundant").sum())} '
+          f'redundant pairs')
+
+    # --- the two methods, scored the way each is meant to be scored ---------
+    def kmeans_score(values, _pids):
+        result = run_replica(values)
+        return result['silhouettes'].get(result['K'], float('nan'))
+
+    def leiden_score(values, pids):
+        holder = P.Matrix(conv_key=conv, phase=2, values=values, pids=pids,
+                          tids=list(range(values.shape[1])), person_keys=[])
+        graph_pids, weights, _ = M.agreement_graph(holder, min_overlap=3)
+        if (weights > 0).sum() == 0:
+            return float('nan')
+        return max(M.leiden_communities(graph_pids, weights, resolution=r)[1]
+                   for r in (0.8, 1.0, 1.2))
+
+    significance = []
+    for level, values in (('naive', base), ('deduplicated', dedup)):
+        for name, fn in (('k-means (silhouette)', kmeans_score),
+                         ('Leiden (modularity)', leiden_score)):
+            result = M.significance_of_grouping(values, eligible, fn,
+                                                n_permutations=args.permutations)
+            significance.append({
+                'level': level, 'method': name, 'real data': result['observed'],
+                'scrambled: typical': result['null_median'],
+                'scrambled: best 5%': result['null_95th'],
+                'p (permutation test)': result['p_value']})
+    significance = pd.DataFrame(significance)
+    print('\nsignificance:')
+    print(significance.to_string(index=False))
+
+    ladder = M.method_ladder(b, conv)['table']
+    print('\nrefinement ladder:')
+    print(ladder.to_string(index=False))
+
+    # --- head to head -------------------------------------------------------
+    replica = run_replica(base)
+    polis = {eligible[i]: int(x) for i, x in enumerate(replica['labels']) if x != -1}
+    graph_pids, weights, _ = M.agreement_graph(matrix, restrict_pids=eligible)
+    leiden, leiden_modularity = M.leiden_communities(graph_pids, weights, resolution=1.0)
+    shared = [p for p in graph_pids if p in polis]
+    crosstab = pd.crosstab(
+        pd.Series([polis[p] + 1 for p in shared], name='k-means group'),
+        pd.Series([leiden[p] + 1 for p in shared], name='Leiden community'))
+    comparison = {
+        'k_polis': replica['K'],
+        'sizes_polis': ' / '.join(str(v) for _, v in
+                                  sorted(collections.Counter(polis.values()).items())),
+        'k_leiden': len(set(leiden.values())),
+        'sizes_leiden': ' / '.join(str(v) for _, v in
+                                   sorted(collections.Counter(leiden.values()).items())),
+        'ari': adjusted_rand_score([polis[p] for p in shared],
+                                   [leiden[p] for p in shared]),
+        'crosstab_html': crosstab.to_html(border=0, classes='data'),
+        # Each method's own score for the partition in the row above it. Leiden's is
+        # the point of the section: at a fixed resolution it returns two communities
+        # like k-means does, but scores them below zero — worse than no split at all.
+        # Without the number beside it the row reads as a second method agreeing that
+        # there are two groups.
+        'silhouette_polis': replica['silhouettes'].get(replica['K'], float('nan')),
+        'modularity_leiden': leiden_modularity,
+        'n_analysed': len(eligible),
+    }
+    print(f'\nhead to head: k-means K={comparison["k_polis"]} '
+          f'(silhouette {comparison["silhouette_polis"]:.3f}) vs '
+          f'Leiden K={comparison["k_leiden"]} '
+          f'(modularity {comparison["modularity_leiden"]:.4f}), '
+          f'ARI {comparison["ari"]:.3f}')
+
+    sweep_rows = [{'resolution': r,
+                   'modularity': M.leiden_communities(graph_pids, weights, resolution=r)[1],
+                   'K_leiden': len(set(M.leiden_communities(graph_pids, weights,
+                                                            resolution=r)[0].values()))}
+                  for r in (0.4, 0.6, 0.8, 1.0, 1.2, 1.5, 2.0)]
+    figure = R.plot_method_comparison(b, conv, polis, leiden, pd.DataFrame(sweep_rows),
+                                      matrix, eligible)
+
+    server = P.server_labels(b, conv, 2)
+    gate = P.reproduction_gate(b, conv, 2)
+
+    # How far the rerun above lands from the tool's published grouping. It is not the
+    # reproduction check — that one feeds the replica the same population the server
+    # had and matches exactly (`gate`). This is the price of the two differences the
+    # report makes on purpose: machine accounts dropped, and only people over the vote
+    # threshold. Reported rather than glossed, because the two sets of group sizes both
+    # appear on the page.
+    shared_with_server = [p for p in polis if p in server.get('labels', {})]
+    comparison['ari_vs_server'] = (
+        adjusted_rand_score([server['labels'][p] for p in shared_with_server],
+                            [polis[p] for p in shared_with_server])
+        if len(shared_with_server) > 1 else float('nan'))
+    print(f'rerun vs published grouping: ARI {comparison["ari_vs_server"]:.3f} '
+          f'on {len(shared_with_server)} shared people '
+          f'(reproduction gate on the server\'s own population: ARI {gate["ari"]:.3f})')
+    head_to_heads = [M.head_to_head(b, conv, g) for g in groups]
+    families = M.statement_families(b, conv)
+
+    shared_kwargs = dict(
+        bundle=b, conv_key=conv, checks=checks,
+        funnel=P.participation_funnel(b, conv), server=server, gate=gate,
+        sweep=M.leiden_sweep(b, gate), stability=M.cluster_stability(b, gate),
+        divergence=R.statement_divergence(b, conv, server), groups=groups, pairs=pairs,
+        head_to_heads=head_to_heads, effect=M.wording_effect(head_to_heads),
+        roster=P.cluster_roster(b, conv),
+        participation=M.wording_participation(b, conv, groups), families=families,
+        generations=M.family_generations(families),
+        descendants=M.statement_descendants(b, conv),
+        representatives=M.family_representatives(b, conv, families),
+        redundant=redundant, comparison_figure=figure, method_comparison=comparison,
+        ladder=ladder, significance=significance)
+
+    print()
+    written = []
+    for audience, name in (('organiser', 'report_organiser.html'),
+                           ('participant', 'report_participant.html')):
+        path = R.write_report(audience=audience, out=name, **shared_kwargs)
+        written.append(path)
+        print(f'  {audience:12s} {path}  {path.stat().st_size:,} bytes')
+
+    if args.copy_to:
+        target = Path(args.copy_to).expanduser()
+        for path in written:
+            destination = target / f'wiki-polis_{conv}_{path.stem.split("_")[-1]}.html'
+            shutil.copy(path, destination)
+            print(f'  copied  {destination}')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/private/analysis/bundle.py
+++ b/private/analysis/bundle.py
@@ -1,0 +1,276 @@
+"""Shared plumbing for the wiki-polis analysis export bundles.
+
+Both exporters (`export_polis_bundle.py`, `export_app_bundle.py`) run ON a server
+holding real data and write a **de-identified bundle** that is the only thing allowed
+to travel. This module owns the three things they must agree on:
+
+  1. `person_key` — the salted pseudonym that lets the two bundles be joined without
+     either of them carrying `uid`, `xid`, `subject`, `pseudonym` or a username.
+  2. the manifest — including `salt_id`, so a salt mismatch between the two hosts
+     fails loudly in the notebook instead of silently producing an empty join.
+  3. the self-check — a denylist + content scan that refuses to write a bundle
+     containing anything from the never-export list.
+
+Stdlib only, so either exporter can be copied to a host and run on its own.
+"""
+from __future__ import annotations
+
+import base64
+import csv
+import datetime as _dt
+import hashlib
+import hmac
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SCHEMA_VERSION = 1
+
+# ── never-export list ────────────────────────────────────────────────────────
+# Column names that must not appear in any bundle file. Checked against the header
+# row of every CSV written, so an accidental `SELECT *` is caught at write time.
+DENIED_COLUMNS = {
+    'uid', 'xid', 'subject', 'mw_user_id', 'mw_username', 'pseudonym',
+    'proposer_pseudonym', 'public_username', 'revealed_at', 'email', 'hname',
+    'notify_email', 'notify_talk_page', 'eligibility_detail', 'owner',
+    'ip', 'ip_address', 'referrer', 'parent_url', 'subscribe_email',
+}
+
+_EMAIL_RE = re.compile(r'[\w.+-]+@[\w-]+\.[\w.]{2,}')
+# A wiki-polis xid is 64 hex chars (sha256 / HMAC-SHA256 hexdigest). If one ever
+# reaches a bundle we want to know, whatever column it arrived in.
+_XID_RE = re.compile(r'\b[0-9a-f]{64}\b')
+
+
+class SelfCheckError(RuntimeError):
+    """Raised when a bundle fails its PII self-check. Nothing is written."""
+
+
+def scan_value(value) -> list[str]:
+    """Return a list of self-check violations for one cell value."""
+    if not isinstance(value, str) or not value:
+        return []
+    problems = []
+    if _EMAIL_RE.search(value):
+        problems.append('looks like an email address')
+    if _XID_RE.search(value):
+        problems.append('looks like a 64-hex identifier (xid?)')
+    return problems
+
+
+# ── salt + person_key ────────────────────────────────────────────────────────
+
+def load_salt(path: str | os.PathLike) -> bytes:
+    """Read the shared export salt. Whitespace-stripped, so the same file gives the
+    same salt_id whether or not it ends in a newline."""
+    raw = Path(path).read_text(encoding='utf-8').strip()
+    if not raw:
+        raise ValueError(f'salt file {path} is empty')
+    if len(raw) < 32:
+        raise ValueError(
+            f'salt file {path} holds only {len(raw)} characters; generate it with '
+            '`openssl rand -hex 32`'
+        )
+    return raw.encode('utf-8')
+
+
+def salt_id(salt: bytes) -> str:
+    """Public fingerprint of the salt. Safe to put in a manifest — it does not
+    reveal the salt, but two bundles built with different salts will differ here."""
+    return hashlib.sha256(salt).hexdigest()[:8]
+
+
+def _key(salt: bytes, namespace: str, value: str) -> str:
+    dig = hmac.new(salt, f'{namespace}:{value}'.encode('utf-8'), hashlib.sha256).digest()
+    return base64.b32encode(dig[:10]).decode('ascii').rstrip('=').lower()
+
+
+def person_key(salt: bytes, subject: str) -> str:
+    """Stable pseudonym for a person, derived from the subject Polis knows them by.
+
+    That subject is *not* the xid. Since #246 wiki-polis asserts a conversation-scoped
+    value — `HMAC(PARTICIAPI_SUB_SECRET, f'{xid}:{conversation_id}')`, see
+    `v2/app.py::_conversation_subject` — and that is what lands in
+    `particiapi_users.subject`. The Polis exporter hashes it directly; the app exporter
+    must recompute it with `conversation_subject()` below before calling this.
+
+    Hashing the raw xid on the app side (as this did until the join was found empty)
+    produces keys in a disjoint space from the Polis side, so `people.csv` and
+    `votes_latest.csv` silently fail to join and every pseudonym-linked result is lost.
+    """
+    return _key(salt, 'u', subject)
+
+
+def conversation_subject(sub_secret: bytes, xid: str, conversation_id) -> str:
+    """Recompute the conversation-scoped subject wiki-polis asserts to Particiapi.
+
+    Byte-for-byte mirror of `v2/app.py::_conversation_subject` (#246). Kept here rather
+    than imported because the exporters run without the Flask app on the path.
+
+    The scoping is deliberate upstream: it stops the same person being linkable across
+    conversations. Recomputing it here preserves that property — the resulting
+    `person_key` is per-conversation, exactly as the Polis side already is.
+    """
+    return hmac.new(sub_secret, f'{xid}:{conversation_id}'.encode('utf-8'),
+                    hashlib.sha256).hexdigest()
+
+
+def secret_id(secret: bytes) -> str:
+    """Public fingerprint of the sub-secret, for the manifest. A rotated secret
+    produces subjects that never existed, and the join goes quiet rather than loud —
+    so record which one built the bundle."""
+    return hashlib.sha256(secret).hexdigest()[:8]
+
+
+def anon_key(salt: bytes, uid) -> str:
+    """Pseudonym for a Polis uid with no `particiapi_users` row — an anonymous
+    session, the conversation owner, or a pre-trusted-sub participant.
+
+    Deliberately *not* joinable to the app side: an unlinkable participant must
+    show up as an unlinked row, never as a silent false merge.
+    """
+    return 'anon-' + _key(salt, 'anon', str(uid))
+
+
+# ── bundle writer ────────────────────────────────────────────────────────────
+
+class BundleWriter:
+    """Collects CSV/JSON parts, self-checks them, then writes the bundle directory.
+
+    Nothing touches disk until `close()` succeeds, so a failed self-check cannot
+    leave a partial bundle lying around on a production host.
+    """
+
+    def __init__(self, out_dir, *, kind: str, env: str, salt: bytes,
+                 with_text: bool, allow_columns: set[str] | None = None,
+                 extra_manifest: dict | None = None):
+        self.out_dir = Path(out_dir)
+        self.kind = kind                 # 'polis' | 'app'
+        self.env = env                   # 'local' | 'staging' | 'prod'
+        self.salt_id = salt_id(salt)
+        self.with_text = with_text
+        # Columns deliberately lifted off the never-export list for this run. Only
+        # ever set from an explicit command-line flag, and recorded in the manifest
+        # so a bundle always says what it was allowed to carry.
+        self.allow_columns = {c.lower() for c in (allow_columns or set())}
+        self.extra = dict(extra_manifest or {})
+        self._csvs: dict[str, tuple[list[str], list[list]]] = {}
+        self._jsons: dict[str, object] = {}
+
+    def add_csv(self, name: str, columns: list[str], rows) -> None:
+        """Stage one CSV. `name` is relative to the bundle's kind directory."""
+        self._csvs[name] = (list(columns), [list(r) for r in rows])
+
+    def add_json(self, name: str, payload) -> None:
+        self._jsons[name] = payload
+
+    # ── self-check ───────────────────────────────────────────────────────────
+    def _check(self) -> dict:
+        violations: list[str] = []
+        scanned_cells = 0
+
+        for name, (columns, rows) in self._csvs.items():
+            for col in columns:
+                if col.lower() in DENIED_COLUMNS and col.lower() not in self.allow_columns:
+                    violations.append(f'{name}: column {col!r} is on the never-export list')
+            for row_no, row in enumerate(rows):
+                for col, value in zip(columns, row):
+                    scanned_cells += 1
+                    for problem in scan_value(value):
+                        violations.append(
+                            f'{name}: row {row_no + 1} column {col!r} {problem}'
+                        )
+                        break   # one report per cell is enough
+
+        for name, payload in self._jsons.items():
+            for path, leaf in _walk_json(payload):
+                if isinstance(leaf, str):
+                    scanned_cells += 1
+                    for problem in scan_value(leaf):
+                        violations.append(f'{name}: at {path} {problem}')
+                        break
+
+        if violations:
+            raise SelfCheckError(
+                'bundle self-check failed — nothing written:\n  '
+                + '\n  '.join(violations[:40])
+                + ('\n  …' if len(violations) > 40 else '')
+            )
+        return {'passed': True, 'cells_scanned': scanned_cells,
+                'denylist_size': len(DENIED_COLUMNS)}
+
+    def close(self) -> Path:
+        checks = self._check()          # raises before anything is written
+
+        base = self.out_dir / self.kind
+        base.mkdir(parents=True, exist_ok=True)
+
+        counts = {}
+        for name, (columns, rows) in self._csvs.items():
+            target = base / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with target.open('w', newline='', encoding='utf-8') as fh:
+                writer = csv.writer(fh)
+                writer.writerow(columns)
+                writer.writerows(rows)
+            counts[f'{self.kind}/{name}'] = len(rows)
+
+        for name, payload in self._jsons.items():
+            target = base / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(json.dumps(payload, indent=1, sort_keys=True,
+                                         default=str), encoding='utf-8')
+            counts[f'{self.kind}/{name}'] = 1
+
+        manifest = {
+            'schema_version': SCHEMA_VERSION,
+            'kind': self.kind,
+            'env': self.env,
+            'exported_at': _dt.datetime.now(_dt.timezone.utc).isoformat(timespec='seconds'),
+            'salt_id': self.salt_id,
+            'with_text': self.with_text,
+            'allowed_columns': sorted(self.allow_columns),
+            'git_sha': _git_sha(),
+            'python': sys.version.split()[0],
+            'counts': counts,
+            'checks': checks,
+            **self.extra,
+        }
+        manifest_path = self.out_dir / f'manifest_{self.kind}.json'
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps(manifest, indent=1, sort_keys=True),
+                                 encoding='utf-8')
+
+        _print_summary(self.kind, manifest, counts)
+        return self.out_dir
+
+
+def _walk_json(node, path='$'):
+    if isinstance(node, dict):
+        for key, value in node.items():
+            yield from _walk_json(value, f'{path}.{key}')
+    elif isinstance(node, list):
+        for i, value in enumerate(node):
+            yield from _walk_json(value, f'{path}[{i}]')
+    else:
+        yield path, node
+
+
+def _git_sha() -> str | None:
+    try:
+        out = subprocess.run(['git', 'rev-parse', '--short', 'HEAD'],
+                             capture_output=True, text=True, timeout=5)
+        return out.stdout.strip() or None
+    except Exception:
+        return None
+
+
+def _print_summary(kind: str, manifest: dict, counts: dict) -> None:
+    print(f'\n{kind} bundle written  (env={manifest["env"]}, '
+          f'salt_id={manifest["salt_id"]}, with_text={manifest["with_text"]})')
+    for name, n in sorted(counts.items()):
+        print(f'  {n:>8,}  {name}')
+    print(f'  self-check: passed ({manifest["checks"]["cells_scanned"]:,} cells scanned)')

--- a/private/analysis/data_provenance.ipynb
+++ b/private/analysis/data_provenance.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Where the data came from, and what was left out\n",
+    "\n",
+    "Companion to `wiki_polis_analysis.ipynb`. Nothing here is needed to read the\n",
+    "findings \u2014 this is the audit trail: which queries pulled the data, what was\n",
+    "deliberately excluded, and the checks that ran before any of it was analysed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Two databases\n",
+    "\n",
+    "wiki-polis splits its data by concern:\n",
+    "\n",
+    "| | Database | Holds |\n",
+    "|---|---|---|\n",
+    "| **App** | MariaDB on Toolforge | conversations, who joined, pseudonyms, and **statement provenance** \u2014 which statement was submitted as an improvement on which other |\n",
+    "| **Polis** | PostgreSQL on the VPS | statements, every vote, and `math_main` \u2014 the clustering the Polis maths service computed |\n",
+    "\n",
+    "Neither is read directly. Two exporters run *on the servers* and write a\n",
+    "de-identified bundle; only that bundle travels. The halves join on `person_key`, an\n",
+    "HMAC of the participant's internal id under a salt that never leaves the server.\n",
+    "\n",
+    "The queries below are printed from the exporter modules, not copied, so what appears\n",
+    "here is necessarily what ran."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import sys, textwrap\n",
+    "sys.path.insert(0, '.')\n",
+    "import export_polis_bundle as polis_export\n",
+    "import export_app_bundle as app_export\n",
+    "\n",
+    "for name in ('Q_CONVERSATION', 'Q_COMMENTS', 'Q_VOTES_LATEST', 'Q_VOTES_HISTORY',\n",
+    "             'Q_PARTICIPANTS', 'Q_IDENTITY', 'Q_MATH_MAIN'):\n",
+    "    print(f'\u2500\u2500 {name} ' + '\u2500' * (66 - len(name)))\n",
+    "    print(textwrap.dedent(getattr(polis_export, name)).strip())\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Two notes.\n",
+    "\n",
+    "**`Q_VOTES_LATEST` reads `votes_latest_unique`, not `votes`.** Polis keeps `votes` as\n",
+    "an append-only log \u2014 changing your mind inserts another row \u2014 and maintains\n",
+    "`votes_latest_unique` as current state. Counting the log would count people twice.\n",
+    "\n",
+    "**`Q_IDENTITY` never reaches the bundle.** It maps each participant to the subject\n",
+    "Particiapi knows them by; the exporter uses it in memory to derive `person_key` and\n",
+    "discards it. Participants shown as `anon-\u2026` have no such record and are deliberately\n",
+    "*not* joinable rather than guessed at.\n",
+    "\n",
+    "`Q_COMMENTS` selects the author's `pid`, but the exporter drops it before writing. An\n",
+    "author column is harmless alone; combined with the pseudonym table it would\n",
+    "reconstruct who wrote what."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "print('app-side columns written to the bundle:\\n')\n",
+    "for name in ('CONVERSATION_COLUMNS', 'FEATURED_COLUMNS', 'PROVENANCE_COLUMNS',\n",
+    "             'SIMILARITY_COLUMNS', 'PEOPLE_COLUMNS'):\n",
+    "    print(f'  {name:<22} {\", \".join(getattr(app_export, name))}')\n",
+    "\n",
+    "import bundle\n",
+    "print('\\nnever exported in any mode:\\n')\n",
+    "print(textwrap.fill(', '.join(sorted(bundle.DENIED_COLUMNS)), 78,\n",
+    "                    initial_indent='  ', subsequent_indent='  '))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Checks that ran before analysis\n",
+    "\n",
+    "These run identically on a synthetic test bundle, a local test conversation and real\n",
+    "server data. A check that passes locally and fails here indicates a problem in the\n",
+    "*data*, not in the analysis.\n",
+    "\n",
+    "The last one rebuilds \"latest vote per person per statement\" from the append-only log\n",
+    "and compares it with the table Polis maintains for that purpose. Those can drift \u2014\n",
+    "the Polis schema ships a repair query for exactly this \u2014 and every vote count depends\n",
+    "on them agreeing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import warnings; warnings.filterwarnings('ignore')\n",
+    "import pipeline as P\n",
+    "\n",
+    "b = P.load_bundles('2026-nlwiki-arbcom_bundle')\n",
+    "for check in P.integrity_checks(b):\n",
+    "    print(check)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Personal information\n",
+    "\n",
+    "Audited independently of the exporter's own self-check \u2014 that check passed on an\n",
+    "earlier bundle which reconstructed statement authorship through a join, so re-running\n",
+    "it would only re-confirm the same blind spot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!./.venv/bin/python audit_bundle.py 2026-nlwiki-arbcom_bundle effeietsanders ciell"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "wiki-polis analysis",
+   "language": "python",
+   "name": "wiki-polis-analysis"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/private/analysis/export_app_bundle.py
+++ b/private/analysis/export_app_bundle.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+"""Export the de-identified wiki-polis app-database half of an analysis bundle.
+
+RUNS ON THE HOST THAT HOLDS THE APP DATABASE (Toolforge for prod/staging, or the
+local SQLite file in dev). Read-only: every statement is a SELECT.
+
+What leaves: conversation settings and phase flags, the featured-statement bridge
+between the Phase 2 and Phase 6 Polis conversations, **statement provenance**
+(which statement was submitted as an improvement to which other statement) and its
+similarity scores, and optionally arguments — all keyed by a salted `person_key`.
+
+What never leaves: `mw_user_id`, `mw_username`, `xid`, `pseudonym`,
+`public_username`, `revealed_at`, invites, content flags, audit events,
+eligibility detail, notification preferences.
+
+Also writes `conversations.tsv` (slug / phase-2 zinvite / phase-6 zinvite), which
+is the input to export_polis_bundle.py — so run this exporter FIRST.
+
+Usage
+-----
+    python3 export_app_bundle.py \
+        --db-url "$DATABASE_URL" \
+        --slug cats-vs-dogs-ab12cd \
+        --salt-file ~/.wiki-polis-export-salt \
+        --env prod --out ./prod_2026-08-14
+"""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from bundle import (BundleWriter, SelfCheckError, conversation_subject,  # noqa: E402
+                    load_salt, person_key, secret_id)
+
+
+# ── database access ──────────────────────────────────────────────────────────
+
+class SqliteClient:
+    paramstyle = '?'
+
+    def __init__(self, path: str):
+        self._conn = sqlite3.connect(f'file:{path}?mode=ro', uri=True)
+        self._conn.row_factory = sqlite3.Row
+
+    def query(self, sql: str, params: tuple = ()) -> list[dict]:
+        cur = self._conn.execute(sql, params)
+        return [dict(row) for row in cur.fetchall()]
+
+
+class MySQLClient:
+    paramstyle = '%s'
+
+    def __init__(self, url: str):
+        import pymysql
+        parsed = urlparse(url)
+        self._conn = pymysql.connect(
+            host=parsed.hostname, port=parsed.port or 3306,
+            user=unquote(parsed.username or ''),
+            password=unquote(parsed.password or ''),
+            database=(parsed.path or '/').lstrip('/'),
+            cursorclass=pymysql.cursors.DictCursor,
+        )
+
+    def query(self, sql: str, params: tuple = ()) -> list[dict]:
+        with self._conn.cursor() as cur:
+            cur.execute(sql, params)
+            return [dict(row) for row in cur.fetchall()]
+
+
+def open_client(db_url: str):
+    """SQLAlchemy-style URL in, minimal driver out."""
+    if db_url.startswith('sqlite'):
+        path = db_url.split('///', 1)[1] if '///' in db_url else db_url
+        return SqliteClient(path)
+    if db_url.startswith(('mysql', 'mariadb')):
+        return MySQLClient(db_url)
+    raise ValueError(f'unsupported database URL: {db_url.split("://")[0]}://…')
+
+
+def placeholders(client, n: int) -> str:
+    return ', '.join([client.paramstyle] * n)
+
+
+# ── export ───────────────────────────────────────────────────────────────────
+
+CONVERSATION_COLUMNS = [
+    'conv_key', 'slug', 'polis_id', 'phase6_polis_conversation_id', 'title',
+    'language', 'access_policy', 'phase_route', 'active', 'paused',
+    'phase_submission', 'phase_personal_results', 'phase_argument_mapping',
+    'phase_cleanup', 'phase_public_results', 'phase_informed_voting',
+    'argument_vote_method', 'created_at', 'closed_at', 'n_participations',
+]
+
+FEATURED_COLUMNS = [
+    'conv_key', 'polis_statement_id', 'phase6_polis_statement_id',
+    'suggested_by_system', 'confirmed_by_admin', 'created_at', 'statement_text',
+]
+
+PROVENANCE_COLUMNS = [
+    'conv_key', 'polis_statement_id', 'derived_from_tid', 'provenance_type',
+    'link_method', 'created_at',
+]
+
+SIMILARITY_COLUMNS = ['conv_key', 'polis_statement_id', 'model', 'value', 'scored_at']
+
+# No proposer column, for the same reason statements carry no author: it would
+# reconstruct who wrote which argument. `is_seeded` distinguishes an admin-seeded
+# argument from a participant-written one, which is all the analysis needs.
+ARGUMENT_COLUMNS = [
+    'conv_key', 'argument_id', 'polis_statement_id', 'side', 'hidden',
+    'is_seeded', 'created_at', 'body',
+]
+
+ARGUMENT_VOTE_COLUMNS = ['conv_key', 'argument_id', 'person_key', 'value', 'created_at']
+
+# Only written with --with-pseudonyms. Lets a report say which opinion group a
+# pseudonym landed in, so a participant can find themselves in it.
+#
+# The pseudonym is already visible inside the app (it labels arguments), and this
+# file carries no username: `public_username` and `revealed_at` are never exported,
+# so the bundle cannot link a pseudonym to a Wikimedia account on its own. But a
+# participant who has *voluntarily revealed* their username in the app is linkable
+# by anyone who saw that reveal — for them, publishing pseudonym → opinion group
+# publishes account → opinion group. That is the organiser's call, not a default.
+PEOPLE_COLUMNS = ['conv_key', 'person_key', 'pseudonym']
+
+
+DEFAULT_SUB_SECRET_PATH = '/run/secrets/wiki-polis/particiapi-sub-secret'
+
+
+def load_sub_secret(path: str | None) -> bytes:
+    """The secret wiki-polis uses to derive each conversation-scoped subject.
+
+    Hard-fails rather than falling back to hashing the raw xid. That fallback is what
+    produced a bundle whose `people.csv` could not be joined to any vote at all — an
+    empty intersection that no self-check caught and that only surfaced when a report
+    tried to name which pseudonym sat in which group. An exporter that cannot key its
+    output correctly should stop, not emit rows that look fine and join to nothing.
+    """
+    import os
+
+    for candidate in (path, DEFAULT_SUB_SECRET_PATH):
+        if candidate and Path(candidate).exists():
+            raw = Path(candidate).read_text(encoding='utf-8').strip()
+            if raw:
+                return raw.encode('utf-8')
+            raise ValueError(f'sub-secret file {candidate} is empty')
+    env = os.environ.get('PARTICIAPI_SUB_SECRET', '').strip()
+    if env:
+        return env.encode('utf-8')
+    raise SystemExit(
+        'no PARTICIAPI_SUB_SECRET available.\n'
+        f'  Pass --sub-secret-file, place it at {DEFAULT_SUB_SECRET_PATH}, or set '
+        '$PARTICIAPI_SUB_SECRET.\n'
+        '  This must be the same secret the running app uses: person_key is derived '
+        'from HMAC(secret, "<xid>:<conversation_id>"), which is what Particiapi stores '
+        'as the subject. A different secret produces keys that join to nothing.')
+
+
+def _bool(value):
+    return None if value is None else bool(value)
+
+
+def export(client, salt, slugs, *, sub_secret: bytes, with_text: bool,
+           with_arguments: bool, with_pseudonyms: bool = False):
+    rows = {'conversations': [], 'featured_statements': [], 'statement_provenance': [],
+            'statement_similarity': [], 'arguments': [], 'argument_votes': [],
+            'people': []}
+    stats = []
+    tsv_lines = []
+
+    ph = placeholders(client, len(slugs))
+    convs = client.query(
+        f'SELECT * FROM conversations WHERE slug IN ({ph}) ORDER BY id', tuple(slugs))
+    found = {c['slug'] for c in convs}
+    missing = [s for s in slugs if s not in found]
+    if missing:
+        raise LookupError(f'no such conversation slug(s): {", ".join(missing)}')
+
+    # xid → person_key for everyone with a participation in these conversations.
+    # The xid is read only to derive the key and is never staged into the bundle.
+    conv_ids = [c['id'] for c in convs]
+    ph_ids = placeholders(client, len(conv_ids))
+    people = client.query(
+        f'''SELECT pt.id AS participant_id, pt.xid, pn.pseudonym, pn.conversation_id
+            FROM participations pn
+            JOIN participants pt ON pt.id = pn.participant_id
+            WHERE pn.conversation_id IN ({ph_ids})''', tuple(conv_ids))
+    # Keyed by (participant, conversation), not participant alone: the subject Polis
+    # stores is conversation-scoped, so one person in two conversations has two keys.
+    # The old participant-only dict also collapsed those two rows into one.
+    key_by_participant = {
+        (p['participant_id'], p['conversation_id']):
+            person_key(salt, conversation_subject(sub_secret, p['xid'],
+                                                  p['conversation_id']))
+        for p in people}
+
+    for conv in convs:
+        conv_key = conv['slug']
+        rows['conversations'].append([
+            conv_key, conv['slug'], conv['polis_id'],
+            conv['phase6_polis_conversation_id'], conv['title'], conv['language'],
+            conv['access_policy'], conv['phase_route'],
+            _bool(conv['active']), _bool(conv['paused']),
+            _bool(conv['phase_submission']), _bool(conv['phase_personal_results']),
+            _bool(conv['phase_argument_mapping']), _bool(conv['phase_cleanup']),
+            _bool(conv['phase_public_results']), _bool(conv['phase_informed_voting']),
+            conv['argument_vote_method'], conv['created_at'], conv['closed_at'],
+            # How many people joined — the first step of the participation funnel,
+            # and a different number from "people who voted at least once".
+            sum(1 for p in people if p['conversation_id'] == conv['id']),
+        ])
+        tsv_lines.append(
+            f"{conv['slug']}\t{conv['polis_id']}\t{conv['phase6_polis_conversation_id'] or ''}")
+
+        if with_pseudonyms:
+            for person in people:
+                if person['conversation_id'] == conv['id']:
+                    rows['people'].append([
+                        conv_key,
+                        key_by_participant[(person['participant_id'], conv['id'])],
+                        person['pseudonym'],
+                    ])
+
+        featured = client.query(
+            f'SELECT * FROM featured_statements WHERE conversation_id = {client.paramstyle} '
+            'ORDER BY polis_statement_id', (conv['id'],))
+        for fs in featured:
+            rows['featured_statements'].append([
+                conv_key, fs['polis_statement_id'], fs['phase6_polis_statement_id'],
+                _bool(fs['suggested_by_system']), _bool(fs['confirmed_by_admin']),
+                fs['created_at'], (fs['statement_text'] or '') if with_text else '',
+            ])
+
+        provenance = client.query(
+            f'SELECT * FROM statement_provenance WHERE conversation_id = {client.paramstyle} '
+            'ORDER BY polis_statement_id', (conv['id'],))
+        for pv in provenance:
+            rows['statement_provenance'].append([
+                conv_key, pv['polis_statement_id'], pv['derived_from_tid'],
+                pv['provenance_type'], pv['link_method'], pv['created_at'],
+            ])
+
+        if provenance:
+            prov_ids = [pv['id'] for pv in provenance]
+            tid_by_prov = {pv['id']: pv['polis_statement_id'] for pv in provenance}
+            ph_prov = placeholders(client, len(prov_ids))
+            scores = client.query(
+                f'SELECT * FROM statement_similarity_scores WHERE provenance_id IN ({ph_prov})',
+                tuple(prov_ids))
+            for sc in scores:
+                rows['statement_similarity'].append([
+                    conv_key, tid_by_prov[sc['provenance_id']], sc['model'],
+                    sc['value'], sc['scored_at'],
+                ])
+
+        n_arguments = 0
+        if with_arguments and featured:
+            fs_ids = [fs['id'] for fs in featured]
+            tid_by_fs = {fs['id']: fs['polis_statement_id'] for fs in featured}
+            ph_fs = placeholders(client, len(fs_ids))
+            arguments = client.query(
+                f'SELECT * FROM arguments WHERE featured_statement_id IN ({ph_fs}) ORDER BY id',
+                tuple(fs_ids))
+            n_arguments = len(arguments)
+            for arg in arguments:
+                # proposer_pseudonym is read only to tell seeded from participant-
+                # written; the identity itself is not exported.
+                rows['arguments'].append([
+                    conv_key, arg['id'], tid_by_fs[arg['featured_statement_id']],
+                    arg['side'], _bool(arg['hidden']),
+                    arg['proposer_pseudonym'] is None,
+                    arg['created_at'], (arg['body'] or '') if with_text else '',
+                ])
+            if arguments:
+                arg_ids = [a['id'] for a in arguments]
+                ph_args = placeholders(client, len(arg_ids))
+                votes = client.query(
+                    f'SELECT * FROM argument_votes WHERE argument_id IN ({ph_args})',
+                    tuple(arg_ids))
+                for av in votes:
+                    rows['argument_votes'].append([
+                        conv_key, av['argument_id'],
+                        key_by_participant.get((av['participant_id'], conv['id']), ''),
+                        av['value'], av['created_at'],
+                    ])
+
+        stats.append({
+            'conv_key': conv_key,
+            'phase2_zinvite': conv['polis_id'],
+            'phase6_zinvite': conv['phase6_polis_conversation_id'],
+            'n_participations': sum(1 for p in people if p['conversation_id'] == conv['id']),
+            'n_featured': len(featured),
+            'n_featured_confirmed': sum(1 for fs in featured if fs['confirmed_by_admin']),
+            'n_featured_bridged': sum(1 for fs in featured
+                                      if fs['phase6_polis_statement_id'] is not None),
+            'n_provenance': len(provenance),
+            'n_arguments': n_arguments,
+        })
+
+    return rows, stats, tsv_lines
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--out', required=True)
+    ap.add_argument('--salt-file', required=True)
+    ap.add_argument('--sub-secret-file',
+                    help='file holding PARTICIAPI_SUB_SECRET. Defaults to '
+                         '/run/secrets/wiki-polis/particiapi-sub-secret, then '
+                         '$PARTICIAPI_SUB_SECRET. Required: without it the '
+                         'person_key cannot be made to join the Polis half.')
+    ap.add_argument('--env', required=True, choices=('local', 'staging', 'prod'))
+    ap.add_argument('--db-url', required=True,
+                    help='sqlite:///path/to.db or mysql://user:pass@host/db')
+    ap.add_argument('--slug', action='append', default=[], help='repeatable')
+    ap.add_argument('--all', action='store_true', help='every conversation in the database')
+    ap.add_argument('--all-closed', action='store_true', help='every closed conversation')
+    ap.add_argument('--with-arguments', action='store_true',
+                    help='also export arguments and argument votes')
+    ap.add_argument('--with-pseudonyms', action='store_true',
+                    help='export the pseudonym for each person, so a report can show '
+                         'which opinion group a pseudonym landed in and participants '
+                         'can find themselves. Off by default: for anyone who has '
+                         'voluntarily revealed their username in the app, this makes '
+                         'their opinion group publicly attributable.')
+    ap.add_argument('--no-text', dest='with_text', action='store_false',
+                    help='omit statement text and argument bodies')
+    ap.set_defaults(with_text=True)
+    args = ap.parse_args()
+
+    client = open_client(args.db_url)
+    slugs = list(args.slug)
+    if args.all or args.all_closed:
+        where = 'WHERE closed_at IS NOT NULL' if args.all_closed else ''
+        slugs += [r['slug'] for r in client.query(f'SELECT slug FROM conversations {where}')]
+    slugs = sorted(set(slugs))
+    if not slugs:
+        ap.error('no conversations selected (--slug / --all / --all-closed)')
+
+    salt = load_salt(args.salt_file)
+    sub_secret = load_sub_secret(args.sub_secret_file)
+    rows, stats, tsv_lines = export(client, salt, slugs, sub_secret=sub_secret,
+                                    with_text=args.with_text,
+                                    with_arguments=args.with_arguments,
+                                    with_pseudonyms=args.with_pseudonyms)
+
+    writer = BundleWriter(args.out, kind='app', env=args.env, salt=salt,
+                          with_text=args.with_text,
+                          allow_columns={'pseudonym'} if args.with_pseudonyms else None,
+                          extra_manifest={'conversations': stats,
+                                          'with_arguments': args.with_arguments,
+                                          'with_pseudonyms': args.with_pseudonyms,
+                                          # So a rotated secret is visible rather
+                                          # than silently unjoinable.
+                                          'sub_secret_id': secret_id(sub_secret)})
+    writer.add_csv('conversations.csv', CONVERSATION_COLUMNS, rows['conversations'])
+    writer.add_csv('featured_statements.csv', FEATURED_COLUMNS, rows['featured_statements'])
+    writer.add_csv('statement_provenance.csv', PROVENANCE_COLUMNS, rows['statement_provenance'])
+    writer.add_csv('statement_similarity.csv', SIMILARITY_COLUMNS, rows['statement_similarity'])
+    if args.with_arguments:
+        writer.add_csv('arguments.csv', ARGUMENT_COLUMNS, rows['arguments'])
+        writer.add_csv('argument_votes.csv', ARGUMENT_VOTE_COLUMNS, rows['argument_votes'])
+    if args.with_pseudonyms:
+        writer.add_csv('people.csv', PEOPLE_COLUMNS, rows['people'])
+
+    try:
+        writer.close()
+    except SelfCheckError as exc:
+        print(f'\nABORTED: {exc}', file=sys.stderr)
+        return 2
+
+    tsv_path = Path(args.out) / 'conversations.tsv'
+    tsv_path.write_text('\n'.join(tsv_lines) + '\n', encoding='utf-8')
+    print(f'\n  wrote {tsv_path} — pass it to export_polis_bundle.py --conversations')
+
+    for s in stats:
+        phase6 = s['phase6_zinvite'] or 'none'
+        print(f"  {s['conv_key']}: phase2={s['phase2_zinvite']} phase6={phase6}, "
+              f"{s['n_featured_confirmed']}/{s['n_featured']} featured confirmed, "
+              f"{s['n_featured_bridged']} bridged to phase 6, "
+              f"{s['n_provenance']} provenance link(s)")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/private/analysis/export_polis_bundle.py
+++ b/private/analysis/export_polis_bundle.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Export the de-identified Polis half of an analysis bundle.
+
+RUNS ON THE HOST THAT HOLDS THE POLIS DATABASE (the VPS, or the local dev stack).
+Read-only: every statement is a SELECT.
+
+What leaves: votes, statements, per-conversation pids, and the server's own
+clustering output (`math_main.data`), keyed by a salted `person_key`.
+What never leaves: `uid`, `particiapi_users.subject` (= the xid), the Polis
+`users` table, anything from `participants_extended`.
+
+Two ways to reach the database, in order of preference:
+
+  --db-url postgresql://user:pass@host/db     (needs psycopg2 on the host)
+  --psql-cmd 'docker exec -i <container> psql -U polis polis'
+                                              (needs nothing but docker)
+
+Usage
+-----
+    python3 export_polis_bundle.py \
+        --conversations conversations.tsv \
+        --salt-file ~/.wiki-polis-export-salt \
+        --env prod --out ./prod_2026-08-14 \
+        --db-url "$POLIS_DATABASE_URL"
+
+`conversations.tsv` is written by export_app_bundle.py and holds one row per
+conversation:  slug <TAB> phase2_zinvite <TAB> phase6_zinvite_or_blank
+Run the app exporter first, or pass --conversation slug:phase2[:phase6] instead.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from bundle import BundleWriter, SelfCheckError, anon_key, load_salt, person_key  # noqa: E402
+
+SAFE_ZINVITE = re.compile(r'^[a-zA-Z0-9]{1,50}$')
+
+
+# ── database access ──────────────────────────────────────────────────────────
+
+class PsqlClient:
+    """Runs queries through a `psql` command line. No Python driver needed, which
+    is what makes this usable on a VPS that only has docker."""
+
+    def __init__(self, cmd: str):
+        self.cmd = cmd
+
+    def query(self, sql: str, params: tuple = ()) -> list[dict]:
+        # \copy is a psql meta-command and must sit on a single line, so the
+        # statement's own newlines are collapsed first.
+        statement = ' '.join(_inline_params(sql, params).split()).rstrip(';')
+        proc = subprocess.run(
+            self.cmd, shell=True,
+            input=f'\\copy ({statement}) TO STDOUT WITH CSV HEADER\n',
+            capture_output=True, text=True,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(f'psql failed: {proc.stderr.strip()[:500]}')
+        reader = csv.DictReader(io.StringIO(proc.stdout))
+        return [dict(row) for row in reader]
+
+
+class Psycopg2Client:
+    def __init__(self, db_url: str):
+        import psycopg2
+        import psycopg2.extras
+        self._conn = psycopg2.connect(db_url)
+        self._conn.set_session(readonly=True, autocommit=True)
+        self._extras = psycopg2.extras
+
+    def query(self, sql: str, params: tuple = ()) -> list[dict]:
+        with self._conn.cursor(cursor_factory=self._extras.RealDictCursor) as cur:
+            cur.execute(sql, params)
+            return [dict(row) for row in cur.fetchall()]
+
+
+def _inline_params(sql: str, params: tuple) -> str:
+    """Substitute %s placeholders for the psql path.
+
+    Only ever called with values this script controls — zinvites already matched
+    against SAFE_ZINVITE, and integers. Anything else is refused rather than quoted,
+    because a half-safe quoting routine is worse than none.
+    """
+    out = sql
+    for value in params:
+        if isinstance(value, int):
+            literal = str(value)
+        elif isinstance(value, str) and SAFE_ZINVITE.match(value):
+            literal = f"'{value}'"
+        else:
+            raise ValueError(f'refusing to inline unsafe parameter {value!r}')
+        out = out.replace('%s', literal, 1)
+    return out
+
+
+# ── SQL ──────────────────────────────────────────────────────────────────────
+
+Q_CONVERSATION = """
+    SELECT c.zid, c.is_active, c.is_public, c.strict_moderation, c.vis_type, c.created
+    FROM conversations c
+    WHERE c.zid = (SELECT zid FROM zinvites WHERE zinvite = %s)
+"""
+
+Q_COMMENTS = """
+    SELECT c.tid, c.pid, c.txt, c.mod, c.active, c.is_seed, c.lang, c.created
+    FROM comments c
+    WHERE c.zid = (SELECT zid FROM zinvites WHERE zinvite = %s)
+    ORDER BY c.tid
+"""
+
+Q_VOTES_LATEST = """
+    SELECT v.pid, v.tid, v.vote, v.modified
+    FROM votes_latest_unique v
+    WHERE v.zid = (SELECT zid FROM zinvites WHERE zinvite = %s)
+    ORDER BY v.pid, v.tid
+"""
+
+Q_VOTES_HISTORY = """
+    SELECT v.pid, v.tid, v.vote, v.created
+    FROM votes v
+    WHERE v.zid = (SELECT zid FROM zinvites WHERE zinvite = %s)
+    ORDER BY v.created, v.pid, v.tid
+"""
+
+Q_PARTICIPANTS = """
+    SELECT p.pid, p.uid, p.vote_count, p.last_interaction
+    FROM participants p
+    WHERE p.zid = (SELECT zid FROM zinvites WHERE zinvite = %s)
+    ORDER BY p.pid
+"""
+
+# Identity map. Consumed in memory to build person_keys and then dropped —
+# neither uid nor subject is ever staged into the bundle.
+Q_IDENTITY = """
+    SELECT p.pid, pu.subject
+    FROM participants p
+    JOIN particiapi_users pu ON pu.uid = p.uid
+    WHERE p.zid = (SELECT zid FROM zinvites WHERE zinvite = %s)
+"""
+
+Q_MATH_MAIN = """
+    SELECT m.math_env, m.data, m.last_vote_timestamp, m.math_tick, m.modified
+    FROM math_main m
+    WHERE m.zid = (SELECT zid FROM zinvites WHERE zinvite = %s)
+"""
+
+
+# ── export ───────────────────────────────────────────────────────────────────
+
+def _as_int(value):
+    return None if value in (None, '') else int(value)
+
+
+def _as_bool(value):
+    if isinstance(value, bool) or value is None:
+        return value
+    return str(value).lower() in ('t', 'true', '1', 'y')
+
+
+def export_conversation(client, writer_rows, salt, conv_key, phase, zinvite,
+                        with_text: bool) -> dict:
+    """Pull one Polis conversation into the staged row lists. Returns a stats dict."""
+    if not SAFE_ZINVITE.match(zinvite or ''):
+        raise ValueError(f'unsafe zinvite {zinvite!r}')
+
+    conv_rows = client.query(Q_CONVERSATION, (zinvite,))
+    if not conv_rows:
+        raise LookupError(f'no Polis conversation for zinvite {zinvite}')
+    conv = conv_rows[0]
+
+    identity = {int(r['pid']): r['subject']
+                for r in client.query(Q_IDENTITY, (zinvite,)) if r.get('subject')}
+    participants = client.query(Q_PARTICIPANTS, (zinvite,))
+
+    keys: dict[int, str] = {}
+    for row in participants:
+        pid = int(row['pid'])
+        subject = identity.get(pid)
+        keys[pid] = person_key(salt, subject) if subject else anon_key(salt, row['uid'])
+    linked = sum(1 for pid in keys if pid in identity)
+
+    writer_rows['conversations'].append([
+        conv_key, phase, zinvite,
+        _as_bool(conv['is_active']), _as_bool(conv['is_public']),
+        _as_bool(conv['strict_moderation']), _as_int(conv['vis_type']),
+        _as_int(conv['created']),
+    ])
+
+    for row in participants:
+        pid = int(row['pid'])
+        writer_rows['participants'].append([
+            conv_key, phase, keys[pid], pid,
+            _as_int(row['vote_count']), _as_int(row['last_interaction']),
+            pid in identity,
+        ])
+
+    comments = client.query(Q_COMMENTS, (zinvite,))
+    for row in comments:
+        # `pid` is read but deliberately dropped: statement authorship is not exported.
+        writer_rows['statements'].append([
+            conv_key, phase, _as_int(row['tid']),
+            _as_bool(row['is_seed']),
+            _as_int(row['mod']), _as_bool(row['active']),
+            _as_int(row['created']), row['lang'] or '',
+            (row['txt'] or '') if with_text else '',
+        ])
+
+    votes = client.query(Q_VOTES_LATEST, (zinvite,))
+    for row in votes:
+        pid = int(row['pid'])
+        writer_rows['votes_latest'].append([
+            conv_key, phase, keys.get(pid, anon_key(salt, f'orphan-{pid}')), pid,
+            _as_int(row['tid']), _as_int(row['vote']), _as_int(row['modified']),
+        ])
+
+    history = client.query(Q_VOTES_HISTORY, (zinvite,))
+    for row in history:
+        pid = int(row['pid'])
+        writer_rows['votes_history'].append([
+            conv_key, phase, keys.get(pid, anon_key(salt, f'orphan-{pid}')), pid,
+            _as_int(row['tid']), _as_int(row['vote']), _as_int(row['created']),
+        ])
+
+    math_rows = client.query(Q_MATH_MAIN, (zinvite,))
+    math_payload = None
+    for row in math_rows:
+        data = row['data']
+        if isinstance(data, str):
+            data = json.loads(data)
+        math_payload = {
+            'conv_key': conv_key, 'phase': phase, 'zinvite': zinvite,
+            'math_env': row['math_env'],
+            'last_vote_timestamp': _as_int(row['last_vote_timestamp']),
+            'math_tick': _as_int(row['math_tick']),
+            'modified': _as_int(row['modified']),
+            'data': data,
+        }
+        writer_rows['math'][f'math_main/{conv_key}_phase{phase}.json'] = math_payload
+
+    return {
+        'conv_key': conv_key, 'phase': phase, 'zinvite': zinvite,
+        'n_participants': len(participants), 'n_identity_linked': linked,
+        'n_statements': len(comments), 'n_votes_latest': len(votes),
+        'n_votes_history': len(history), 'has_math_main': math_payload is not None,
+    }
+
+
+COLUMNS = {
+    'conversations': ['conv_key', 'phase', 'zinvite', 'is_active', 'is_public',
+                      'strict_moderation', 'vis_type', 'created_ms'],
+    'participants': ['conv_key', 'phase', 'person_key', 'pid', 'vote_count',
+                     'last_interaction_ms', 'identity_linked'],
+    # No author column, by design. A per-statement author key plus people.csv would
+    # reconstruct who wrote what; `is_seed` (moderator-seeded vs participant-submitted)
+    # is the only authorship fact the analysis needs.
+    'statements': ['conv_key', 'phase', 'tid', 'is_seed', 'mod',
+                   'active', 'created_ms', 'lang', 'txt'],
+    'votes_latest': ['conv_key', 'phase', 'person_key', 'pid', 'tid', 'vote',
+                     'modified_ms'],
+    'votes_history': ['conv_key', 'phase', 'person_key', 'pid', 'tid', 'vote',
+                      'created_ms'],
+}
+
+
+def read_conversations_tsv(path) -> list[tuple[str, str, str | None]]:
+    out = []
+    for line in Path(path).read_text(encoding='utf-8').splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        parts = line.split('\t')
+        slug, phase2 = parts[0], parts[1]
+        phase6 = parts[2] if len(parts) > 2 and parts[2] else None
+        out.append((slug, phase2, phase6))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--out', required=True, help='bundle directory to create')
+    ap.add_argument('--salt-file', required=True)
+    ap.add_argument('--env', required=True, choices=('local', 'staging', 'prod'))
+    ap.add_argument('--db-url', help='postgres URL (needs psycopg2)')
+    ap.add_argument('--psql-cmd',
+                    help="e.g. 'docker exec -i particiapp-docker-postgres-1 psql -U polis polis'")
+    ap.add_argument('--conversations', help='TSV from export_app_bundle.py')
+    ap.add_argument('--conversation', action='append', default=[],
+                    metavar='SLUG:PHASE2[:PHASE6]',
+                    help='inline conversation spec; repeatable')
+    ap.add_argument('--no-text', dest='with_text', action='store_false',
+                    help='omit statement text from the bundle')
+    ap.set_defaults(with_text=True)
+    args = ap.parse_args()
+
+    if not args.db_url and not args.psql_cmd:
+        ap.error('one of --db-url or --psql-cmd is required')
+
+    convs: list[tuple[str, str, str | None]] = []
+    if args.conversations:
+        convs += read_conversations_tsv(args.conversations)
+    for spec in args.conversation:
+        parts = spec.split(':')
+        convs.append((parts[0], parts[1], parts[2] if len(parts) > 2 and parts[2] else None))
+    if not convs:
+        ap.error('no conversations given (--conversations or --conversation)')
+
+    salt = load_salt(args.salt_file)
+    client = Psycopg2Client(args.db_url) if args.db_url else PsqlClient(args.psql_cmd)
+
+    rows = {name: [] for name in COLUMNS}
+    rows['math'] = {}
+    stats = []
+    for slug, phase2, phase6 in convs:
+        stats.append(export_conversation(client, rows, salt, slug, 2, phase2, args.with_text))
+        if phase6:
+            stats.append(export_conversation(client, rows, salt, slug, 6, phase6, args.with_text))
+
+    writer = BundleWriter(args.out, kind='polis', env=args.env, salt=salt,
+                          with_text=args.with_text,
+                          extra_manifest={'conversations': stats})
+    for name, columns in COLUMNS.items():
+        writer.add_csv(f'{name}.csv', columns, rows[name])
+    for name, payload in rows['math'].items():
+        writer.add_json(name, payload)
+
+    try:
+        writer.close()
+    except SelfCheckError as exc:
+        print(f'\nABORTED: {exc}', file=sys.stderr)
+        return 2
+
+    for s in stats:
+        unlinked = s['n_participants'] - s['n_identity_linked']
+        note = f", {unlinked} without a particiapi_users row" if unlinked else ''
+        print(f"  {s['conv_key']} phase {s['phase']}: {s['n_participants']} participants{note}, "
+              f"{s['n_statements']} statements, {s['n_votes_latest']} current votes, "
+              f"math_main={'yes' if s['has_math_main'] else 'MISSING'}")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/private/analysis/make_report_pdf.py
+++ b/private/analysis/make_report_pdf.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Render a consultation report HTML to a print-ready PDF.
+
+Two things the browser-printed version does not do:
+
+  * Drops the faint warm background (`--surface: #fcfcfb`) to true white. On
+    screen it reads as paper; in print it reads as a scanning artefact, and it
+    costs ink on every page.
+  * Puts a running header on *every* page naming the product, the round, the
+    consultation and the URL it came from. A PDF gets separated from its
+    context the moment someone downloads it — page 14 on its own should still
+    say what it is and where it came from.
+
+WeasyPrint rather than headless Chrome: Chrome emits no `@page` margin boxes
+(so no running header), and its Skia PDF writer produced files Acrobat would
+not open — the participant report came out with zero embedded font resources.
+
+Usage:
+    ./make_report_pdf.py report_participant.html out.pdf \
+        --round 1 --process "nl.wikipedia arbitragecommissie" \
+        --url wiki-polis.toolforge.org/c/2026-nlwiki-arbcom
+"""
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+FONT_DIR = Path(__file__).resolve().parents[2] / "v2" / "static" / "fonts"
+
+# Inter Tight and JetBrains Mono, both SIL Open Font License, both already
+# self-hosted by the product. An embedded font ships inside the PDF, so for a
+# Commons upload it has to be one that may be freely redistributed — which
+# rules out the system UI faces the screen stylesheet falls back to.
+FONT_CSS = """
+@font-face {{
+    font-family: 'Inter Tight PDF';
+    font-style: normal;
+    font-weight: 400 700;
+    src: url('file://{font_dir}/inter-tight-latin.woff2') format('woff2');
+}}
+@font-face {{
+    font-family: 'Inter Tight PDF';
+    font-style: normal;
+    font-weight: 400 700;
+    src: url('file://{font_dir}/inter-tight-latin-ext.woff2') format('woff2');
+    unicode-range: U+0100-02BA, U+1E00-1EFF, U+2020, U+20A0-20AB, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}}
+@font-face {{
+    font-family: 'JetBrains Mono PDF';
+    font-style: normal;
+    font-weight: 400 700;
+    src: url('file://{font_dir}/jetbrains-mono-latin.woff2') format('woff2');
+}}
+"""
+
+# Inter Tight's latin subset stops at U+206F, so a maths operator like "≥"
+# (U+2265, used in the participation table) falls through to whatever the system
+# offers — Verdana here, which is proprietary and would then be embedded in the
+# PDF. DejaVu Sans covers the range and is freely licensed, so it is used as the
+# fallback when present. Not fatal if absent: the document still renders, just
+# with a system face for those few glyphs.
+DEJAVU_CANDIDATES = (
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    "/opt/homebrew/share/fonts/DejaVuSans.ttf",
+    "/usr/local/share/fonts/DejaVuSans.ttf",
+    "/Library/Fonts/DejaVuSans.ttf",
+)
+
+FALLBACK_CSS = """
+@font-face {{
+    font-family: 'Fallback PDF';
+    src: url('file://{path}');
+}}
+"""
+
+
+def find_fallback() -> Path | None:
+    """First freely-licensed font on disk that covers the maths operators."""
+    for candidate in DEJAVU_CANDIDATES:
+        if Path(candidate).is_file():
+            return Path(candidate)
+    # TeX Live ships DejaVu and is common on machines that build documents.
+    for root in (Path("/usr/local/texlive"), Path("/opt/texlive")):
+        if root.is_dir():
+            found = sorted(root.glob("*/texmf-dist/fonts/truetype/public/dejavu/DejaVuSans.ttf"))
+            if found:
+                return found[-1]
+    return None
+
+PRINT_CSS = """
+@page {{
+    size: A4;
+    margin: 16mm 14mm 14mm 14mm;
+
+    @top-left {{
+        content: "{header}";
+        font-family: 'Inter Tight PDF', sans-serif;
+        font-size: 7.5pt;
+        color: #6f6f6a;
+        padding-bottom: 3mm;
+        border-bottom: 0.4pt solid #ddddd8;
+        width: 100%;
+        vertical-align: bottom;
+    }}
+
+    @bottom-right {{
+        content: counter(page) " / " counter(pages);
+        font-family: 'Inter Tight PDF', sans-serif;
+        font-size: 7.5pt;
+        color: #8a8880;
+    }}
+}}
+
+/* True white. The screen palette's warm off-white prints as a dirty cast. */
+:root {{ --surface: #ffffff; }}
+html, body {{ background: #ffffff !important; }}
+.caveats {{ background: #f7f7f6 !important; }}
+
+/* Open fonts, and a tighter measure. The screen sizing is generous because a
+   browser window scrolls; a page does not, and the loose version ran to 57
+   pages against a browser print's 30. */
+/* Universal, because any element with its own font-family would otherwise
+   fall through to a system face and embed it. Verdana, Arial and Menlo are
+   proprietary; shipping them inside a Commons upload is a licence problem. */
+* {{ font-family: 'Inter Tight PDF', 'Fallback PDF', sans-serif !important; }}
+html, body {{
+    font-family: 'Inter Tight PDF', 'Fallback PDF', sans-serif !important;
+    font-size: 9pt !important;
+    line-height: 1.42 !important;
+}}
+code, pre, kbd, samp, .check, .diff .ids {{
+    font-family: 'JetBrains Mono PDF', 'Fallback PDF', monospace !important;
+    font-size: 8pt !important;
+}}
+
+/* Say who this is for, before anything else. The two versions of this report
+   differ in what they contain and in what they assume the reader wants; a PDF
+   circulates without its filename, so the document has to say so itself. */
+body::before {{
+    content: "{audience}";
+    display: block;
+    font-size: 8pt;
+    font-weight: 700;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+    color: #55554f;
+    border: 0.6pt solid #d9d9d2;
+    border-left: 2.5pt solid #55554f;
+    padding: 4pt 8pt;
+    margin: 0 0 12pt;
+}}
+h1 {{ font-size: 17pt !important; }}
+h2 {{ font-size: 12.5pt !important; }}
+h3 {{ font-size: 10.5pt !important; }}
+table {{ font-size: 8.2pt !important; }}
+th, td {{ padding: 2.5pt 5pt !important; }}
+p {{ margin: 0 0 5pt !important; }}
+figure {{ margin: 7pt 0 !important; }}
+
+/* Keep small blocks whole. Deliberately NOT `table`: these reports carry
+   tables longer than a page, and forcing those whole pushes each one to a
+   fresh page and leaves half the preceding page empty. Let long tables split
+   and repeat their header row instead. */
+figure, .callout, .caveats {{ break-inside: avoid; }}
+thead {{ display: table-header-group; }}
+tr {{ break-inside: avoid; }}
+h1, h2, h3 {{ break-after: avoid; }}
+img, svg {{ max-width: 100% !important; height: auto !important; }}
+"""
+
+
+def build(source: Path, out: Path, header: str, audience: str) -> int:
+    """Shell out to the weasyprint CLI.
+
+    Importing weasyprint is not an option: Homebrew installs it against its own
+    pinned interpreter, so `import weasyprint` fails under whichever python
+    happens to run this script. The CLI is the stable interface.
+    """
+    exe = shutil.which("weasyprint")
+    if exe is None:
+        sys.exit("weasyprint not found on PATH: brew install weasyprint")
+
+    # Escape for the CSS string context: backslash first, then the quote.
+    def css_str(value: str) -> str:
+        return value.replace("\\", "\\\\").replace('"', '\\"')
+
+    if not FONT_DIR.is_dir():
+        sys.exit(f"font directory not found: {FONT_DIR}")
+
+    fallback = find_fallback()
+    if fallback is None:
+        print("  note: no free fallback font found; a system face will be embedded "
+              "for maths glyphs such as \u2265", file=sys.stderr)
+
+    with tempfile.NamedTemporaryFile("w", suffix=".css", delete=False) as fh:
+        fh.write(FONT_CSS.format(font_dir=FONT_DIR))
+        if fallback is not None:
+            fh.write(FALLBACK_CSS.format(path=fallback))
+        fh.write(PRINT_CSS.format(
+            header=css_str(header), audience=css_str(audience),
+        ))
+        css_path = fh.name
+    try:
+        result = subprocess.run(
+            [exe, "-s", css_path, str(source), str(out)],
+            capture_output=True, text=True,
+        )
+    finally:
+        Path(css_path).unlink(missing_ok=True)
+
+    if result.returncode != 0 or not out.is_file():
+        sys.exit(f"weasyprint failed:\n{result.stderr.strip()}")
+    return out.stat().st_size
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("source", type=Path, help="report HTML")
+    p.add_argument("out", type=Path, help="PDF to write")
+    p.add_argument("--round", required=True, help="round number, e.g. 1")
+    p.add_argument("--process", required=True, help="consultation name")
+    p.add_argument("--url", required=True, help="URL of the original process")
+    p.add_argument("--brand", default="Proto", help="product name (default: Proto)")
+    p.add_argument("--audience", required=True,
+                   help='who the report is for, e.g. "For participants in this consultation"')
+    args = p.parse_args()
+
+    if not args.source.is_file():
+        sys.exit(f"no such file: {args.source}")
+
+    header = f"{args.brand} · Round {args.round} · {args.process} · {args.url}"
+    size = build(args.source, args.out, header, args.audience)
+    print(f"{args.out}  {size:,} bytes")
+    print(f"  header:   {header}")
+    print(f"  audience: {args.audience}")
+
+
+if __name__ == "__main__":
+    main()

--- a/private/analysis/make_test_bundle.py
+++ b/private/analysis/make_test_bundle.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Build a synthetic bundle that exercises every path in the pipeline.
+
+This is a PLUMBING test, not a validation of the clustering. Its `math_main` is
+produced by running the replica and writing the result in the engine's own JSON
+shape — so the reproduction gate necessarily passes and proves nothing about
+agreement with the real Clojure engine. Only a bundle exported from a real Polis
+database (local stack or server) can do that.
+
+What it does prove: the bundle loads, the integrity checks fire, matrices build,
+Leiden runs, near-duplicate groups form, head-to-heads compute, and the report
+renders — without waiting on docker.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from bundle import BundleWriter, load_salt, person_key  # noqa: E402
+
+CONV = 'test-conv'
+SALT_FILE = Path(__file__).with_name('.test_salt')
+
+# Ten propositions; the last two each get a near-duplicate rewording so the
+# wording-effect path has something to chew on.
+STATEMENTS = [
+    'Members should serve a term of two years',
+    'Members should be elected by the community',
+    'A case needs at least three arbitrators',
+    'Requests must show prior attempts at resolution',
+    'Decisions should be published in full',
+    'Blocked users may request clarification',
+    'The committee should meet monthly',
+    'Candidates need one year of tenure',
+    'Candidates need at least a thousand edits',
+    'Appeals must explain what has changed since',
+]
+NEAR_DUPLICATES = [
+    (8, 'Candidates need at least a thousand non-vandalism edits'),
+    (8, 'Candidates need at least a thousand edits in the article namespace'),
+    (7, 'Candidates need at least one year of tenure before the election'),
+]
+
+N_GROUP_A, N_GROUP_B = 22, 18
+
+
+def main() -> int:
+    rng = np.random.default_rng(20260606)
+    if not SALT_FILE.exists():
+        SALT_FILE.write_text('0' * 64)
+    salt = load_salt(SALT_FILE)
+    out = Path(sys.argv[1] if len(sys.argv) > 1 else 'test_bundle')
+
+    texts = list(STATEMENTS)
+    parent_of: dict[int, int] = {}
+    for parent_tid, text in NEAR_DUPLICATES:
+        parent_of[len(texts)] = parent_tid
+        texts.append(text)
+
+    n_people = N_GROUP_A + N_GROUP_B
+    # Group A agrees with the even-indexed propositions, group B with the odd.
+    # A derivative inherits its parent's stance, so a lineage looks like a lineage.
+    stance = np.zeros((n_people, len(texts)))
+    for tid in range(len(texts)):
+        base = parent_of.get(tid, tid)
+        for pid in range(n_people):
+            group_a = pid < N_GROUP_A
+            agrees = (base % 2 == 0) if group_a else (base % 2 == 1)
+            stance[pid, tid] = -1 if agrees else 1
+
+    # One of the three rewordings genuinely shifts a few people, so the
+    # head-to-head has a real effect to find.
+    shifted_tid = len(STATEMENTS)
+    for pid in rng.choice(N_GROUP_A, size=6, replace=False):
+        stance[pid, shifted_tid] = 1
+
+    votes, history = [], []
+    for pid in range(n_people):
+        # A handful of people vote on very little, so the funnel and the in-conv
+        # threshold both have someone to exclude.
+        n_seen = 3 if pid % 13 == 0 else len(texts)
+        for tid in range(n_seen):
+            vote = int(stance[pid, tid])
+            if rng.random() < 0.08:
+                vote = 0
+            elif rng.random() < 0.06:
+                vote = -vote
+            key = person_key(salt, f'xid-{pid:03d}')
+            timestamp = 1_770_000_000_000 + pid * 1000 + tid
+            votes.append([CONV, 2, key, pid, tid, vote, timestamp])
+            history.append([CONV, 2, key, pid, tid, vote, timestamp])
+
+    # No author column: statement authorship is deliberately not exported.
+    statements_rows = [
+        [CONV, 2, tid, tid < len(STATEMENTS), 0, True,
+         1_770_000_000_000 + tid, 'en', text]
+        for tid, text in enumerate(texts)
+    ]
+    participants_rows = [
+        [CONV, 2, person_key(salt, f'xid-{pid:03d}'), pid,
+         sum(1 for v in votes if v[3] == pid), 1_770_000_100_000, True]
+        for pid in range(n_people)
+    ]
+
+    # math_main, in the engine's own shape, from the replica.
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from pipeline import POLIS_STUDY  # noqa: F401  (sets sys.path for the replica)
+    from analysis.polis_replica import run_replica
+
+    matrix = np.full((n_people, len(texts)), np.nan)
+    for _, _, _, pid, tid, vote, _ in votes:
+        matrix[pid, tid] = vote
+    result = run_replica(matrix)
+
+    base_members: dict[int, list[int]] = {}
+    for cluster in result['base_clusters']:
+        base_members[int(cluster['id'])] = [int(m) for m in cluster['members']]
+    group_clusters = [
+        {'id': int(gi), 'center': [float(x) for x in g['center']],
+         'members': [int(m) for m in g['members']]}
+        for gi, g in enumerate(result['group_clusters'])
+    ]
+    math_payload = {
+        'conv_key': CONV, 'phase': 2, 'zinvite': 'testzin001',
+        'math_env': 'test', 'last_vote_timestamp': 1_770_000_100_000,
+        'math_tick': 1, 'modified': 1_770_000_100_000,
+        'data': {
+            'n': n_people, 'n-cmts': len(texts),
+            'tids': list(range(len(texts))),
+            'in-conv': [int(p) for p in result['in_conv']],
+            'mod-in': [], 'mod-out': [], 'meta-tids': [],
+            'base-clusters': {
+                'id': sorted(base_members),
+                'members': [base_members[i] for i in sorted(base_members)],
+                'count': [len(base_members[i]) for i in sorted(base_members)],
+            },
+            'group-clusters': group_clusters,
+        },
+    }
+
+    polis = BundleWriter(out, kind='polis', env='local', salt=salt, with_text=True,
+                         extra_manifest={'conversations': [
+                             {'conv_key': CONV, 'phase': 2, 'zinvite': 'testzin001',
+                              'n_participants': n_people, 'n_identity_linked': n_people,
+                              'n_statements': len(texts), 'n_votes_latest': len(votes),
+                              'n_votes_history': len(history), 'has_math_main': True}]})
+    polis.add_csv('conversations.csv',
+                  ['conv_key', 'phase', 'zinvite', 'is_active', 'is_public',
+                   'strict_moderation', 'vis_type', 'created_ms'],
+                  [[CONV, 2, 'testzin001', True, True, False, 1, 1_770_000_000_000]])
+    polis.add_csv('participants.csv',
+                  ['conv_key', 'phase', 'person_key', 'pid', 'vote_count',
+                   'last_interaction_ms', 'identity_linked'], participants_rows)
+    polis.add_csv('statements.csv',
+                  ['conv_key', 'phase', 'tid', 'is_seed', 'mod',
+                   'active', 'created_ms', 'lang', 'txt'], statements_rows)
+    polis.add_csv('votes_latest.csv',
+                  ['conv_key', 'phase', 'person_key', 'pid', 'tid', 'vote', 'modified_ms'],
+                  votes)
+    polis.add_csv('votes_history.csv',
+                  ['conv_key', 'phase', 'person_key', 'pid', 'tid', 'vote', 'created_ms'],
+                  history)
+    polis.add_json(f'math_main/{CONV}_phase2.json', math_payload)
+    polis.close()
+
+    app = BundleWriter(out, kind='app', env='local', salt=salt, with_text=True,
+                       allow_columns={'pseudonym'},
+                       extra_manifest={'conversations': [
+                           {'conv_key': CONV, 'phase2_zinvite': 'testzin001',
+                            'phase6_zinvite': None, 'n_participations': n_people,
+                            'n_featured': 0, 'n_featured_confirmed': 0,
+                            'n_featured_bridged': 0,
+                            'n_provenance': len(NEAR_DUPLICATES), 'n_arguments': 0}],
+                           'with_arguments': False, 'with_pseudonyms': True})
+    app.add_csv('conversations.csv',
+                ['conv_key', 'slug', 'polis_id', 'phase6_polis_conversation_id', 'title',
+                 'language', 'access_policy', 'phase_route', 'active', 'paused',
+                 'phase_submission', 'phase_personal_results', 'phase_argument_mapping',
+                 'phase_cleanup', 'phase_public_results', 'phase_informed_voting',
+                 'argument_vote_method', 'created_at', 'closed_at', 'n_participations'],
+                [[CONV, CONV, 'testzin001', None, 'Synthetic test', 'en', 'public',
+                  'default_7', True, False, True, True, False, False, True, False,
+                  'kApproval', '2026-01-01', None, n_people]])
+    app.add_csv('featured_statements.csv',
+                ['conv_key', 'polis_statement_id', 'phase6_polis_statement_id',
+                 'suggested_by_system', 'confirmed_by_admin', 'created_at',
+                 'statement_text'], [])
+    # Only two of the three rewordings were *declared* as improvements — the third
+    # must be found by the embeddings alone, which is what makes the detected-vs-
+    # declared comparison meaningful.
+    app.add_csv('statement_provenance.csv',
+                ['conv_key', 'polis_statement_id', 'derived_from_tid', 'provenance_type',
+                 'link_method', 'created_at'],
+                [[CONV, tid, parent, 'derivative', 'declared', '2026-01-02']
+                 for tid, parent in list(parent_of.items())[:2]])
+    app.add_csv('statement_similarity.csv',
+                ['conv_key', 'polis_statement_id', 'model', 'value', 'scored_at'],
+                [[CONV, tid, 'semantic-v1', 0.93, '2026-01-02']
+                 for tid in list(parent_of)[:2]])
+    app.add_csv('people.csv', ['conv_key', 'person_key', 'pseudonym'],
+                [[CONV, person_key(salt, f'xid-{pid:03d}'), f'testuser-{pid:03d}']
+                 for pid in range(n_people)])
+    app.close()
+
+    print(f'\nsynthetic bundle written to {out}')
+    print(f'  {n_people} people, {len(texts)} statements '
+          f'({len(NEAR_DUPLICATES)} of them rewordings), {len(votes):,} votes')
+    print(f'  replica K={result["K"]}  (written into math_main — plumbing only)')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/private/analysis/methods.py
+++ b/private/analysis/methods.py
@@ -1,0 +1,1159 @@
+"""Comparison methods on top of the server's own clustering.
+
+Two questions this module answers, both raised as the point of the analysis:
+
+  1. **How much clustering is actually there?** Polis always returns 2–5 groups; it
+     never says "there are no groups". So an independent method is needed to tell a
+     real division from a partition of noise. Leiden community detection on a
+     participant-agreement graph is that second opinion, plus a stability sweep
+     that reports how many people sit on a boundary rather than inside a group.
+
+  2. **Does phrasing move votes?** Consultations accumulate near-duplicate
+     statements — one proposition in three wordings. For an organiser choosing
+     which phrasing to put to a vote, the head-to-head between those variants is
+     the decision, and it is invisible in a whole-conversation view.
+
+Neither method replaces `math_main`. The server's clustering stays the headline;
+these say how much weight it can bear.
+"""
+from __future__ import annotations
+
+import collections
+import os
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from pipeline import (MIN_DECIDED_FOR_HEAD_TO_HEAD, MIN_PAIR_OVERLAP, RAW_AGREE,
+                      RAW_DISAGREE, SIMILARITY_THRESHOLD, Bundles, Matrix,
+                      compare_labels, server_labels)
+
+EMBEDDING_MODEL = os.environ.get(
+    'ANALYSIS_EMBEDDING_MODEL',
+    'sentence-transformers/paraphrase-multilingual-mpnet-base-v2')
+
+
+# ── participant agreement graph ──────────────────────────────────────────────
+
+def agreement_graph(matrix: Matrix, *, min_overlap: int = MIN_PAIR_OVERLAP,
+                    restrict_pids: list[int] | None = None):
+    """Participant × participant agreement, over statements both actually voted on.
+
+    Deliberately sparse-aware rather than imputed: two people are compared only on
+    the statements they both voted, and only if they share at least `min_overlap`
+    of them. Passes are excluded — a pass is not an opinion, and counting it as
+    agreement would inflate similarity between two people who simply skipped a lot.
+
+    Edge weight rescales agreement from [0.5, 1] to [0, 1]; a pair agreeing at or
+    below chance gets no edge, so the graph encodes attraction only.
+    """
+    pids = list(matrix.pids)
+    values = matrix.values
+    if restrict_pids is not None:
+        keep = set(restrict_pids)
+        idx = [i for i, pid in enumerate(pids) if pid in keep]
+        pids = [pids[i] for i in idx]
+        values = values[idx, :]
+
+    opinion = np.where(np.isin(values, [RAW_AGREE, RAW_DISAGREE]), values, np.nan)
+    n = len(pids)
+    weights = np.zeros((n, n))
+    overlaps = np.zeros((n, n), dtype=int)
+    for i in range(n):
+        for j in range(i + 1, n):
+            both = ~np.isnan(opinion[i]) & ~np.isnan(opinion[j])
+            k = int(both.sum())
+            overlaps[i, j] = overlaps[j, i] = k
+            if k < min_overlap:
+                continue
+            agree = float(np.mean(opinion[i, both] == opinion[j, both]))
+            weight = max(0.0, (agree - 0.5) * 2)
+            weights[i, j] = weights[j, i] = weight
+    return pids, weights, overlaps
+
+
+def leiden_communities(pids, weights, *, resolution: float = 1.0, seed: int = 20260606):
+    """Leiden on the agreement graph. Returns {pid: community}."""
+    import igraph as ig
+    import leidenalg
+
+    n = len(pids)
+    edges, edge_weights = [], []
+    for i in range(n):
+        for j in range(i + 1, n):
+            if weights[i, j] > 0:
+                edges.append((i, j))
+                edge_weights.append(float(weights[i, j]))
+
+    graph = ig.Graph(n=n, edges=edges)
+    graph.es['weight'] = edge_weights
+    partition = leidenalg.find_partition(
+        graph, leidenalg.RBConfigurationVertexPartition,
+        weights='weight', resolution_parameter=resolution, seed=seed)
+    return ({pids[i]: int(c) for i, c in enumerate(partition.membership)},
+            float(partition.modularity))
+
+
+def leiden_sweep(b: Bundles, gate: dict, *,
+                 resolutions=(0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2.0),
+                 min_overlap: int = MIN_PAIR_OVERLAP) -> pd.DataFrame:
+    """Leiden across resolutions, compared with the server's groups at each one.
+
+    The resolution parameter, not the data, decides how many communities Leiden
+    returns — so a single run proves nothing. The informative reading is the shape
+    of this table: if the server's split is real, agreement with it should peak
+    sharply at whatever resolution yields the same K, and K should be stable across
+    a broad band of resolutions rather than climbing steadily.
+    """
+    server = gate['server']
+    matrix = gate['matrix']
+    in_conv = gate['replica']['in_conv']
+    pids, weights, overlaps = agreement_graph(matrix, min_overlap=min_overlap,
+                                              restrict_pids=in_conv)
+
+    rows = []
+    for resolution in resolutions:
+        labels, modularity = leiden_communities(pids, weights, resolution=resolution)
+        sizes = pd.Series(list(labels.values())).value_counts()
+        singletons = int((sizes == 1).sum())
+        ari, n_common = compare_labels(server['labels'], labels)
+        rows.append({
+            'resolution': resolution,
+            'K_leiden': len(sizes),
+            'K_server': server['K'],
+            'largest_community': int(sizes.iloc[0]) if len(sizes) else 0,
+            'singletons': singletons,
+            'modularity': round(modularity, 4),
+            'ari_vs_server': round(ari, 4) if ari == ari else float('nan'),
+            'n_compared': n_common,
+        })
+    out = pd.DataFrame(rows)
+    out.attrs['n_nodes'] = len(pids)
+    out.attrs['n_edges'] = int((weights > 0).sum() // 2)
+    out.attrs['median_overlap'] = float(np.median(overlaps[np.triu_indices(len(pids), 1)]))
+    return out
+
+
+def cluster_stability(b: Bundles, gate: dict, *,
+                      resolutions=(0.6, 0.8, 1.0, 1.25, 1.5),
+                      seeds=(1, 2, 3, 4, 5), min_overlap: int = MIN_PAIR_OVERLAP) -> dict:
+    """How reliably does each person land with the same people?
+
+    Runs Leiden over a grid of resolutions and seeds and measures, for every pair,
+    how often they end up in the same community. A person whose co-assignment is
+    consistently near 0 or 1 sits inside a group; one hovering near 0.5 sits on a
+    boundary and should not be described as belonging to either.
+    """
+    matrix = gate['matrix']
+    # `gate` deliberately keeps machine accounts: reproducing the server's clustering
+    # means feeding the replica the population the server had. Stability is a different
+    # question — it describes people — and machine accounts wreck it. Each votes once,
+    # so it shares no statements with anyone, gets no graph edge, and sits as an
+    # isolated singleton that never moves between runs: trivially "decided", and here
+    # they supplied most of the decided pairs. Drop them before measuring.
+    machine = set(b.machine.get((gate['conv_key'], gate['phase']), {}))
+    in_conv = [p for p in gate['replica']['in_conv'] if p not in machine]
+    pids, weights, _ = agreement_graph(matrix, min_overlap=min_overlap,
+                                       restrict_pids=in_conv)
+    n = len(pids)
+    if n < 2:
+        return {'available': False, 'reason': 'too few in-conv participants'}
+
+    together = np.zeros((n, n))
+    runs = 0
+    for resolution in resolutions:
+        for seed in seeds:
+            labels, _ = leiden_communities(pids, weights, resolution=resolution, seed=seed)
+            member = np.array([labels[p] for p in pids])
+            together += (member[:, None] == member[None, :]).astype(float)
+            runs += 1
+    together /= runs
+
+    triu = np.triu_indices(n, 1)
+    pair_scores = together[triu]
+    # A pair is "decided" if the runs nearly always agree, either way.
+    decided = float(np.mean((pair_scores > 0.9) | (pair_scores < 0.1)))
+
+    # Self-comparisons are trivially 1.0 and must not drag the boundary score, so
+    # they are excluded here — but the returned matrix keeps them, because a blank
+    # diagonal in the heatmap reads as "never grouped with themselves".
+    scored = together.copy()
+    np.fill_diagonal(scored, np.nan)
+    per_person = np.nanmean(np.minimum(scored, 1 - scored), axis=1)
+    boundary = pd.DataFrame({'pid': pids, 'boundary_score': per_person.round(3)})
+    boundary = boundary.sort_values('boundary_score', ascending=False)
+
+    server = gate['server']
+    key_by_pid = dict(zip(b.phase('participants', gate['conv_key'], gate['phase'])['pid'],
+                          b.phase('participants', gate['conv_key'], gate['phase'])['person_key']))
+    boundary['person_key'] = boundary['pid'].map(key_by_pid)
+    boundary['server_group'] = boundary['pid'].map(server['labels'])
+
+    return {
+        'available': True,
+        'n_runs': runs,
+        'n_people': n,
+        'pairs_decided': round(decided, 4),
+        'mean_boundary_score': round(float(np.nanmean(per_person)), 4),
+        'n_on_boundary': int((per_person > 0.25).sum()),
+        'boundary': boundary,
+        'co_assignment': pd.DataFrame(together, index=pids, columns=pids),
+    }
+
+
+# ── near-duplicate statement groups ──────────────────────────────────────────
+
+@dataclass
+class StatementGroup:
+    group_id: int
+    tids: list[int]
+    texts: dict[int, str]
+    declared_links: list[tuple[int, int]]
+
+    def __len__(self) -> int:
+        return len(self.tids)
+
+
+def embed_statements(texts: list[str], model_name: str = EMBEDDING_MODEL) -> np.ndarray:
+    from sentence_transformers import SentenceTransformer
+    model = SentenceTransformer(model_name)
+    return model.encode(texts, normalize_embeddings=True)
+
+
+def similar_statement_groups(b: Bundles, conv_key: str, phase: int = 2, *,
+                             threshold: float = SIMILARITY_THRESHOLD,
+                             include_declared: bool = True) -> tuple[list[StatementGroup], pd.DataFrame]:
+    """Group statements that say near enough the same thing.
+
+    Similarity is cosine over multilingual sentence embeddings (the same model the
+    app's similarity sidecar uses, so "similar" means here what it means in the
+    product). Groups are connected components at `threshold`: A~B and B~C puts all
+    three together, which is what a chain of successive rewordings looks like.
+
+    Declared provenance links are unioned in when present — a participant saying
+    "this improves on that" is stronger evidence than any threshold.
+
+    Returns the groups and the full pairwise table, so the threshold can be
+    checked against the actual similarity distribution rather than assumed.
+    """
+    statements = b.phase('statements', conv_key, phase)
+    statements = statements[statements['active'] & (statements['mod'] >= 0)]
+    statements = statements[statements['txt'].notna() & (statements['txt'] != '')]
+    if statements.empty:
+        return [], pd.DataFrame()
+
+    tids = statements['tid'].tolist()
+    texts = statements['txt'].tolist()
+    text_by_tid = dict(zip(tids, texts))
+    vectors = embed_statements(texts)
+    similarity = vectors @ vectors.T
+
+    pairs = []
+    n = len(tids)
+    for i in range(n):
+        for j in range(i + 1, n):
+            pairs.append({'tid_a': tids[i], 'tid_b': tids[j],
+                          'similarity': float(similarity[i, j]),
+                          'text_a': texts[i], 'text_b': texts[j]})
+    pair_table = pd.DataFrame(pairs).sort_values('similarity', ascending=False)
+
+    # union-find over the threshold graph, plus declared provenance
+    parent = {tid: tid for tid in tids}
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a, bb):
+        ra, rb = find(a), find(bb)
+        if ra != rb:
+            parent[rb] = ra
+
+    for row in pair_table.itertuples():
+        if row.similarity >= threshold:
+            union(row.tid_a, row.tid_b)
+
+    declared: list[tuple[int, int]] = []
+    prov = b.app['statement_provenance']
+    if include_declared and not prov.empty:
+        prov = prov[prov['conv_key'] == conv_key]
+        for link in prov.itertuples():
+            child, par = int(link.polis_statement_id), int(link.derived_from_tid)
+            if child in parent and par in parent:
+                declared.append((child, par))
+                union(child, par)
+
+    members: dict[int, list[int]] = {}
+    for tid in tids:
+        members.setdefault(find(tid), []).append(tid)
+
+    groups = []
+    for gid, (_, member_tids) in enumerate(
+            sorted((r, sorted(m)) for r, m in members.items() if len(m) > 1)):
+        member_set = set(member_tids)
+        groups.append(StatementGroup(
+            group_id=gid, tids=member_tids,
+            texts={t: text_by_tid[t] for t in member_tids},
+            declared_links=[(c, p) for c, p in declared
+                            if c in member_set and p in member_set]))
+    return groups, pair_table
+
+
+def statement_families(b: Bundles, conv_key: str, phase: int = 2) -> list[dict]:
+    """Families of statements linked by *declared* provenance.
+
+    Different from the near-duplicate groups above, and worth having both. A
+    near-duplicate group is what an embedding model judges to say the same thing. A
+    family is what participants said they were doing: "this improves on that". The
+    two disagree in both directions — someone rewrites a statement into something
+    genuinely different, or two people independently write near-identical statements
+    with no link between them.
+
+    A family also has shape that a similarity group does not: a root, and generations
+    descending from it. That makes a question available which flat grouping cannot
+    ask — *did successive rewriting build support, or lose it?*
+    """
+    prov = b.app['statement_provenance']
+    if prov.empty:
+        return []
+    prov = prov[prov['conv_key'] == conv_key]
+    if prov.empty:
+        return []
+
+    parent_of = {int(r.polis_statement_id): int(r.derived_from_tid)
+                 for r in prov.itertuples()}
+    children: dict[int, list[int]] = {}
+    for child, parent in parent_of.items():
+        children.setdefault(parent, []).append(child)
+
+    statements = b.phase('statements', conv_key, phase).set_index('tid')
+    votes = b.phase('votes_latest', conv_key, phase)
+
+    def root_of(tid: int) -> int:
+        seen, cur = {tid}, tid
+        while cur in parent_of:
+            nxt = parent_of[cur]
+            if nxt in seen:
+                break
+            seen.add(nxt)
+            cur = nxt
+        return cur
+
+    members_by_root: dict[int, set[int]] = {}
+    for tid in set(parent_of) | set(children):
+        members_by_root.setdefault(root_of(tid), set()).add(tid)
+
+    families = []
+    for root, members in sorted(members_by_root.items(), key=lambda kv: -len(kv[1])):
+        depth = {root: 0}
+        queue = [root]
+        while queue:
+            cur = queue.pop()
+            for child in children.get(cur, []):
+                if child not in depth:
+                    depth[child] = depth[cur] + 1
+                    queue.append(child)
+        for tid in members:                     # anything unreachable from the root
+            depth.setdefault(tid, 0)
+
+        rows = []
+        for tid in sorted(members, key=lambda t: (depth[t], t)):
+            block = votes[votes['tid'] == tid]
+            decided = int(((block['vote'] == RAW_AGREE) |
+                           (block['vote'] == RAW_DISAGREE)).sum())
+            rows.append({
+                'tid': tid,
+                'generation': depth[tid],
+                'improves_on': parent_of.get(tid),
+                'n_voters': len(block),
+                'n_decided': decided,
+                'agree_pct': round(int((block['vote'] == RAW_AGREE).sum()) / decided * 100, 1)
+                             if decided else np.nan,
+                'text': statements['txt'].get(tid, ''),
+            })
+        families.append({
+            'root': root,
+            'size': len(members),
+            'generations': max(depth.values()) + 1,
+            'members': pd.DataFrame(rows),
+        })
+    return families
+
+
+def statement_descendants(b: Bundles, conv_key: str, phase: int = 2) -> pd.DataFrame:
+    """Which statements provoked rewriting, and how much.
+
+    `n_children` counts direct rewrites; `n_descendants` counts the whole subtree
+    beneath a statement, so a statement whose rewrite was itself rewritten gets
+    credit for both. Statements nobody rewrote are included with zeros, because the
+    absence of rewriting is as informative as its presence.
+
+    A high descendant count marks a proposition people kept trying to get right —
+    which is a different signal from disagreement, and often more useful to an
+    organiser deciding what still needs work.
+    """
+    prov = b.app['statement_provenance']
+    statements = b.phase('statements', conv_key, phase)
+    votes = b.phase('votes_latest', conv_key, phase)
+
+    parent_of: dict[int, int] = {}
+    if not prov.empty:
+        sub = prov[prov['conv_key'] == conv_key]
+        parent_of = {int(r.polis_statement_id): int(r.derived_from_tid)
+                     for r in sub.itertuples()}
+    children: dict[int, list[int]] = {}
+    for child, parent in parent_of.items():
+        children.setdefault(parent, []).append(child)
+
+    def descendants(tid: int) -> int:
+        total, stack, seen = 0, list(children.get(tid, [])), set()
+        while stack:
+            cur = stack.pop()
+            if cur in seen:
+                continue
+            seen.add(cur)
+            total += 1
+            stack.extend(children.get(cur, []))
+        return total
+
+    rows = []
+    for row in statements.itertuples():
+        tid = int(row.tid)
+        block = votes[votes['tid'] == tid]
+        decided = int(((block['vote'] == RAW_AGREE) | (block['vote'] == RAW_DISAGREE)).sum())
+        rows.append({
+            'tid': tid,
+            'n_children': len(children.get(tid, [])),
+            'n_descendants': descendants(tid),
+            'improves_on': parent_of.get(tid),
+            'is_seed': bool(row.is_seed),
+            'moderated_out': int(row.mod) == -1,
+            'n_voters': len(block),
+            'agree_pct': round(int((block['vote'] == RAW_AGREE).sum()) / decided * 100, 1)
+                         if decided else np.nan,
+            'text': row.txt,
+        })
+    out = pd.DataFrame(rows)
+    return out.sort_values(['n_descendants', 'n_children', 'n_voters'],
+                           ascending=False).reset_index(drop=True)
+
+
+def family_generations(families: list[dict]) -> pd.DataFrame:
+    """Does support rise or fall as a family is rewritten?
+
+    Weighted by decided votes, so a much-voted statement counts for more than one
+    that two people saw. Compares generations *across* families, which is only
+    meaningful because the question is about the act of rewriting rather than about
+    any particular proposition.
+    """
+    rows = []
+    for family in families:
+        for member in family['members'].itertuples():
+            if member.n_decided:
+                rows.append({'root': family['root'], 'generation': member.generation,
+                             'agree_pct': member.agree_pct, 'n_decided': member.n_decided})
+    table = pd.DataFrame(rows)
+    if table.empty:
+        return table
+
+    def weighted(block):
+        return pd.Series({
+            'n_statements': len(block),
+            'total_clear_opinions': int(block['n_decided'].sum()),
+            'weighted_agree_pct': round(
+                float(np.average(block['agree_pct'], weights=block['n_decided'])), 1),
+            'median_agree_pct': round(float(block['agree_pct'].median()), 1),
+        })
+
+    return (table.groupby('generation').apply(weighted, include_groups=False)
+                 .reset_index().astype({'n_statements': int, 'total_clear_opinions': int}))
+
+
+def family_vs_similarity(families: list[dict], groups: list[StatementGroup]) -> dict:
+    """How much do declared families and embedding groups actually agree?
+
+    Reported because the two are routinely conflated. Where they diverge is
+    informative in itself: a declared link the model does not see is a rewrite that
+    changed the meaning; a similarity group with no declared link is duplication
+    nobody noticed.
+    """
+    family_pairs, group_pairs = set(), set()
+    for family in families:
+        tids = sorted(family['members']['tid'])
+        for i, a in enumerate(tids):
+            for bb in tids[i + 1:]:
+                family_pairs.add((a, bb))
+    for group in groups:
+        tids = sorted(group.tids)
+        for i, a in enumerate(tids):
+            for bb in tids[i + 1:]:
+                group_pairs.add((a, bb))
+
+    both = family_pairs & group_pairs
+    return {
+        'pairs_declared_family': len(family_pairs),
+        'pairs_similarity_group': len(group_pairs),
+        'pairs_in_both': len(both),
+        'declared_but_not_similar': len(family_pairs - group_pairs),
+        'similar_but_not_declared': len(group_pairs - family_pairs),
+        'jaccard': round(len(both) / len(family_pairs | group_pairs), 3)
+                   if (family_pairs | group_pairs) else float('nan'),
+    }
+
+
+def head_to_head(b: Bundles, conv_key: str, group: StatementGroup, phase: int = 2,
+                 use_groups: bool = True) -> dict:
+    """Compare the variants in one near-duplicate group, head to head.
+
+    Two views, because they answer different questions:
+
+      * **All voters** — what an organiser sees on the results page. Confounded:
+        different variants were live for different lengths of time, so they were
+        seen by different people.
+      * **Common voters** — only people who voted on both variants. This is the
+        one that can support a claim about wording, because the population is held
+        fixed and each person acts as their own control.
+
+    Discordant pairs (agreed with one wording, not the other) are tested with an
+    exact binomial test — the paired form, since the same people voted both.
+    """
+    from scipy.stats import binomtest
+
+    votes = b.phase('votes_latest', conv_key, phase)
+    votes = votes[votes['tid'].isin(group.tids)]
+    server = server_labels(b, conv_key, phase) if use_groups else {'available': False}
+
+    per_variant = []
+    for tid in group.tids:
+        v = votes[votes['tid'] == tid]
+        row = {
+            'tid': tid, 'text': group.texts[tid], 'n_voters': len(v),
+            'agree': int((v['vote'] == RAW_AGREE).sum()),
+            'disagree': int((v['vote'] == RAW_DISAGREE).sum()),
+            'pass': int((v['vote'] == 0).sum()),
+        }
+        decided = row['agree'] + row['disagree']
+        row['agree_pct'] = round(row['agree'] / decided * 100, 1) if decided else np.nan
+        if server.get('available'):
+            key_by_pid = dict(zip(b.phase('participants', conv_key, phase)['pid'],
+                                  b.phase('participants', conv_key, phase)['person_key']))
+            group_by_key = {key_by_pid[pid]: lab for pid, lab in server['labels'].items()
+                            if pid in key_by_pid}
+            v = v.assign(opinion_group=v['person_key'].map(group_by_key))
+            for gid in sorted({g for g in group_by_key.values()}):
+                sub = v[v['opinion_group'] == gid]
+                dec = int((sub['vote'] == RAW_AGREE).sum() + (sub['vote'] == RAW_DISAGREE).sum())
+                row[f'agree_pct_group{gid}'] = (
+                    round(int((sub['vote'] == RAW_AGREE).sum()) / dec * 100, 1)
+                    if dec else np.nan)
+                row[f'n_group{gid}'] = len(sub)
+        per_variant.append(row)
+
+    comparisons = []
+    for i, tid_a in enumerate(group.tids):
+        for tid_b in group.tids[i + 1:]:
+            va = votes[votes['tid'] == tid_a][['person_key', 'vote']]
+            vb = votes[votes['tid'] == tid_b][['person_key', 'vote']]
+            both = va.merge(vb, on='person_key', suffixes=('_a', '_b'))
+            decided = both[both['vote_a'].isin([RAW_AGREE, RAW_DISAGREE]) &
+                           both['vote_b'].isin([RAW_AGREE, RAW_DISAGREE])]
+            a_only = int(((decided['vote_a'] == RAW_AGREE) &
+                          (decided['vote_b'] == RAW_DISAGREE)).sum())
+            b_only = int(((decided['vote_a'] == RAW_DISAGREE) &
+                          (decided['vote_b'] == RAW_AGREE)).sum())
+            discordant = a_only + b_only
+            p_value = (binomtest(a_only, discordant, 0.5).pvalue
+                       if discordant else float('nan'))
+            comparisons.append({
+                'tid_a': tid_a, 'tid_b': tid_b,
+                'n_common_voters': len(both), 'n_common_decided': len(decided),
+                'agreed_with_a_only': a_only, 'agreed_with_b_only': b_only,
+                'n_discordant': discordant,
+                'shift_pct_points': (
+                    round((b_only - a_only) / len(decided) * 100, 1) if len(decided) else np.nan),
+                'p_value': round(p_value, 4) if p_value == p_value else np.nan,
+            })
+
+    return {'group_id': group.group_id,
+            'variants': pd.DataFrame(per_variant),
+            'comparisons': pd.DataFrame(comparisons),
+            'declared_links': group.declared_links,
+            'n_declared': len(group.declared_links)}
+
+
+def wording_participation(b: Bundles, conv_key: str, groups: list[StatementGroup],
+                          phase: int = 2) -> dict:
+    """How many actual people are behind the wording comparisons.
+
+    Exists because the pair counts are treacherous in prose. Summing discordant
+    pairs across comparisons counts one person once per pair they appear in, and a
+    family of 13 variants generates 78 pairs, so a handful of people can produce
+    several hundred "disagreements". These are counts of people.
+    """
+    votes = b.phase('votes_latest', conv_key, phase)
+    decided = votes[votes['vote'].isin([RAW_AGREE, RAW_DISAGREE])]
+
+    voted_multiple, split, instances = set(), set(), 0
+    for group in groups:
+        block = decided[decided['tid'].isin(group.tids)]
+        for person, rows in block.groupby('person_key'):
+            if len(rows) > 1:
+                voted_multiple.add(person)
+                if rows['vote'].nunique() > 1:
+                    split.add(person)
+                    instances += 1
+
+    return {
+        'n_participants': int(votes['person_key'].nunique()),
+        'n_voted_on_multiple_variants': len(voted_multiple),
+        'n_voted_differently': len(split),
+        'n_person_family_instances': instances,
+    }
+
+
+def wording_effect(head_to_heads: list[dict]) -> dict:
+    """Per-pair tests of whether two wordings of one proposition draw different support.
+
+    Three things this deliberately does NOT do, each of which would manufacture
+    significance out of nothing:
+
+    **It does not pool discordant counts into one binomial test.** Variants are
+    compared in tid order, so "side A" is always the earlier-submitted wording. A
+    pooled test of A-versus-B therefore measures whether *earlier* statements draw
+    more agreement than later ones — an ordering effect — and answers it in the
+    voice of a wording effect. That result is reported below under its own name,
+    separately, because it is a real question and a different one.
+
+    **It does not treat the pairs as independent.** A group of k variants yields
+    k(k-1)/2 pairs over the same statements and the same people; one group of 13
+    contributes 78 of them. Each pair is tested on its own and the p-values are
+    Benjamini-Hochberg corrected across the family.
+
+    **It does not report a median shift over pairs with almost no data.** A pair
+    where two people happened to disagree can show a 100-point "shift". Pairs below
+    `min_decided` are reported but excluded from the headline.
+    """
+    from scipy.stats import binomtest
+
+    rows = []
+    for h2h in head_to_heads:
+        for comparison in h2h['comparisons'].itertuples():
+            rows.append({'group_id': h2h['group_id'], 'tid_earlier': comparison.tid_a,
+                         'tid_later': comparison.tid_b,
+                         'n_common_decided': comparison.n_common_decided,
+                         'n_discordant': comparison.n_discordant,
+                         'agreed_earlier_only': comparison.agreed_with_a_only,
+                         'agreed_later_only': comparison.agreed_with_b_only,
+                         'shift_pct_points': comparison.shift_pct_points,
+                         'p_value': comparison.p_value})
+    table = pd.DataFrame(rows)
+    if table.empty or table['n_discordant'].sum() == 0:
+        return {'available': False,
+                'reason': 'no participant voted on two variants of the same statement',
+                'table': table}
+
+    min_decided = MIN_DECIDED_FOR_HEAD_TO_HEAD
+    tested = table[(table['n_discordant'] > 0) &
+                   (table['n_common_decided'] >= min_decided)].copy()
+
+    if tested.empty:
+        return {'available': True, 'n_pairs_tested': 0, 'n_significant': 0,
+                'table': table, 'min_decided': min_decided,
+                'reading': (f'No pair had at least {min_decided} people who voted '
+                            f'decisively on both wordings, so no comparison here can '
+                            f'support a claim about wording.')}
+
+    # Benjamini-Hochberg across the family of pair tests.
+    tested = tested.sort_values('p_value')
+    m = len(tested)
+    tested['q_value'] = (tested['p_value'] * m /
+                         np.arange(1, m + 1)).cummin().clip(upper=1).round(4)
+    significant = tested[tested['q_value'] < 0.05]
+
+    # The ordering question, asked in its own right rather than smuggled in.
+    total_earlier = int(tested['agreed_earlier_only'].sum())
+    total_discordant = int(tested['n_discordant'].sum())
+    order_test = binomtest(total_earlier, total_discordant, 0.5)
+
+    shifts = tested['shift_pct_points'].dropna()
+    return {
+        'available': True,
+        'n_pairs_tested': m,
+        'n_pairs_dropped_thin': int(len(table) - m),
+        'min_decided': min_decided,
+        'n_significant': len(significant),
+        'significant': significant,
+        'median_abs_shift_pct_points': round(float(shifts.abs().median()), 1),
+        'max_abs_shift_pct_points': round(float(shifts.abs().max()), 1),
+        'order_effect_p': round(float(order_test.pvalue), 5),
+        'order_effect_share_earlier': round(total_earlier / total_discordant, 3),
+        'table': table, 'tested': tested,
+        'reading': (
+            f'{len(significant)} of {m} comparisons survive correction for multiple '
+            f'testing. These pairs are not independent — variants of one proposition '
+            f'are compared against each other repeatedly and by the same people — so '
+            f'read them as pointers to specific wording choices, not as a count of '
+            f'discoveries.'),
+    }
+
+
+def family_representatives(b: Bundles, conv_key: str, families: list[dict],
+                           min_decided: int = 5) -> pd.DataFrame:
+    """For each family of rewrites, which wording best represents it.
+
+    A family is one proposition written several ways. Carrying all of them into a
+    next round asks people to vote repeatedly on the same idea; carrying none loses
+    the idea. So each family needs one representative.
+
+    Chosen by support among people who took a side, with a floor on how many did:
+    the highest-agreement variant in a family is often one that three people saw.
+    Where no variant clears the floor the family is reported as undecided rather
+    than given a representative on thin evidence — an explicit "needs a decision"
+    is more useful to an organiser than a confident wrong pick.
+    """
+    rows = []
+    for family in families:
+        members = family['members']
+        eligible = members[members['n_decided'] >= min_decided]
+        if eligible.empty:
+            best = members.sort_values('n_decided', ascending=False).iloc[0]
+            rows.append({
+                'family': family['root'], 'n_variants': family['size'],
+                'representative_tid': None,
+                'status': f'undecided — no variant reached {min_decided} decisive votes',
+                'best_seen_tid': int(best['tid']), 'n_decided': int(best['n_decided']),
+                'agree_pct': best['agree_pct'], 'is_rewrite': best['generation'] > 0,
+                'text': best['text'],
+            })
+            continue
+        best = eligible.sort_values(['agree_pct', 'n_decided'], ascending=False).iloc[0]
+        spread = eligible['agree_pct'].max() - eligible['agree_pct'].min()
+        rows.append({
+            'family': family['root'], 'n_variants': family['size'],
+            'representative_tid': int(best['tid']),
+            'status': ('clear' if spread >= 15 else
+                       'variants are close — any of them would do'),
+            'best_seen_tid': int(best['tid']), 'n_decided': int(best['n_decided']),
+            'agree_pct': best['agree_pct'], 'is_rewrite': bool(best['generation'] > 0),
+            'text': best['text'],
+        })
+    out = pd.DataFrame(rows)
+    return out.sort_values(['agree_pct', 'n_decided'], ascending=False).reset_index(drop=True)
+
+
+NUMBER_WORDS = {
+    'een': '1', 'één': '1', 'twee': '2', 'drie': '3', 'vier': '4', 'vijf': '5',
+    'zes': '6', 'zeven': '7', 'acht': '8', 'negen': '9', 'tien': '10', 'elf': '11',
+    'twaalf': '12', 'dertien': '13', 'veertien': '14', 'vijftien': '15',
+    'twintig': '20', 'dertig': '30', 'vijftig': '50', 'honderd': '100',
+    'tweehonderd': '200', 'driehonderd': '300', 'vijfhonderd': '500',
+    'duizend': '1000', 'tweeduizend': '2000',
+}
+
+
+def normalise_text(text: str) -> str:
+    """Reduce a statement to what it *says*, ignoring how it is written.
+
+    Lower-cases, strips punctuation and repeated whitespace, and writes number words
+    as digits — so "ten laatste 2 weken" and "ten laatste twee weken" come out the
+    same. It deliberately does NOT map different numbers onto each other: "duizend"
+    becomes 1000 and "vijfhonderd" becomes 500, so a real difference in threshold
+    survives normalisation and the two statements stay distinct.
+    """
+    import re
+    tokens = re.findall(r"[\w']+", (text or '').lower())
+    return ' '.join(NUMBER_WORDS.get(t, t) for t in tokens)
+
+
+def unvoted_statements(b: Bundles, conv_key: str, phase: int = 2) -> pd.DataFrame:
+    """Statements nobody voted on. No data exists about them, so they are set aside
+    before anything else — they cannot be compared, merged or clustered, and leaving
+    them in the deduplication lists only buries the pairs that can be judged."""
+    statements = b.phase('statements', conv_key, phase)
+    votes = b.phase('votes_latest', conv_key, phase)
+    voted = set(votes['tid'])
+    out = statements[~statements['tid'].isin(voted)][['tid', 'txt', 'mod', 'is_seed']]
+    return out.reset_index(drop=True)
+
+
+def redundant_pairs(b: Bundles, conv_key: str, pairs: pd.DataFrame, *,
+                    text_threshold: float = SIMILARITY_THRESHOLD,
+                    concordance: float = 0.9, min_common: int = 5,
+                    phase: int = 2) -> pd.DataFrame:
+    """Which similar-looking statements are genuinely the *same* statement.
+
+    Text similarity alone is not enough and gets this badly wrong: "at least a
+    thousand edits" and "at least five hundred edits" score 0.976 together while
+    proposing different things. Merging that pair would delete a real disagreement.
+
+    So similarity only nominates a pair; the votes decide. Among people who voted
+    decisively on both, a pair is redundant when they voted the *same* way almost
+    every time — then the second column carries no information the first does not,
+    and counting it twice simply doubles that proposition's weight in the maths.
+    Where too few people voted on both to tell, the pair is left alone: keeping a
+    real distinction is the safer error.
+    """
+    votes = b.phase('votes_latest', conv_key, phase)
+    decisive = votes[votes['vote'].isin([RAW_AGREE, RAW_DISAGREE])]
+    unvoted = set(unvoted_statements(b, conv_key, phase)['tid'])
+
+    rows = []
+    for pair in pairs[pairs['similarity'] >= text_threshold].itertuples():
+        a, bb = int(pair.tid_a), int(pair.tid_b)
+        va = decisive[decisive['tid'] == a][['person_key', 'vote']]
+        vb = decisive[decisive['tid'] == bb][['person_key', 'vote']]
+        both = va.merge(vb, on='person_key', suffixes=('_a', '_b'))
+        n = len(both)
+        agree = float((both['vote_a'] == both['vote_b']).mean()) if n else float('nan')
+
+        # Wording differences that carry no meaning are settled without votes: if the
+        # two say the same thing once spelling and number-format are normalised, they
+        # are the same statement whatever anybody did or did not vote. Where the
+        # meaning might genuinely differ and the votes cannot settle it, they stay
+        # apart — keeping a real distinction is the safer error.
+        same_after_normalising = normalise_text(pair.text_a) == normalise_text(pair.text_b)
+
+        # Normalisation is checked first: two statements that differ only in spelling
+        # are the same statement, and that is true whether or not anyone voted.
+        if same_after_normalising:
+            verdict = 'redundant — identical apart from spelling or number format'
+        elif a in unvoted or bb in unvoted:
+            verdict = 'set aside — nobody voted on one of them'
+        elif n < min_common:
+            verdict = 'undecided — too few voted on both'
+        elif agree >= concordance:
+            verdict = 'redundant — same statement, reworded'
+        else:
+            verdict = 'distinct — people voted differently on them' 
+        rows.append({'tid_a': a, 'tid_b': bb, 'similarity': round(pair.similarity, 3),
+                     'n_common': n,
+                     'vote_concordance': round(agree, 3) if agree == agree else np.nan,
+                     'verdict': verdict, 'text_a': pair.text_a, 'text_b': pair.text_b})
+    return pd.DataFrame(rows).sort_values('similarity', ascending=False).reset_index(drop=True)
+
+
+def deduplication_map(redundant: pd.DataFrame, tids: list[int]) -> dict[int, int]:
+    """{tid: representative tid}, merging only pairs judged redundant."""
+    parent = {int(t): int(t) for t in tids}
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for row in redundant[redundant['verdict'].str.startswith('redundant')].itertuples():
+        a, bb = int(row.tid_a), int(row.tid_b)
+        if a in parent and bb in parent:
+            ra, rb = find(a), find(bb)
+            if ra != rb:
+                parent[rb] = ra
+    return {t: find(t) for t in parent}
+
+
+#: Communities of one person are outliers, not groups. OSLOM calls these "homeless"
+#: nodes — vertices not significantly linked to any cluster — and Infomap refuses to
+#: emit singletons at all. Reporting "a group of 1" invites a reader to treat one
+#: person as a faction.
+MIN_COMMUNITY_SIZE = 2
+
+
+def split_outliers(labels: dict) -> tuple[dict, list]:
+    """Separate real communities from single-person outliers."""
+    sizes = collections.Counter(labels.values())
+    outliers = [p for p, g in labels.items() if sizes[g] < MIN_COMMUNITY_SIZE]
+    kept = {p: g for p, g in labels.items() if sizes[g] >= MIN_COMMUNITY_SIZE}
+    return kept, outliers
+
+
+def multilayer_leiden(layer_matrices: list, pids: list, *, resolution: float = 1.0,
+                      seed: int = 20260606, min_overlap: int = 3):
+    """Leiden over several layers at once, the way the multilayer literature does it.
+
+    One graph per topic, all on the same set of people, optimised jointly rather than
+    separately-then-combined. This is the direct multilayer method (Mucha et al.);
+    the alternative — clustering each layer and merging the results through a
+    co-classification matrix — is Lancichinetti–Fortunato consensus clustering, which
+    is designed for combining repeated runs of one algorithm for robustness, not for
+    data that is genuinely layered.
+
+    The distinction matters here: consensus clustering asks "where do these partitions
+    agree?", which presumes one underlying partition. Multilayer modularity allows the
+    layers to disagree and scores the result accordingly.
+    """
+    import igraph as ig
+    import leidenalg
+
+    graphs = []
+    for values in layer_matrices:
+        holder = Matrix(conv_key='layer', phase=2, values=values, pids=pids,
+                        tids=list(range(values.shape[1])), person_keys=[])
+        graph_pids, weights, _ = agreement_graph(holder, min_overlap=min_overlap)
+        index = {p: i for i, p in enumerate(graph_pids)}
+        edges, edge_weights = [], []
+        for i in range(len(pids)):
+            for j in range(i + 1, len(pids)):
+                a, bb = index.get(pids[i]), index.get(pids[j])
+                if a is None or bb is None:
+                    continue
+                if weights[a, bb] > 0:
+                    edges.append((i, j))
+                    edge_weights.append(float(weights[a, bb]))
+        graph = ig.Graph(n=len(pids), edges=edges)
+        graph.es['weight'] = edge_weights
+        graphs.append(graph)
+
+    if not graphs:
+        return {}, float('nan')
+    membership, _improvement = leidenalg.find_partition_multiplex(
+        graphs, leidenalg.RBConfigurationVertexPartition,
+        resolution_parameter=resolution, weights='weight', seed=seed)
+
+    # NOT the second return value: that is the optimiser's improvement, which is
+    # unbounded and not comparable with anything. Score the joint partition by the
+    # modularity it achieves in each layer, and report the mean — directly comparable
+    # with the single-layer numbers above it.
+    per_layer = []
+    for graph in graphs:
+        if graph.ecount():
+            per_layer.append(graph.modularity(membership, weights='weight'))
+    quality = float(np.mean(per_layer)) if per_layer else float('nan')
+    return {pids[i]: int(c) for i, c in enumerate(membership)}, quality
+
+
+def method_ladder(b: Bundles, conv_key: str, *, phase: int = 2, n_topics: int = 5) -> dict:
+    """Both grouping methods at three levels of refinement, side by side.
+
+    The levels are cumulative, and every one of them starts from a matrix with
+    statements nobody voted on already removed — those carry no information at any
+    level, so including them would only be a fourth way of being wrong.
+
+      naive        the method as the tool applies it
+      deduplicated near-identical statements merged, so one proposition written
+                   several ways stops counting several times
+      layered      statements split into topics, each topic grouped on its own, and
+                   the results combined by how often two people land together across
+                   topics. This is the only level that can represent people who
+                   agree on one subject and disagree on another; a single partition
+                   cannot.
+
+    Reported per cell: how many groups, their sizes, the method's own quality score,
+    and how far the result has moved from the naive version. Comparing a method
+    against itself down the column shows how much of the answer was an artefact of
+    the preprocessing rather than the opinions.
+    """
+    import warnings as _w
+
+    from sklearn.cluster import AgglomerativeClustering
+    from sklearn.metrics import adjusted_rand_score
+
+    import pipeline as P
+    from analysis.polis_replica import run_replica
+
+    matrix = P.build_matrix(b, conv_key, phase)          # unvoted already dropped
+    counts = P.real_vote_counts(b, conv_key, phase)
+    eligible = [p for p in matrix.pids
+                if counts.get(p, 0) >= P.POLIS_VOTE_THRESHOLD]
+    rows_idx = [i for i, p in enumerate(matrix.pids) if p in set(eligible)]
+    base = matrix.values[rows_idx, :]
+    tids = list(matrix.tids)
+
+    groups, pairs = similar_statement_groups(b, conv_key)
+    redundant = redundant_pairs(b, conv_key, pairs)
+    mapping = deduplication_map(redundant, tids)
+    column = {t: j for j, t in enumerate(tids)}
+    merged: dict[int, list[int]] = {}
+    for tid in tids:
+        merged.setdefault(mapping[tid], []).append(column[tid])
+    dedup_keys = sorted(merged)
+    dedup = np.full((len(eligible), len(dedup_keys)), np.nan)
+    for j, key in enumerate(dedup_keys):
+        with _w.catch_warnings():
+            _w.simplefilter('ignore')
+            dedup[:, j] = np.nanmean(base[:, merged[key]], axis=1)
+
+    statements = b.phase('statements', conv_key, phase).set_index('tid')
+    texts = [statements['txt'].get(t, '') for t in dedup_keys]
+    vectors = embed_statements(texts)
+    topics = AgglomerativeClustering(n_clusters=min(n_topics, len(texts) - 1),
+                                     metric='cosine', linkage='average'
+                                     ).fit_predict(vectors)
+
+    def kmeans_partition(values):
+        result = run_replica(values)
+        labels = {eligible[i]: int(x) for i, x in enumerate(result['labels']) if x != -1}
+        quality = result.get('silhouettes', {}).get(result['K'], float('nan'))
+        return labels, result['K'], quality
+
+    def leiden_partition(values):
+        holder = Matrix(conv_key=conv_key, phase=phase, values=values, pids=eligible,
+                        tids=list(range(values.shape[1])), person_keys=[])
+        pids, weights, _ = agreement_graph(holder, min_overlap=3)
+        if (weights > 0).sum() == 0:
+            return {}, 0, float('nan')
+        best = (-9.0, None)
+        for resolution in (0.8, 1.0, 1.2):
+            labels, modularity = leiden_communities(pids, weights, resolution=resolution)
+            if modularity > best[0]:
+                best = (modularity, labels)
+        labels = best[1] or {}
+        return labels, len(set(labels.values())), best[0]
+
+    def layered(values, partition_fn):
+        """Group inside each topic, then combine by how often two people co-occur."""
+        n = len(eligible)
+        together = np.zeros((n, n))
+        used = 0
+        for topic in sorted(set(topics)):
+            cols = [j for j, t in enumerate(topics) if t == topic]
+            if len(cols) < 4:
+                continue
+            labels, k, _ = partition_fn(values[:, cols])
+            if k < 2:
+                continue
+            member = np.array([labels.get(p, -1) for p in eligible])
+            same = (member[:, None] == member[None, :]) & (member[:, None] >= 0)
+            together += same.astype(float)
+            used += 1
+        if used < 2:
+            return {}, 0, float('nan'), used
+        together /= used
+        distance = 1 - together
+        np.fill_diagonal(distance, 0.0)
+        best = (-9.0, None, 0)
+        for k in (2, 3, 4):
+            labels = AgglomerativeClustering(n_clusters=k, metric='precomputed',
+                                             linkage='average').fit_predict(distance)
+            # How cleanly the layers agree on this grouping: mean co-occurrence
+            # inside groups minus mean co-occurrence between them.
+            inside, between = [], []
+            for i in range(n):
+                for j in range(i + 1, n):
+                    (inside if labels[i] == labels[j] else between).append(together[i, j])
+            score = (np.mean(inside) - np.mean(between)) if inside and between else np.nan
+            if score == score and score > best[0]:
+                best = (score, labels, k)
+        if best[1] is None:
+            return {}, 0, float('nan'), used
+        return ({eligible[i]: int(x) for i, x in enumerate(best[1])},
+                best[2], best[0], used)
+
+    rows, partitions = [], {}
+    for method, fn, quality_name in (('k-means on the opinion map', kmeans_partition, 'silhouette'),
+                                     ('Leiden communities', leiden_partition, 'modularity')):
+        naive_labels = None
+        for level, values in (('naive', base), ('deduplicated', dedup)):
+            labels, k, quality = fn(values)
+            if naive_labels is None:
+                naive_labels, ari = labels, 1.0
+            else:
+                shared = [p for p in labels if p in naive_labels]
+                ari = (adjusted_rand_score([naive_labels[p] for p in shared],
+                                           [labels[p] for p in shared])
+                       if len(shared) > 1 else float('nan'))
+            labels, outliers = split_outliers(labels)
+            k = len(set(labels.values()))
+            partitions[(method, level)] = labels
+            rows.append({'method': method, 'level': level,
+                         'statements': values.shape[1], 'groups': k,
+                         'group sizes (people)': ' / '.join(str(v) for v in sorted(
+                             pd.Series(list(labels.values())).value_counts().values,
+                             reverse=True)) if labels else '—',
+                         'unplaced (people)': len(outliers),
+                         'quality': round(quality, 3) if quality == quality else np.nan,
+                         'quality is': quality_name,
+                         'agreement with naive (ARI)': round(ari, 3) if ari == ari else np.nan})
+        if method.startswith('Leiden'):
+            layer_values, used = [], 0
+            for topic in sorted(set(topics)):
+                cols = [j for j, t in enumerate(topics) if t == topic]
+                if len(cols) >= 4:
+                    layer_values.append(dedup[:, cols])
+                    used += 1
+            labels, score = (multilayer_leiden(layer_values, eligible)
+                             if used >= 2 else ({}, float('nan')))
+            labels, outliers = split_outliers(labels)
+            k = len(set(labels.values()))
+        else:
+            labels, k, score, used = layered(dedup, fn)
+            labels, outliers = split_outliers(labels)
+            k = len(set(labels.values()))
+        shared = [p for p in labels if p in naive_labels]
+        ari = (adjusted_rand_score([naive_labels[p] for p in shared],
+                                   [labels[p] for p in shared])
+               if len(shared) > 1 else float('nan'))
+        partitions[(method, 'layered')] = labels
+        rows.append({'method': method, 'level': f'layered ({used} topics)',
+                     'statements': dedup.shape[1], 'groups': k,
+                     'group sizes (people)': ' / '.join(str(v) for v in sorted(
+                         pd.Series(list(labels.values())).value_counts().values,
+                         reverse=True)) if labels else '—',
+                     'unplaced (people)': len(outliers),
+                     'quality': round(score, 3) if score == score else np.nan,
+                     'quality is': ('multilayer modularity'
+                                    if method.startswith('Leiden') else 'layer agreement'),
+                     'agreement with naive (ARI)': round(ari, 3) if ari == ari else np.nan})
+
+    return {'table': pd.DataFrame(rows), 'partitions': partitions,
+            'eligible': eligible, 'n_topics': len(set(topics))}
+
+
+def shuffle_within_statements(values: np.ndarray, rng) -> np.ndarray:
+    """Permute each statement's votes across people.
+
+    Preserves how many people voted on each statement and how that statement's
+    agree/disagree balance looks, while destroying any relationship *between*
+    statements. So a shuffled dataset is what this conversation would look like if
+    people's opinions on one statement told you nothing about their opinions on
+    another — i.e. no groups, same overall shape.
+    """
+    out = values.copy()
+    for j in range(out.shape[1]):
+        column = out[:, j]
+        voted = ~np.isnan(column)
+        if voted.sum() > 1:
+            picks = column[voted].copy()
+            rng.shuffle(picks)
+            column[voted] = picks
+    return out
+
+
+def significance_of_grouping(values: np.ndarray, pids: list, score_fn,
+                             *, n_permutations: int = 100, seed: int = 20260606) -> dict:
+    """Could this grouping have arisen from votes with no group structure at all?
+
+    A clustering method always returns a score, and on 22 people that score is often
+    respectable by luck alone. The only way to know whether it means anything is to
+    run the identical procedure on data known to have no structure, and see how often
+    chance does as well.
+
+    p is the fraction of shuffled datasets scoring at least as high as the real one
+    (with the standard +1 correction, so p is never reported as 0). A large p means
+    the grouping is indistinguishable from one computed on noise — which is not the
+    same as proving no groups exist, but does mean this data cannot show them.
+    """
+    rng = np.random.default_rng(seed)
+    observed = score_fn(values, pids)
+    if observed != observed:
+        return {'observed': float('nan'), 'p_value': float('nan'), 'null_scores': []}
+
+    null = []
+    for _ in range(n_permutations):
+        score = score_fn(shuffle_within_statements(values, rng), pids)
+        if score == score:
+            null.append(score)
+    if not null:
+        return {'observed': observed, 'p_value': float('nan'), 'null_scores': []}
+
+    at_least_as_good = sum(1 for s in null if s >= observed)
+    return {
+        'observed': round(float(observed), 4),
+        'null_median': round(float(np.median(null)), 4),
+        'null_95th': round(float(np.percentile(null, 95)), 4),
+        'n_permutations': len(null),
+        'p_value': round((at_least_as_good + 1) / (len(null) + 1), 4),
+        'null_scores': null,
+    }

--- a/private/analysis/pipeline.py
+++ b/private/analysis/pipeline.py
@@ -1,0 +1,1025 @@
+"""Analysis pipeline over a pair of wiki-polis export bundles.
+
+The logic behind `wiki_polis_analysis.ipynb`, kept in a module so it can be tested
+and re-run without a kernel. Nothing here touches a database — it reads only the
+de-identified bundles produced by the two exporters.
+
+Governing principle: **stay as close to the server as possible.**
+
+  * The headline clustering is the server's own (`math_main.data`, written by the
+    stock polis-math Clojure service). We read it; we never recompute it.
+  * `polis_replica.run_replica` — the pinned Python port of `pca.clj` /
+    `clusters.clj` / `conversation.clj` in the polis-study repo — is used only to
+    (a) demonstrate we can reproduce the server's answer on this data, and
+    (b) run counterfactuals the server cannot run.
+  * Every counterfactual is gated on (a). A conversation whose server result we
+    cannot reproduce reports server labels only.
+
+Matrix policy follows polis-study's `matrix_policy.CLOJURE_FAITHFUL`:
+owner included, `mod = -1` columns zeroed whole-column, raw Polis signs kept
+(-1 agree / +1 disagree / 0 pass).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import warnings
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+# polis-study holds the faithful replica. Overridable for a checkout elsewhere.
+POLIS_STUDY = Path(os.environ.get(
+    'POLIS_STUDY_DIR',
+    Path.home() / 'Documents' / 'GitHub' / 'polis-study'))
+if str(POLIS_STUDY) not in sys.path:
+    sys.path.insert(0, str(POLIS_STUDY))
+
+RAW_AGREE, RAW_DISAGREE, RAW_PASS = -1, 1, 0
+EXPECTED_SCHEMA_VERSION = 1
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Thresholds. Every cutoff the analysis applies is declared here, so that what
+# counts as a participant is a stated decision rather than a number buried in a
+# function. The engine-derived ones are marked: changing those makes the analysis
+# describe something other than what Polis did.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# --- from the Polis engine (conversation.clj) — do not change to taste ---------
+
+#: Votes needed to be clustered. The engine uses min(this, number of statements),
+#: so in a short conversation the effective cutoff is lower. This is also the
+#: cutoff the analysis uses to decide who counts as a participant, so that the two
+#: agree by construction.
+POLIS_VOTE_THRESHOLD = 7
+
+#: If fewer than this many people clear the threshold, the engine tops the set up
+#: with the next-highest voters regardless. This is why people with 2–6 votes can
+#: appear in a clustering, and — because the engine's in-conv set is cumulative
+#: and never shrinks — why they stay there for the rest of the conversation.
+POLIS_GREEDY_N = 15
+
+#: Upper bound on the number of opinion groups: min(this, 2 + in_conv // 12).
+POLIS_MAX_K = 5
+
+# --- our own choices ----------------------------------------------------------
+
+#: A vote landing within this many milliseconds of its statement being created was
+#: not cast by a person. Observed machine lags are 5–51 ms; the nearest human vote
+#: is orders of magnitude slower, so the gap is wide and the exact value is not
+#: delicate.
+MACHINE_LAG_MS = 2000
+
+#: Steps reported in the attrition table. Presentation only — no analysis depends
+#: on these, and POLIS_VOTE_THRESHOLD is what actually filters.
+FUNNEL_THRESHOLDS = (1, 5, POLIS_VOTE_THRESHOLD, 10, 20)
+
+#: Agreement with the server's own clustering required before any counterfactual
+#: is reported. Below this we report the server's result and stop.
+REPRODUCTION_ARI = 0.95
+
+#: Cosine similarity above which two statements are treated as the same
+#: proposition reworded. Check it against the actual similarity distribution
+#: before trusting it — it should be cutting a visible gap, not an arbitrary point.
+SIMILARITY_THRESHOLD = 0.85
+
+#: Statements two people must both have voted on before their agreement is used as
+#: a graph edge. Below this, agreement is noise.
+MIN_PAIR_OVERLAP = 5
+
+#: People who voted decisively on both wordings before a head-to-head is tested at
+#: all. Thin pairs are still listed, but excluded from the headline.
+MIN_DECIDED_FOR_HEAD_TO_HEAD = 8
+
+
+# ── loading ──────────────────────────────────────────────────────────────────
+
+@dataclass
+class Bundles:
+    """A loaded (polis, app) bundle pair."""
+    root: Path
+    manifest_polis: dict
+    manifest_app: dict
+    polis: dict[str, pd.DataFrame]
+    app: dict[str, pd.DataFrame]
+    math: dict[tuple[str, int], dict]
+
+    @property
+    def conversations(self) -> list[str]:
+        return sorted(self.app['conversations']['conv_key'].tolist())
+
+    # Populated by load_bundles: {(conv_key, phase): {pid: reason}}. Machine-made
+    # participants are filtered out of every `phase()` read by default, so no
+    # analysis has to remember to exclude them. Set `include_machine=True` to get
+    # them back — needed only to reproduce what the server's own maths did, since
+    # the server counted them.
+    machine: dict = field(default_factory=dict)
+    include_machine: bool = False
+
+    def phase(self, name: str, conv_key: str, phase: int,
+              include_machine: bool | None = None) -> pd.DataFrame:
+        df = self.polis[name]
+        out = df[(df['conv_key'] == conv_key) & (df['phase'] == phase)].copy()
+        keep_machine = self.include_machine if include_machine is None else include_machine
+        if keep_machine or 'pid' not in out.columns:
+            return out
+        drop = set(self.machine.get((conv_key, phase), {}))
+        return out[~out['pid'].isin(drop)] if drop else out
+
+    def has_phase6(self, conv_key: str) -> bool:
+        return (conv_key, 6) in self.math or not self.phase('votes_latest', conv_key, 6).empty
+
+
+def load_bundles(root) -> Bundles:
+    root = Path(root)
+    manifest_polis = json.loads((root / 'manifest_polis.json').read_text())
+    manifest_app = json.loads((root / 'manifest_app.json').read_text())
+
+    for name, manifest in (('polis', manifest_polis), ('app', manifest_app)):
+        if manifest['schema_version'] != EXPECTED_SCHEMA_VERSION:
+            raise ValueError(
+                f'{name} bundle is schema v{manifest["schema_version"]}, '
+                f'this pipeline expects v{EXPECTED_SCHEMA_VERSION}')
+
+    if manifest_polis['salt_id'] != manifest_app['salt_id']:
+        raise ValueError(
+            f'salt mismatch: polis bundle salt_id={manifest_polis["salt_id"]}, '
+            f'app bundle salt_id={manifest_app["salt_id"]} — the two hosts used '
+            'different salts, so person_keys cannot be joined. Re-export with the '
+            'same salt file.')
+    if manifest_polis['env'] != manifest_app['env']:
+        raise ValueError(f'env mismatch: {manifest_polis["env"]} vs {manifest_app["env"]}')
+
+    polis = {name: pd.read_csv(root / 'polis' / f'{name}.csv')
+             for name in ('conversations', 'participants', 'statements',
+                          'votes_latest', 'votes_history')}
+    app = {}
+    for name in ('conversations', 'featured_statements', 'statement_provenance',
+                 'statement_similarity', 'arguments', 'argument_votes', 'people'):
+        path = root / 'app' / f'{name}.csv'
+        app[name] = pd.read_csv(path) if path.exists() else pd.DataFrame()
+
+    # The salt check above passes whenever both halves used the same salt file — but
+    # they can still hash *different values* under it, which is exactly what happened
+    # when the app side hashed the raw xid and the Polis side the conversation-scoped
+    # subject. The keys looked well-formed on both sides and joined to nothing, and
+    # every pseudonym-linked result silently became empty rather than wrong. Assert the
+    # join actually exists, once, at load.
+    if not app['people'].empty:
+        linked = {k for k in polis['participants']['person_key'].dropna()
+                  if not str(k).startswith('anon-')}
+        overlap = set(app['people']['person_key'].dropna()) & linked
+        if linked and not overlap:
+            message = (
+                f'person_key join is empty: {len(app["people"])} people in the app '
+                f'bundle, {len(linked)} identity-linked participants in the polis '
+                f'bundle, 0 in common. The two halves hashed different values under '
+                f'the same salt — the app side must hash the conversation-scoped '
+                f'subject (see bundle.conversation_subject), not the raw xid. '
+                f'Re-export the app half; the polis half is unaffected.')
+            # Bundles predating the fix cannot join and never will, so refusing to load
+            # them would strand every report built from data already exported. They
+            # warn. A bundle whose manifest carries `sub_secret_id` was built by the
+            # fixed exporter and has no excuse — that one is an error.
+            if manifest_app.get('sub_secret_id'):
+                raise ValueError(message)
+            warnings.warn(f'{message} (bundle predates the fix — pseudonym-linked '
+                          f'results will be empty)', stacklevel=2)
+
+    math = {}
+    math_dir = root / 'polis' / 'math_main'
+    if math_dir.exists():
+        for path in sorted(math_dir.glob('*.json')):
+            payload = json.loads(path.read_text())
+            math[(payload['conv_key'], int(payload['phase']))] = payload
+
+    bundles = Bundles(root=root, manifest_polis=manifest_polis,
+                      manifest_app=manifest_app, polis=polis, app=app, math=math)
+
+    # Identify machine-made participants once, at load, so nothing downstream has to
+    # remember. Detection needs a fully built Bundles, hence the second pass with
+    # filtering switched off.
+    bundles.include_machine = True
+    for conv_key in sorted(set(polis['conversations']['conv_key'])):
+        for phase in sorted(set(polis['conversations']['phase'])):
+            found = machine_participants(bundles, conv_key, int(phase))
+            if found:
+                bundles.machine[(conv_key, int(phase))] = found
+    bundles.include_machine = False
+    return bundles
+
+
+# ── integrity gate ───────────────────────────────────────────────────────────
+
+@dataclass
+class Check:
+    name: str
+    passed: bool
+    detail: str = ''
+
+    def __str__(self) -> str:
+        return f'[{"PASS" if self.passed else "FAIL"}] {self.name}' + (
+            f' — {self.detail}' if self.detail else '')
+
+
+def integrity_checks(b: Bundles) -> list[Check]:
+    """Assertions run identically on a local test export and a production one.
+
+    A failure here on server data that passed locally is a *data* finding, not a
+    pipeline bug — which is the whole point of running both through one harness.
+    """
+    checks: list[Check] = []
+
+    votes = pd.concat([b.phase('votes_latest', c, p)
+                       for c in b.conversations for p in (2, 6)], ignore_index=True)
+    bad = sorted(set(votes['vote'].unique()) - {RAW_AGREE, RAW_DISAGREE, RAW_PASS})
+    checks.append(Check('vote values are raw Polis signs {-1,0,1}', not bad,
+                        f'unexpected values: {bad}' if bad else
+                        f'{len(votes):,} current votes'))
+
+    stmt_keys = set(map(tuple, b.polis['statements'][['conv_key', 'phase', 'tid']].values))
+    vote_keys = set(map(tuple, votes[['conv_key', 'phase', 'tid']].values))
+    orphan_votes = vote_keys - stmt_keys
+    checks.append(Check('every vote targets a known statement', not orphan_votes,
+                        f'{len(orphan_votes)} orphan (conv, phase, tid) combinations'
+                        if orphan_votes else ''))
+
+    part_keys = set(map(tuple, b.polis['participants'][['conv_key', 'phase', 'pid']].values))
+    vote_pids = set(map(tuple, votes[['conv_key', 'phase', 'pid']].values))
+    orphan_pids = vote_pids - part_keys
+    checks.append(Check('every vote has a participant row', not orphan_pids,
+                        f'{len(orphan_pids)} pids voting without a participants row'
+                        if orphan_pids else ''))
+
+    # The votes RULE that maintains votes_latest_unique is known to drift; the
+    # Polis schema even ships a repair query for it. Rebuild and compare.
+    history = pd.concat([b.phase('votes_history', c, p)
+                         for c in b.conversations for p in (2, 6)], ignore_index=True)
+    if history.empty:
+        checks.append(Check('votes_latest_unique matches the vote history', True,
+                            'no history exported — skipped'))
+    else:
+        rebuilt = (history.sort_values('created_ms')
+                          .groupby(['conv_key', 'phase', 'pid', 'tid'], as_index=False)
+                          .last()[['conv_key', 'phase', 'pid', 'tid', 'vote']])
+        merged = rebuilt.merge(votes[['conv_key', 'phase', 'pid', 'tid', 'vote']],
+                               on=['conv_key', 'phase', 'pid', 'tid'],
+                               how='outer', suffixes=('_rebuilt', '_stored'),
+                               indicator=True)
+        drift = merged[(merged['_merge'] != 'both') |
+                       (merged['vote_rebuilt'] != merged['vote_stored'])]
+        checks.append(Check('votes_latest_unique matches the vote history', drift.empty,
+                            f'{len(drift)} row(s) differ — the on_vote_insert RULE has '
+                            'drifted; see the repair query in the Polis schema'
+                            if not drift.empty else f'{len(rebuilt):,} rows agree'))
+
+    # Provenance: parents must exist as Phase 2 statements in the same conversation.
+    prov = b.app['statement_provenance']
+    if prov.empty:
+        checks.append(Check('every derived_from_tid resolves to a statement', True,
+                            'no provenance rows in this export — skipped'))
+    else:
+        phase2 = {(r.conv_key, r.tid) for r in
+                  b.polis['statements'][b.polis['statements']['phase'] == 2].itertuples()}
+        missing = [(r.conv_key, r.derived_from_tid) for r in prov.itertuples()
+                   if (r.conv_key, r.derived_from_tid) not in phase2]
+        checks.append(Check('every derived_from_tid resolves to a statement', not missing,
+                            f'unresolved parents: {missing[:5]}' if missing
+                            else f'{len(prov)} provenance link(s)'))
+        self_links = prov[prov['polis_statement_id'] == prov['derived_from_tid']]
+        checks.append(Check('no statement is its own parent', self_links.empty,
+                            f'{len(self_links)} self-link(s)' if not self_links.empty else ''))
+
+    # The Phase 2 ↔ Phase 6 statement bridge.
+    featured = b.app['featured_statements']
+    for conv_key in b.conversations:
+        if not b.has_phase6(conv_key):
+            continue
+        conf = featured[(featured['conv_key'] == conv_key) & featured['confirmed_by_admin']]
+        # tid 0 is a real tid: test for null, never for truthiness.
+        bridged = conf['phase6_polis_statement_id'].notna().sum()
+        checks.append(Check(f'{conv_key}: confirmed featured statements bridged to Phase 6',
+                            bridged == len(conf),
+                            f'{bridged}/{len(conf)} bridged'))
+
+    for conv_key in b.conversations:
+        for phase in (2, 6):
+            if (conv_key, phase) not in b.math and not b.phase('votes_latest', conv_key, phase).empty:
+                checks.append(Check(f'{conv_key} phase {phase}: math_main present', False,
+                                    'no math_main row — the math service has not run, or '
+                                    'the conversation was exported before it did'))
+    return checks
+
+
+# ── machine-generated participants ───────────────────────────────────────────
+
+def machine_participants(b: Bundles, conv_key: str, phase: int = 2,
+                         max_lag_ms: int = MACHINE_LAG_MS) -> dict[int, str]:
+    """Participants that are not people. Returns {pid: reason}.
+
+    Submitting a statement through wiki-polis opens a Particiapi session without
+    asserting the author's identity, so Particiapi's "agree with your own statement"
+    lands on a fresh unbound uid. Polis then holds a participant row with votes and
+    no way to tell it apart from a person — its own maths counts it.
+
+    Detection is behavioural, not identity-based: a participant qualifies only if
+    *every* vote it cast landed within `max_lag_ms` of that statement being created.
+    Observed lags here are 5–51 ms; no human votes that fast, and no human votes only
+    that fast. Using `identity_linked` alone would be wrong — a real person can lack
+    an identity record for unrelated reasons, and would then be silently deleted.
+    """
+    votes = b.phase('votes_latest', conv_key, phase)
+    statements = b.phase('statements', conv_key, phase)
+    if votes.empty or statements.empty:
+        return {}
+
+    created = dict(zip(statements['tid'], statements['created_ms']))
+    seeds = set(statements.loc[statements['is_seed'].astype(bool), 'tid'])
+
+    flagged: dict[int, str] = {}
+    for pid, block in votes.groupby('pid'):
+        lags = [row.modified_ms - created.get(row.tid, row.modified_ms)
+                for row in block.itertuples()]
+        if not lags or max(lags) > max_lag_ms or min(lags) < 0:
+            continue
+        on_seeds = sum(1 for row in block.itertuples() if row.tid in seeds)
+        flagged[int(pid)] = ('seeding account — passes on seed statements only'
+                             if on_seeds == len(block)
+                             else 'statement-author auto-agree')
+    return flagged
+
+
+def auto_agree_votes(b: Bundles, conv_key: str, phase: int = 2,
+                     max_lag_ms: int = MACHINE_LAG_MS) -> dict:
+    """The automatic agreement the tool records when a statement is submitted.
+
+    Submitting a statement — new, or a reworded version of another — registers an
+    agree vote on it on the submitter's behalf. Those votes are indistinguishable
+    from considered ones in the vote table, so they are identified the same way
+    machine accounts are: by landing within `max_lag_ms` of the statement being
+    created. Nobody reads and votes that fast.
+
+    Where they land decides whether they count. An auto-agree on an unbound session
+    lands on a machine pid and is dropped with it; one on a properly bound account
+    lands on the author and is counted as an ordinary agree vote, inflating that
+    statement's support by one. The reports say which happened rather than assuming,
+    because it depends on a bug whose fix would change the answer.
+
+    Authorship is not in the export, so this cannot say who submitted what — only
+    how many of these votes exist and whether they survive into the analysis.
+    """
+    votes = b.phase('votes_latest', conv_key, phase, include_machine=True)
+    statements = b.phase('statements', conv_key, phase, include_machine=True)
+    if votes.empty or statements.empty:
+        return {'total': 0, 'on_machine': 0, 'on_real': 0, 'statements': 0}
+
+    created = dict(zip(statements['tid'], statements['created_ms']))
+    lag = votes['modified_ms'] - votes['tid'].map(created)
+    auto = votes[(lag >= 0) & (lag <= max_lag_ms)]
+    machine = set(b.machine.get((conv_key, phase), {}))
+    on_machine = int(auto['pid'].isin(machine).sum())
+    return {'total': len(auto), 'on_machine': on_machine,
+            'on_real': len(auto) - on_machine,
+            'statements': int(auto['tid'].nunique())}
+
+
+# ── matrix build (matrix_policy.CLOJURE_FAITHFUL) ────────────────────────────
+
+@dataclass
+class Matrix:
+    conv_key: str
+    phase: int
+    values: np.ndarray                 # (n_ptpt, n_cmt), NaN = did not vote
+    pids: list[int]
+    tids: list[int]
+    person_keys: list[str]
+    notes: dict = field(default_factory=dict)
+
+    @property
+    def density(self) -> float:
+        return float(np.mean(~np.isnan(self.values)))
+
+
+def build_matrix(b: Bundles, conv_key: str, phase: int, *,
+                 mod_out: str = 'zero', include_owner: bool = True,
+                 restrict_tids: list[int] | None = None,
+                 include_machine: bool = False, drop_unvoted: bool = True) -> Matrix:
+    """Participant × statement matrix under the Clojure-faithful policy.
+
+    mod_out: 'zero'  — whole column of a `mod = -1` statement set to 0, including
+                       non-voters (named_matrix/zero-out-columns). The default and
+                       the only engine-faithful option.
+             'keep'  — leave the real votes in place.
+             'drop'  — remove the column entirely.
+    """
+    if mod_out not in ('zero', 'keep', 'drop'):
+        raise ValueError(f'mod_out must be zero|keep|drop, got {mod_out!r}')
+
+    votes = b.phase('votes_latest', conv_key, phase, include_machine=include_machine)
+    statements = b.phase('statements', conv_key, phase)
+    participants = b.phase('participants', conv_key, phase,
+                           include_machine=include_machine)
+    if votes.empty:
+        raise LookupError(f'{conv_key} phase {phase}: no votes in this bundle')
+
+    tids = sorted(statements['tid'].tolist())
+    if restrict_tids is not None:
+        keep = set(restrict_tids)
+        tids = [t for t in tids if t in keep]
+    moderated_out = set(statements.loc[statements['mod'] == -1, 'tid'])
+    if mod_out == 'drop':
+        tids = [t for t in tids if t not in moderated_out]
+
+    pids = sorted(participants['pid'].tolist())
+    if not include_owner and pids:
+        pids = [p for p in pids if p != 0]
+
+    pid_row = {pid: i for i, pid in enumerate(pids)}
+    tid_col = {tid: j for j, tid in enumerate(tids)}
+    values = np.full((len(pids), len(tids)), np.nan)
+    for row in votes.itertuples():
+        i, j = pid_row.get(row.pid), tid_col.get(row.tid)
+        if i is not None and j is not None:
+            values[i, j] = row.vote
+
+    # Statements nobody voted on carry no information: they are an empty column that
+    # the engine fills with zeros. Dropping them does not change the grouping, but it
+    # stops the statement count overstating what was actually deliberated. They are
+    # still reported to the organiser — an unvoted proposal is a finding about
+    # exposure, not something to hide.
+    dropped_unvoted = 0
+    if drop_unvoted:
+        voted = set(votes['tid'])
+        keep = [j for j, tid in enumerate(tids) if tid in voted]
+        dropped_unvoted = len(tids) - len(keep)
+        if dropped_unvoted:
+            values = values[:, keep]
+            tids = [tids[j] for j in keep]
+            tid_col = {tid: j for j, tid in enumerate(tids)}
+
+    zeroed = 0
+    if mod_out == 'zero':
+        for tid in moderated_out & set(tid_col):
+            values[:, tid_col[tid]] = 0.0     # whole column, non-voters included
+            zeroed += 1
+
+    key_by_pid = dict(zip(participants['pid'], participants['person_key']))
+    return Matrix(
+        conv_key=conv_key, phase=phase, values=values, pids=pids, tids=tids,
+        person_keys=[key_by_pid.get(p, '') for p in pids],
+        notes={'mod_out': mod_out, 'include_owner': include_owner,
+               'n_moderated_out': len(moderated_out), 'n_columns_zeroed': zeroed,
+               'n_unvoted_dropped': dropped_unvoted,
+               'restricted': restrict_tids is not None},
+    )
+
+
+# ── the server's own clustering ──────────────────────────────────────────────
+
+def _get(node, *names):
+    """math_main JSON uses Clojure-ish keys; accept a few spellings."""
+    if not isinstance(node, dict):
+        return None
+    for name in names:
+        if name in node:
+            return node[name]
+    return None
+
+
+def server_labels(b: Bundles, conv_key: str, phase: int) -> dict:
+    """Per-pid group label straight out of `math_main.data`.
+
+    Polis stores base clusters (k=100 buckets of participants) and group clusters
+    (the 2–5 opinion groups, whose members are *base cluster ids*). A participant's
+    group is therefore found by walking group → base-cluster → member pids.
+    """
+    payload = b.math.get((conv_key, phase))
+    if payload is None:
+        return {'available': False, 'reason': 'no math_main in the bundle'}
+
+    data = payload['data']
+    base = _get(data, 'base-clusters', 'base_clusters')
+    groups = _get(data, 'group-clusters', 'group_clusters')
+    if base is None or groups is None:
+        return {'available': False, 'reason': 'math_main has no cluster keys',
+                'keys': sorted(data.keys()) if isinstance(data, dict) else None}
+
+    # base-clusters is a struct-of-arrays: {id: [...], members: [[pid,...], ...]}
+    base_members: dict[int, list[int]] = {}
+    if isinstance(base, dict):
+        ids = _get(base, 'id', 'ids') or []
+        members = _get(base, 'members') or []
+        for bid, mem in zip(ids, members):
+            base_members[int(bid)] = [int(m) for m in mem]
+    else:                                    # list-of-maps fallback
+        for entry in base:
+            base_members[int(_get(entry, 'id'))] = [int(m) for m in (_get(entry, 'members') or [])]
+
+    labels: dict[int, int] = {}
+    for gi, group in enumerate(groups):
+        gid = _get(group, 'id')
+        gid = gi if gid is None else int(gid)
+        for bid in (_get(group, 'members') or []):
+            for pid in base_members.get(int(bid), []):
+                labels[pid] = gid
+
+    in_conv = _get(data, 'in-conv', 'in_conv') or []
+    return {
+        'available': True,
+        'labels': labels,
+        'K': len(groups),
+        'n_labelled': len(labels),
+        'in_conv': [int(p) for p in in_conv],
+        'math_tick': payload.get('math_tick'),
+        'last_vote_timestamp': payload.get('last_vote_timestamp'),
+        'math_env': payload.get('math_env'),
+    }
+
+
+# ── participation funnel ─────────────────────────────────────────────────────
+
+def participation_funnel(b: Bundles, conv_key: str, phase: int = 2) -> pd.DataFrame:
+    """How many people reached each level of participation.
+
+    The results page reports a single "N participants", which is the number of
+    people with **at least one vote row, passes included** — not the number who
+    joined, and not the number the clustering actually used. Those are three
+    different populations and the gap between them is often large:
+
+      joined            — accepted the conversation (app DB `participations`)
+      voted ≥1          — the number the results page currently shows
+      voted ≥7          — Polis's own clustering threshold, min(7, n_statements)
+      in-conv           — who the math actually clustered, after the threshold
+                          and its greedy top-up to 15
+      clustered         — who ended up with a group label
+
+    "Opened the conversation" is deliberately not tracked (passive page views are
+    not logged), so `joined` is the earliest step we can honestly report.
+    """
+    votes = b.phase('votes_latest', conv_key, phase)
+    statements = b.phase('statements', conv_key, phase)
+    server = server_labels(b, conv_key, phase)
+
+    per_person = votes.groupby('person_key').size()
+    n_statements = len(statements)
+
+    rows = []
+    app_conv = b.app['conversations']
+    joined = app_conv.loc[app_conv['conv_key'] == conv_key, 'n_participations'] \
+        if 'n_participations' in app_conv.columns else None
+    # Machine-made accounts are excluded upstream and deliberately do not appear as
+    # a row here. They are not a step people fall out of — they were never people,
+    # and giving them a line in a table about participation implies otherwise. The
+    # discrepancy with the live results page is explained once, in prose.
+    machine = b.machine.get((conv_key, phase), {})
+    if joined is not None and len(joined):
+        rows.append({'step': 'people who joined the conversation',
+                     'n_people': int(joined.iloc[0]),
+                     'note': 'app database'})
+
+    for threshold in FUNNEL_THRESHOLDS:
+        if threshold > 1 and threshold > n_statements:
+            continue
+        rows.append({'step': f'gave an opinion on ≥{threshold} statement(s)',
+                     'n_people': int((per_person >= threshold).sum()),
+                     'note': 'the number the results page shows' if threshold == 1 else ''})
+
+    threshold = min(POLIS_VOTE_THRESHOLD, n_statements)
+    rows.append({'step': f'ANALYSED HERE: ≥{threshold} opinions',
+                 'n_people': int((per_person >= threshold).sum()),
+                 'note': "Polis's own clustering cutoff, min(7, statements)"})
+
+    if server['available']:
+        # Report only the real people the tool placed. The count it published also
+        # includes machine-made accounts, but that is a defect to fix rather than a
+        # number to explain to readers.
+        real_clustered = len(set(server['labels']) - set(machine))
+        rows.append({'step': 'placed into an opinion group',
+                     'n_people': real_clustered,
+                     'note': f'K={server["K"]}'})
+
+    out = pd.DataFrame(rows)
+    out['pct_of_voters'] = (out['n_people'] /
+                            max(int((per_person >= 1).sum()), 1) * 100).round(1)
+    return out
+
+
+def cluster_roster(b: Bundles, conv_key: str, phase: int = 2) -> pd.DataFrame | None:
+    """Which pseudonyms ended up in which opinion group.
+
+    Needs a bundle exported with `--with-pseudonyms`; returns None otherwise.
+
+    Everyone who voted appears exactly once, including people the clustering did
+    not place — a participant looking for their own pseudonym should always find
+    it, and "not placed" is a real, explainable outcome (too few votes to be
+    clustered), not an omission.
+    """
+    people = b.app['people']
+    if people.empty:
+        return None
+    people = people[people['conv_key'] == conv_key]
+    if people.empty:
+        return None
+
+    votes = b.phase('votes_latest', conv_key, phase)
+    participants = b.phase('participants', conv_key, phase)
+    server = server_labels(b, conv_key, phase)
+
+    key_by_pid = dict(zip(participants['pid'], participants['person_key']))
+    group_by_key = {}
+    if server['available']:
+        group_by_key = {key_by_pid[pid]: lab for pid, lab in server['labels'].items()
+                        if pid in key_by_pid}
+
+    vote_counts = votes.groupby('person_key').size()
+    rows = []
+    for person in people.itertuples():
+        n_votes = int(vote_counts.get(person.person_key, 0))
+        if n_votes == 0:
+            placement = 'joined, did not vote'
+        elif person.person_key in group_by_key:
+            placement = f'group {group_by_key[person.person_key] + 1}'
+        else:
+            placement = 'not placed (too few votes to cluster)'
+        rows.append({'pseudonym': person.pseudonym, 'n_votes': n_votes,
+                     'placement': placement})
+    out = pd.DataFrame(rows).sort_values(['placement', 'pseudonym'])
+    return out.reset_index(drop=True)
+
+
+# ── the reproduction gate ────────────────────────────────────────────────────
+
+def replica_labels(matrix: Matrix, *, vote_counts: dict[int, int] | None = None,
+                   **kwargs) -> dict:
+    """Run the pinned replica, correcting who counts as "in conversation".
+
+    `run_replica` derives in-conv by counting non-NaN cells in the matrix it is
+    given. That is right for a plain vote matrix and wrong for ours: the
+    Clojure-faithful `mod_out='zero'` policy sets the *whole* column of a
+    moderated-out statement to 0, including for people who never voted on it, so
+    those filled cells would count as votes and everyone would clear the threshold.
+
+    The engine does not work that way. `conversation.clj` computes `:in-conv` from
+    `user-vote-counts` — a separate tally of actual votes — while the zeroing applies
+    only to `:rating-mat`. Passing real vote counts here restores that separation.
+
+    The correction is applied after clustering rather than inside it, because
+    `run_replica` takes no in-conv argument and it lives in another repository. The
+    residual difference: base k-means sees the extra rows before they are dropped.
+    Where the reproduction gate passes, that difference is demonstrably immaterial.
+    """
+    from analysis.polis_replica import run_replica
+    result = run_replica(matrix.values, **kwargs)
+    labels = {pid: int(lab) for pid, lab in zip(matrix.pids, result['labels']) if lab != -1}
+    in_conv = [matrix.pids[i] for i in result['in_conv']]
+
+    if vote_counts is not None:
+        threshold = min(POLIS_VOTE_THRESHOLD, len(matrix.tids))
+        qualified = {pid for pid, n in vote_counts.items() if n >= threshold}
+        if len(qualified) < POLIS_GREEDY_N:      # the engine's greedy top-up
+            for pid, _ in sorted(vote_counts.items(), key=lambda kv: -kv[1]):
+                if len(qualified) >= POLIS_GREEDY_N:
+                    break
+                qualified.add(pid)
+        labels = {pid: lab for pid, lab in labels.items() if pid in qualified}
+        in_conv = [pid for pid in in_conv if pid in qualified]
+
+    return {'labels': labels, 'K': int(result['K']),
+            'silhouettes': result.get('silhouettes', {}), 'in_conv': in_conv}
+
+
+def real_vote_counts(b: Bundles, conv_key: str, phase: int,
+                     include_machine: bool = False) -> dict[int, int]:
+    """Votes actually cast per participant — the engine's `user-vote-counts`."""
+    votes = b.phase('votes_latest', conv_key, phase, include_machine=include_machine)
+    return votes.groupby('pid').size().to_dict()
+
+
+def compare_labels(a: dict[int, int], bb: dict[int, int]) -> tuple[float, int]:
+    """Adjusted Rand Index over the pids labelled by both."""
+    from sklearn.metrics import adjusted_rand_score
+    common = sorted(set(a) & set(bb))
+    if len(common) < 2:
+        return float('nan'), len(common)
+    return float(adjusted_rand_score([a[p] for p in common], [bb[p] for p in common])), len(common)
+
+
+def reproduction_gate(b: Bundles, conv_key: str, phase: int) -> dict:
+    """Can the pinned replica reproduce this conversation's server clustering?
+
+    Passing licenses the counterfactuals below. Failing does not invalidate the
+    server's own result — it means we may not reason about *alternatives* to it.
+    """
+    server = server_labels(b, conv_key, phase)
+    # The server clustered whatever was in its database, machine-made accounts and
+    # all. Reproducing it therefore means feeding the replica the same population;
+    # filtering here would compare two different things and fail for the wrong reason.
+    matrix = build_matrix(b, conv_key, phase, include_machine=True)
+    if not server['available']:
+        return {'conv_key': conv_key, 'phase': phase, 'passed': False,
+                'reason': server['reason'], 'matrix': matrix, 'server': server}
+
+    replica = replica_labels(
+        matrix, vote_counts=real_vote_counts(b, conv_key, phase, include_machine=True))
+    ari, n_common = compare_labels(server['labels'], replica['labels'])
+    passed = bool(server['K'] == replica['K'] and ari >= REPRODUCTION_ARI)
+    return {
+        'conv_key': conv_key, 'phase': phase, 'passed': passed,
+        'K_server': server['K'], 'K_replica': replica['K'],
+        'ari': ari, 'n_common': n_common,
+        'n_participants': len(matrix.pids), 'n_statements': len(matrix.tids),
+        'density': matrix.density,
+        'n_in_conv': len(replica['in_conv']),
+        'max_k_allowed': max_k_allowed(len(replica['in_conv'])),
+        'server': server, 'replica': replica, 'matrix': matrix,
+        'reason': '' if passed else
+                  f'K {server["K"]}≠{replica["K"]}' if server['K'] != replica['K']
+                  else f'ARI {ari:.3f} < {REPRODUCTION_ARI}',
+    }
+
+
+def max_k_allowed(n_in_conv: int, max_max_k: int = POLIS_MAX_K) -> int:
+    """conversation.clj max-k-fn. Below 12 in-conversation participants the engine
+    can only ever return K=2, so "we found two groups" is a threshold artefact."""
+    return min(max_max_k, 2 + n_in_conv // 12)
+
+
+# ── counterfactuals (gated) ──────────────────────────────────────────────────
+
+def lineage_root(prov: pd.DataFrame, conv_key: str, tid: int) -> int:
+    """Walk derived_from_tid up to the root of the lineage. Cycle-safe, mirroring
+    `_lineage_group` in the app."""
+    by_tid = dict(zip(prov.loc[prov['conv_key'] == conv_key, 'polis_statement_id'],
+                      prov.loc[prov['conv_key'] == conv_key, 'derived_from_tid']))
+    seen = {tid}
+    cur = tid
+    while cur in by_tid:
+        parent = int(by_tid[cur])
+        if parent in seen:
+            break
+        seen.add(parent)
+        cur = parent
+    return cur
+
+
+def collapse_lineages(b: Bundles, matrix: Matrix) -> Matrix:
+    """Merge each lineage of derivative statements into its root column.
+
+    A near-duplicate statement and its rewording are two highly correlated columns,
+    which PCA reads as extra evidence for whatever axis they sit on. Collapsing them
+    asks: how much of the group structure is carried by the duplication itself?
+    A participant who voted on several members of one lineage contributes the mean
+    of those votes; sign is preserved because all members restate one proposition.
+    """
+    prov = b.app['statement_provenance']
+    if prov.empty:
+        return matrix
+
+    roots = {tid: lineage_root(prov, matrix.conv_key, tid) for tid in matrix.tids}
+    groups: dict[int, list[int]] = {}
+    for tid, root in roots.items():
+        groups.setdefault(root, []).append(tid)
+
+    new_tids = sorted(groups)
+    col = {tid: j for j, tid in enumerate(matrix.tids)}
+    values = np.full((len(matrix.pids), len(new_tids)), np.nan)
+    for j, root in enumerate(new_tids):
+        members = [col[t] for t in groups[root]]
+        block = matrix.values[:, members]
+        # A participant who voted on no member of this lineage stays NaN; nanmean
+        # warns on that all-NaN slice, which is the expected case, not a problem.
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', RuntimeWarning)
+            merged = np.nanmean(block, axis=1)
+        values[:, j] = merged
+
+    notes = dict(matrix.notes)
+    notes.update({'lineage_collapsed': True,
+                  'n_columns_before': len(matrix.tids),
+                  'n_columns_after': len(new_tids),
+                  'n_lineages_merged': sum(1 for g in groups.values() if len(g) > 1)})
+    return Matrix(conv_key=matrix.conv_key, phase=matrix.phase, values=values,
+                  pids=matrix.pids, tids=new_tids, person_keys=matrix.person_keys,
+                  notes=notes)
+
+
+def counterfactuals(b: Bundles, gate: dict) -> pd.DataFrame:
+    """Re-cluster under alternative policies and report the drift from the faithful
+    baseline. Only meaningful for a conversation that passed the reproduction gate."""
+    if not gate['passed']:
+        raise ValueError(f'{gate["conv_key"]} phase {gate["phase"]} did not pass the '
+                         f'reproduction gate ({gate["reason"]}) — no counterfactuals')
+
+    conv_key, phase = gate['conv_key'], gate['phase']
+    baseline = gate['replica']['labels']
+    rows = [{'variant': 'faithful baseline', 'K': gate['K_replica'],
+             'ari_vs_baseline': 1.0, 'n_common': len(baseline), 'detail': ''}]
+
+    collapsed = collapse_lineages(b, gate['matrix'])
+    if collapsed.notes.get('lineage_collapsed'):
+        result = replica_labels(collapsed)
+        ari, n = compare_labels(baseline, result['labels'])
+        rows.append({'variant': 'lineages collapsed', 'K': result['K'],
+                     'ari_vs_baseline': ari, 'n_common': n,
+                     'detail': f'{collapsed.notes["n_columns_before"]}→'
+                               f'{collapsed.notes["n_columns_after"]} columns, '
+                               f'{collapsed.notes["n_lineages_merged"]} lineage(s) merged'})
+
+    for mod_out in ('keep', 'drop'):
+        matrix = build_matrix(b, conv_key, phase, mod_out=mod_out)
+        if matrix.notes['n_moderated_out'] == 0:
+            rows.append({'variant': f'moderated-out: {mod_out}', 'K': gate['K_replica'],
+                         'ari_vs_baseline': 1.0, 'n_common': len(baseline),
+                         'detail': 'no moderated-out statements — identical to baseline'})
+            continue
+        result = replica_labels(matrix)
+        ari, n = compare_labels(baseline, result['labels'])
+        rows.append({'variant': f'moderated-out: {mod_out}', 'K': result['K'],
+                     'ari_vs_baseline': ari, 'n_common': n,
+                     'detail': f'{matrix.notes["n_moderated_out"]} statement(s) affected'})
+
+    for base_k in ('50', '200'):
+        previous = os.environ.get('POLIS_BASE_K')
+        os.environ['POLIS_BASE_K'] = base_k
+        try:
+            result = replica_labels(gate['matrix'])
+        finally:
+            if previous is None:
+                os.environ.pop('POLIS_BASE_K', None)
+            else:
+                os.environ['POLIS_BASE_K'] = previous
+        ari, n = compare_labels(baseline, result['labels'])
+        rows.append({'variant': f'base-K = {base_k}', 'K': result['K'],
+                     'ari_vs_baseline': ari, 'n_common': n,
+                     'detail': 'engine default is 100'})
+
+    return pd.DataFrame(rows)
+
+
+# ── Phase 2 → Phase 6 ────────────────────────────────────────────────────────
+
+def phase_bridge(b: Bundles, conv_key: str) -> pd.DataFrame:
+    """Confirmed featured statements with both tids. The only legitimate way to
+    line up statements across the two Polis conversations."""
+    featured = b.app['featured_statements']
+    conf = featured[(featured['conv_key'] == conv_key) &
+                    featured['confirmed_by_admin'] &
+                    featured['phase6_polis_statement_id'].notna()].copy()
+    conf['phase6_polis_statement_id'] = conf['phase6_polis_statement_id'].astype(int)
+    return conf[['polis_statement_id', 'phase6_polis_statement_id', 'statement_text']]
+
+
+def compare_phases(b: Bundles, conv_key: str) -> dict:
+    """Did the informed round move people, and did it move them together?
+
+    Both rounds are restricted to the bridged featured statements so the comparison
+    is over one statement set — otherwise K and geometry differ merely because
+    Phase 6 has fewer statements.
+    """
+    bridge = phase_bridge(b, conv_key)
+    if bridge.empty:
+        return {'available': False, 'reason': 'no bridged featured statements'}
+
+    p2 = b.phase('votes_latest', conv_key, 2)
+    p6 = b.phase('votes_latest', conv_key, 6)
+    if p2.empty or p6.empty:
+        return {'available': False, 'reason': 'one of the two rounds has no votes'}
+
+    tid6_by_tid2 = dict(zip(bridge['polis_statement_id'],
+                            bridge['phase6_polis_statement_id']))
+    p2 = p2[p2['tid'].isin(tid6_by_tid2)].copy()
+    p2['stmt'] = p2['tid'].map(tid6_by_tid2)
+    p6 = p6[p6['tid'].isin(set(tid6_by_tid2.values()))].copy()
+    p6['stmt'] = p6['tid']
+
+    paired = p2.merge(p6, on=['person_key', 'stmt'], suffixes=('_p2', '_p6'))
+    people_p2 = set(p2['person_key'])
+    people_p6 = set(p6['person_key'])
+    linked = people_p2 & people_p6
+    anon = {k for k in people_p2 | people_p6 if str(k).startswith('anon-')}
+
+    per_statement = None
+    if not paired.empty:
+        per_statement = (paired.groupby('stmt')
+                         .apply(lambda g: pd.Series({
+                             'n_common_voters': len(g),
+                             'agree_p2': float((g['vote_p2'] == RAW_AGREE).mean()),
+                             'agree_p6': float((g['vote_p6'] == RAW_AGREE).mean()),
+                             'n_changed': int((g['vote_p2'] != g['vote_p6']).sum()),
+                         }), include_groups=False)
+                         .reset_index())
+        per_statement['agree_shift'] = per_statement['agree_p6'] - per_statement['agree_p2']
+        text_by_tid6 = dict(zip(bridge['phase6_polis_statement_id'], bridge['statement_text']))
+        per_statement['statement'] = per_statement['stmt'].map(text_by_tid6)
+
+    return {
+        'available': True,
+        'n_bridged_statements': len(bridge),
+        'n_people_phase2': len(people_p2),
+        'n_people_phase6': len(people_p6),
+        'n_people_linked': len(linked),
+        'n_people_anonymous': len(anon),
+        'n_paired_votes': len(paired),
+        'paired': paired,
+        'per_statement': per_statement,
+        'linkage_note': (
+            'no person voted in both rounds — either the rounds had different '
+            'participants, or trusted-sub identity was off and each session got its '
+            'own uid (see ref_cross-device-identity.md)') if not linked else '',
+    }
+
+
+def cluster_migration(b: Bundles, conv_key: str) -> pd.DataFrame | None:
+    """Where did each Phase 2 opinion group end up in the informed round?"""
+    server2 = server_labels(b, conv_key, 2)
+    server6 = server_labels(b, conv_key, 6)
+    if not (server2['available'] and server6['available']):
+        return None
+
+    key2 = dict(zip(b.phase('participants', conv_key, 2)['pid'],
+                    b.phase('participants', conv_key, 2)['person_key']))
+    key6 = dict(zip(b.phase('participants', conv_key, 6)['pid'],
+                    b.phase('participants', conv_key, 6)['person_key']))
+    g2 = {key2[pid]: lab for pid, lab in server2['labels'].items() if pid in key2}
+    g6 = {key6[pid]: lab for pid, lab in server6['labels'].items() if pid in key6}
+    common = sorted(set(g2) & set(g6) - {k for k in g2 if str(k).startswith('anon-')})
+    if not common:
+        return None
+    return (pd.crosstab(pd.Series([g2[k] for k in common], name='phase 2 group'),
+                        pd.Series([g6[k] for k in common], name='phase 6 group')))
+
+
+# ── derivative statements ────────────────────────────────────────────────────
+
+def derivative_analysis(b: Bundles, conv_key: str) -> pd.DataFrame | None:
+    """Parent vs derivative, judged only on the people who voted on both.
+
+    Reports the agreement rate on each, the shift, and how many voters switched
+    side between a statement and its rewording — with the similarity score the app
+    recorded at submission time, so "how different was the wording" can be set
+    against "how differently did people vote".
+    """
+    prov = b.app['statement_provenance']
+    if prov.empty:
+        return None
+    prov = prov[prov['conv_key'] == conv_key]
+    if prov.empty:
+        return None
+
+    votes = b.phase('votes_latest', conv_key, 2)
+    statements = b.phase('statements', conv_key, 2).set_index('tid')
+    similarity = b.app['statement_similarity']
+    sim = similarity[similarity['conv_key'] == conv_key] if not similarity.empty else pd.DataFrame()
+
+    rows = []
+    for link in prov.itertuples():
+        child, parent = int(link.polis_statement_id), int(link.derived_from_tid)
+        vc = votes[votes['tid'] == child][['person_key', 'vote']]
+        vp = votes[votes['tid'] == parent][['person_key', 'vote']]
+        both = vc.merge(vp, on='person_key', suffixes=('_child', '_parent'))
+        scores = {}
+        if not sim.empty:
+            scores = dict(zip(sim.loc[sim['polis_statement_id'] == child, 'model'],
+                              sim.loc[sim['polis_statement_id'] == child, 'value']))
+        rows.append({
+            'parent_tid': parent, 'child_tid': child,
+            'parent_text': statements['txt'].get(parent, ''),
+            'child_text': statements['txt'].get(child, ''),
+            'similarity_semantic': scores.get('semantic-v1', scores.get('semantic')),
+            'similarity_char': scores.get('char'),
+            'n_voters_parent': len(vp), 'n_voters_child': len(vc),
+            'n_voters_both': len(both),
+            'agree_parent': float((vp['vote'] == RAW_AGREE).mean()) if len(vp) else np.nan,
+            'agree_child': float((vc['vote'] == RAW_AGREE).mean()) if len(vc) else np.nan,
+            'agree_parent_common': float((both['vote_parent'] == RAW_AGREE).mean()) if len(both) else np.nan,
+            'agree_child_common': float((both['vote_child'] == RAW_AGREE).mean()) if len(both) else np.nan,
+            'n_switched_side': int(((both['vote_parent'] * both['vote_child']) < 0).sum()) if len(both) else 0,
+            'link_method': link.link_method,
+        })
+    out = pd.DataFrame(rows)
+    out['agree_shift_common'] = out['agree_child_common'] - out['agree_parent_common']
+    return out
+
+
+# ── one-call summary ─────────────────────────────────────────────────────────
+
+def run_all(root) -> dict:
+    """Everything the notebook does, in order, as plain data. Handy for a smoke run
+    without a kernel."""
+    b = load_bundles(root)
+    out = {'bundles': b, 'checks': integrity_checks(b), 'gates': {},
+           'counterfactuals': {}, 'phases': {}, 'derivatives': {}}
+    for conv_key in b.conversations:
+        for phase in (2, 6):
+            if b.phase('votes_latest', conv_key, phase).empty:
+                continue
+            gate = reproduction_gate(b, conv_key, phase)
+            out['gates'][(conv_key, phase)] = gate
+            if gate['passed']:
+                out['counterfactuals'][(conv_key, phase)] = counterfactuals(b, gate)
+        out['phases'][conv_key] = compare_phases(b, conv_key)
+        out['derivatives'][conv_key] = derivative_analysis(b, conv_key)
+    return out

--- a/private/analysis/preflight.py
+++ b/private/analysis/preflight.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Prove both databases are reachable and readable before exporting anything.
+
+Worth its own step because the two most likely failures are silent-ish and happen
+late:
+
+  * **Empty connection string.** Toolforge injects envvars into jobs and the
+    webservice, not into an interactive bastion shell. Typed on the bastion,
+    `$DATABASE_URL` expands to nothing and the driver reports something unhelpful.
+  * **A missing grant.** The Polis connection uses the read-only `wiki_polis_ro`
+    role, set up with `GRANT SELECT ON ALL TABLES IN SCHEMA public`. Any table
+    created *after* that grant ran is not covered — and `particiapi_users` (the
+    identity join) and `math_main` (the server's own clustering) are exactly the
+    kind of table that could be missing without anything else looking wrong.
+
+Every probe is a bounded SELECT. Nothing is written and nothing is exported.
+
+    python3 preflight.py --app-db-url "$DATABASE_URL" \
+                         --polis-db-url "$POLIS_DATABASE_URL" \
+                         --slug 2026-nlwiki-arbcom
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from export_app_bundle import open_client  # noqa: E402
+from export_polis_bundle import Psycopg2Client  # noqa: E402
+
+APP_TABLES = ['conversations', 'participants', 'participations', 'featured_statements',
+              'statement_provenance', 'statement_similarity_scores', 'arguments',
+              'argument_votes']
+POLIS_TABLES = ['zinvites', 'conversations', 'comments', 'participants', 'votes',
+                'votes_latest_unique', 'particiapi_users', 'math_main']
+
+OK, BAD = '  ok  ', ' FAIL '
+
+
+def probe(client, table: str) -> tuple[bool, str]:
+    try:
+        rows = client.query(f'SELECT COUNT(*) AS n FROM {table}')
+        return True, f'{int(list(rows[0].values())[0]):,} rows'
+    except Exception as exc:
+        return False, str(exc).strip().splitlines()[0][:90]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--app-db-url')
+    ap.add_argument('--polis-db-url')
+    ap.add_argument('--slug', action='append', default=[])
+    args = ap.parse_args()
+
+    failures = 0
+
+    if args.app_db_url:
+        print('app database (ToolsDB)')
+        try:
+            client = open_client(args.app_db_url)
+        except Exception as exc:
+            print(f'{BAD} could not connect: {exc}')
+            return 2
+        for table in APP_TABLES:
+            good, detail = probe(client, table)
+            failures += not good
+            print(f'{OK if good else BAD} {table:<30} {detail}')
+
+        for slug in args.slug:
+            rows = client.query(
+                f'SELECT slug, polis_id, phase6_polis_conversation_id '
+                f'FROM conversations WHERE slug = {client.paramstyle}', (slug,))
+            if not rows:
+                print(f'{BAD} slug {slug!r} not found')
+                failures += 1
+            else:
+                row = rows[0]
+                print(f'{OK} slug {slug!r}: phase2={row["polis_id"]} '
+                      f'phase6={row["phase6_polis_conversation_id"] or "none"}')
+        print()
+    else:
+        print('app database: skipped (no --app-db-url)\n')
+
+    if args.polis_db_url:
+        print('Polis database (VPS)')
+        try:
+            polis = Psycopg2Client(args.polis_db_url)
+        except Exception as exc:
+            print(f'{BAD} could not connect: {str(exc).strip().splitlines()[0]}')
+            return 2
+        for table in POLIS_TABLES:
+            good, detail = probe(polis, table)
+            failures += not good
+            print(f'{OK if good else BAD} {table:<30} {detail}')
+
+        # The zinvites named by the app database must actually resolve here.
+        if args.app_db_url and args.slug:
+            for slug in args.slug:
+                rows = client.query(
+                    f'SELECT polis_id, phase6_polis_conversation_id FROM conversations '
+                    f'WHERE slug = {client.paramstyle}', (slug,))
+                for row in rows:
+                    for phase, zinvite in ((2, row['polis_id']),
+                                           (6, row['phase6_polis_conversation_id'])):
+                        if not zinvite:
+                            continue
+                        found = polis.query(
+                            'SELECT z.zid, '
+                            '  (SELECT COUNT(*) FROM votes v WHERE v.zid = z.zid) AS n_votes, '
+                            '  (SELECT COUNT(*) FROM comments c WHERE c.zid = z.zid) AS n_stmts, '
+                            '  (SELECT COUNT(*) FROM math_main m WHERE m.zid = z.zid) AS n_math '
+                            'FROM zinvites z WHERE z.zinvite = %s', (zinvite,))
+                        if not found:
+                            print(f'{BAD} phase {phase} zinvite {zinvite!r} not in zinvites')
+                            failures += 1
+                            continue
+                        r = found[0]
+                        note = '' if r['n_math'] else '  ← no math_main: the clustering ' \
+                                                      'has not run for this conversation'
+                        print(f'{OK} phase {phase} {zinvite}: {r["n_votes"]:,} votes, '
+                              f'{r["n_stmts"]} statements, math_main={r["n_math"]}{note}')
+                        if not r['n_math']:
+                            failures += 1
+        print()
+    else:
+        print('Polis database: skipped (no --polis-db-url)\n')
+
+    if not (args.app_db_url or args.polis_db_url):
+        print('nothing was checked — pass --app-db-url and/or --polis-db-url.')
+        print('(On Toolforge these are empty unless you are inside a job or the '
+              'webservice shell.)')
+        return 2
+    if failures:
+        print(f'{failures} problem(s) found — fix these before exporting.')
+        return 1
+    print('all checks passed — safe to export.')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/private/analysis/report.py
+++ b/private/analysis/report.py
@@ -37,10 +37,14 @@ MIN_COMPARABLE = POLIS_VOTE_THRESHOLD
 
 #: Decisive responses a proposition needs before its agreement figure is printed
 #: for participants. Below this a percentage is arithmetic rather than a finding:
-#: with four people, one more vote moves it 20 points. Derived from the engine's
-#: own cutoff rather than picked, and floored at 5 — the same rule already applied
-#: to representative selection below.
-MIN_DECIDED_TO_REPORT = max(5, POLIS_VOTE_THRESHOLD)
+#: with four people, one more vote moves it 20 points.
+#:
+#: Matches `family_representatives(min_decided=5)`, so the floor for *choosing* a
+#: representative and the floor for *reporting* its agreement are the same number.
+#: Note this is unrelated to POLIS_VOTE_THRESHOLD: that is the engine's
+#: participant-side cutoff — how many statements a person must answer to be
+#: clustered — and says nothing about how many responses a statement needs.
+MIN_DECIDED_TO_REPORT = 5
 
 #: Similarity above which two versions inside one family are near-identical to each
 #: other. Higher than the threshold that forms the families themselves: this flags
@@ -976,7 +980,8 @@ def write_report(*, bundle, conv_key, checks, funnel, server, gate, sweep, stabi
             else:
                 # A percentage from three people reads as a finding and is not one.
                 # Say why it is withheld rather than leaving an empty cell.
-                agreement = f'<span class="footnote">too few responses ({decided})</span>'
+                agreement = ('<span class="footnote">not enough responses '
+                             'to report</span>')
             rows.append(
                 f'<tr><td>{html.escape(str(r.text))}</td>'
                 f'<td class="footnote">{wording}</td>'
@@ -995,8 +1000,8 @@ def write_report(*, bundle, conv_key, checks, funnel, server, gate, sweep, stabi
             parts.append(
                 f'<p class="footnote">{withheld} of {len(representatives)} propositions '
                 f'drew fewer than {MIN_DECIDED_TO_REPORT} responses either way. A '
-                f'percentage from that few people moves by tens with one more vote, '
-                f'so no figure is given for them — they were proposed, not settled.</p>')
+                f'percentage from that few people is arithmetic rather than a result, '
+                f'so none is given.</p>')
 
     # ── groups ───────────────────────────────────────────────────────────────
     if 'groups' in show and server.get('available'):

--- a/private/analysis/report.py
+++ b/private/analysis/report.py
@@ -1,0 +1,1780 @@
+"""Figures and the standalone HTML report.
+
+Palette is the validated default from the dataviz reference instance: categorical
+slots 1 and 2 (blue `#2a78d6`, orange `#eb6834`), which clear every check on the
+all-pairs list — worst CVD ΔE 24.7, worst normal-vision ΔE 33.6. Two opinion groups
+is the only categorical need here; nothing cycles.
+
+Agreement percentages use a diverging encoding (the same two hues either side of a
+neutral grey midpoint) because agree-vs-disagree is polarity, not magnitude. The
+co-assignment heatmap uses a single-hue sequential ramp because it is magnitude.
+
+Identity is never carried by colour alone: every figure with two series carries a
+legend, and the group marks are also distinguished by shape.
+"""
+from __future__ import annotations
+
+import difflib
+import html
+import io
+import re as _re
+from pathlib import Path
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.colors import LinearSegmentedColormap
+from matplotlib.lines import Line2D
+
+from pipeline import (POLIS_VOTE_THRESHOLD, RAW_AGREE, RAW_DISAGREE,
+                      auto_agree_votes)
+
+#: People who voted decisively on BOTH wordings before a diff gets a comparison
+#: rather than 'not enough people'. Matches the engine's own participation cutoff.
+MIN_COMPARABLE = POLIS_VOTE_THRESHOLD
+
+#: Similarity above which two versions inside one family are near-identical to each
+#: other. Higher than the threshold that forms the families themselves: this flags
+#: parallel effort — two people separately narrowing the same statement the same
+#: way — rather than mere relatedness.
+NEAR_IDENTICAL = 0.95
+
+SURFACE = '#fcfcfb'
+INK = '#0b0b0b'
+INK_SOFT = '#52514e'
+INK_MUTED = '#8a8880'
+GRID = '#e5e4e0'
+SERIES = ['#2a78d6', '#eb6834']          # categorical slots 1, 2
+MARKERS = ['o', 's']                      # secondary encoding, so never colour-alone
+NEUTRAL = '#b8b6ae'
+SEQUENTIAL = LinearSegmentedColormap.from_list('wp_seq', ['#fcfcfb', '#2a78d6'])
+
+plt.rcParams.update({
+    'figure.facecolor': SURFACE, 'axes.facecolor': SURFACE,
+    'savefig.facecolor': SURFACE,
+    'text.color': INK, 'axes.labelcolor': INK_SOFT,
+    'xtick.color': INK_SOFT, 'ytick.color': INK_SOFT,
+    'axes.edgecolor': GRID, 'grid.color': GRID, 'grid.linewidth': 0.8,
+    'font.size': 10, 'axes.titlesize': 12, 'axes.titleweight': 'normal',
+    'axes.spines.top': False, 'axes.spines.right': False,
+    'figure.dpi': 110,
+})
+
+
+def _finish(ax, title: str, subtitle: str = '') -> None:
+    ax.set_title(title, loc='left', pad=18 if subtitle else 10, color=INK)
+    if subtitle:
+        ax.text(0, 1.02, subtitle, transform=ax.transAxes, fontsize=9,
+                color=INK_SOFT, va='bottom')
+
+
+# ── figures ──────────────────────────────────────────────────────────────────
+
+def plot_funnel(funnel: pd.DataFrame):
+    """Descending bars. One series, so no legend — the title names it."""
+    data = funnel.iloc[::-1]
+    fig, ax = plt.subplots(figsize=(8, 0.5 * len(data) + 1.6))
+    bars = ax.barh(data['step'], data['n_people'], height=0.62,
+                   color=SERIES[0], zorder=3)
+    # 4px rounded data-ends would need a patch path; a flat end plus a direct label
+    # reads cleanly at this size.
+    for bar, n in zip(bars, data['n_people']):
+        ax.text(bar.get_width() + max(data['n_people']) * 0.015,
+                bar.get_y() + bar.get_height() / 2, f'{n:,}',
+                va='center', fontsize=9, color=INK)
+    ax.set_xlim(0, max(data['n_people']) * 1.12)
+    ax.xaxis.set_visible(False)
+    ax.grid(False)
+    for spine in ax.spines.values():
+        spine.set_visible(False)
+    _finish(ax, 'How many people reached each step',
+            'the results page reports the "voted on ≥1" row')
+    fig.tight_layout()
+    return fig
+
+
+def plot_opinion_map(b, conv_key: str, server: dict):
+    """Polis's own projection — base-cluster coordinates from math_main, not a
+    recomputation. Point area is proportional to how many participants sit in that
+    base cluster."""
+    payload = b.math.get((conv_key, 2))
+    if payload is None or not server.get('available'):
+        return None
+    base = payload['data'].get('base-clusters')
+    groups = payload['data'].get('group-clusters')
+    if not base or not groups:
+        return None
+    # Real math_main carries projected coordinates on the base clusters; a partial
+    # capture may not. Without them there is no map to draw.
+    if not all(k in base for k in ('x', 'y', 'id')):
+        return None
+
+    ids = base['id']
+    xs, ys, counts = base['x'], base['y'], base.get('count', [1] * len(ids))
+    group_of = {int(bid): gi for gi, g in enumerate(groups) for bid in g['members']}
+
+    fig, ax = plt.subplots(figsize=(7, 5.4))
+    for gi in sorted(set(group_of.values())):
+        idx = [i for i, bid in enumerate(ids) if group_of.get(int(bid)) == gi]
+        if not idx:
+            continue
+        ax.scatter([xs[i] for i in idx], [ys[i] for i in idx],
+                   s=[28 + 26 * counts[i] for i in idx],
+                   c=SERIES[gi % len(SERIES)], marker=MARKERS[gi % len(MARKERS)],
+                   edgecolors=SURFACE, linewidths=2, alpha=0.9, zorder=3,
+                   label=f'group {gi + 1}')
+    ax.axhline(0, color=GRID, lw=0.8, zorder=1)
+    ax.axvline(0, color=GRID, lw=0.8, zorder=1)
+    ax.set_xticks([]); ax.set_yticks([])
+    # The legend used to sit unframed inside the axes, at marker sizes inherited from
+    # the scatter — so it read as more data points rather than as a key. Fixed-size
+    # proxy handles, its own surface, and a position outside the plotting area keep
+    # the two apart: the map is only marks, the key is only key.
+    keys = [Line2D([], [], linestyle='none', markersize=9,
+                   marker=MARKERS[gi % len(MARKERS)],
+                   markerfacecolor=SERIES[gi % len(SERIES)],
+                   markeredgecolor=SURFACE, markeredgewidth=1.5,
+                   label=f'group {gi + 1}')
+            for gi in sorted(set(group_of.values()))]
+    legend = ax.legend(handles=keys, loc='upper left', bbox_to_anchor=(1.015, 1.0),
+                       frameon=True, facecolor=SURFACE, edgecolor=GRID,
+                       framealpha=1.0, borderpad=0.75, labelspacing=0.7,
+                       handletextpad=0.7, fontsize=9.5)
+    legend.get_frame().set_linewidth(1.0)
+    for text in legend.get_texts():
+        text.set_color(INK)
+    _finish(ax, 'The opinion map Polis computed',
+            'each mark is a cluster of participants; larger means more people')
+    fig.tight_layout()
+    return fig
+
+
+def plot_stability_heatmap(stability: dict, server: dict):
+    """Sequential single hue: how often each pair landed in the same community."""
+    if not stability.get('available'):
+        return None
+    matrix = stability['co_assignment'].copy()
+    labels = server.get('labels', {}) if server.get('available') else {}
+    order = sorted(matrix.index, key=lambda pid: (labels.get(pid, 99), pid))
+    matrix = matrix.loc[order, order]
+
+    fig, ax = plt.subplots(figsize=(6.4, 5.6))
+    im = ax.imshow(matrix.values, cmap=SEQUENTIAL, vmin=0, vmax=1, interpolation='nearest')
+    ax.set_xticks([]); ax.set_yticks([])
+    ax.grid(False)
+
+    # Mark where the server's groups divide, so the blocks can be read against them.
+    if labels:
+        boundary = 0
+        previous = labels.get(order[0], 99)
+        for i, pid in enumerate(order):
+            if labels.get(pid, 99) != previous:
+                boundary = i
+                previous = labels.get(pid, 99)
+                ax.axhline(boundary - 0.5, color=INK, lw=1.1)
+                ax.axvline(boundary - 0.5, color=INK, lw=1.1)
+
+    bar = fig.colorbar(im, ax=ax, fraction=0.042, pad=0.03)
+    bar.set_label('share of runs in the same community', fontsize=9, color=INK_SOFT)
+    bar.outline.set_visible(False)
+    _finish(ax, 'Do the same people keep grouping together?',
+            f'{stability["n_runs"]} runs; black lines mark the groups Polis reported')
+    fig.tight_layout()
+    return fig
+
+
+def plot_agreement_matrix(b, conv_key: str, server: dict, phase: int = 2):
+    """Every participant against every other, shaded by how often they voted alike.
+
+    This is what "a group" means, drawn rather than asserted: people are ordered by
+    the group they were assigned to, so if the grouping reflects something real the
+    squares along the diagonal are darker than the rest. If the whole square looks
+    uniform, the groups are a cut through a gradient rather than two camps — and the
+    reader can see that instead of taking a statistic on trust.
+
+    Agreement counts only statements both people voted on decisively; passes are
+    excluded, since skipping is not agreeing.
+    """
+    import methods as _m
+    from pipeline import POLIS_VOTE_THRESHOLD, build_matrix, real_vote_counts
+
+    if not server.get('available'):
+        return None
+    matrix = build_matrix(b, conv_key, phase)
+    counts = real_vote_counts(b, conv_key, phase)
+    eligible = [p for p in matrix.pids if counts.get(p, 0) >= POLIS_VOTE_THRESHOLD]
+    if len(eligible) < 3:
+        return None
+    pids, weights, _ = _m.agreement_graph(matrix, restrict_pids=eligible)
+
+    labels = server['labels']
+    order = sorted(range(len(pids)), key=lambda i: (labels.get(pids[i], 99), pids[i]))
+    shown = weights[np.ix_(order, order)].copy()
+    np.fill_diagonal(shown, 1.0)
+
+    fig, ax = plt.subplots(figsize=(6.2, 5.4))
+    im = ax.imshow(shown, cmap=SEQUENTIAL, vmin=0, vmax=1, interpolation='nearest')
+    ax.set_xticks([]); ax.set_yticks([])
+    ax.grid(False)
+
+    previous = labels.get(pids[order[0]], 99)
+    for position, i in enumerate(order):
+        current = labels.get(pids[i], 99)
+        if current != previous:
+            ax.axhline(position - 0.5, color=INK, lw=1.1)
+            ax.axvline(position - 0.5, color=INK, lw=1.1)
+            previous = current
+
+    bar = fig.colorbar(im, ax=ax, fraction=0.042, pad=0.03)
+    bar.set_label('how often the two agreed', fontsize=9, color=INK_SOFT)
+    bar.outline.set_visible(False)
+    _finish(ax, 'Who agrees with whom',
+            'people ordered by their group; black lines mark the boundaries')
+    fig.tight_layout()
+    return fig
+
+
+def statement_divergence(b, conv_key: str, server: dict, phase: int = 2) -> pd.DataFrame:
+    """Per statement, the agreement rate inside each opinion group.
+
+    Agreement is over *decided* votes (agree or disagree); passes are excluded from
+    the denominator, so a much-passed statement is not made to look contested.
+    """
+    votes = b.phase('votes_latest', conv_key, phase)
+    statements = b.phase('statements', conv_key, phase).set_index('tid')
+    if not server.get('available'):
+        return pd.DataFrame()
+
+    participants = b.phase('participants', conv_key, phase)
+    key_by_pid = dict(zip(participants['pid'], participants['person_key']))
+    group_by_key = {key_by_pid[pid]: lab for pid, lab in server['labels'].items()
+                    if pid in key_by_pid}
+    votes = votes.assign(opinion_group=votes['person_key'].map(group_by_key))
+    votes = votes[votes['opinion_group'].notna()]
+
+    rows = []
+    for tid, block in votes.groupby('tid'):
+        # Overall agreement, ignoring the grouping entirely. This is the quantity that
+        # survives the finding that the grouping is indistinguishable from noise, so it
+        # is what the selection tables rank on; the per-group split is context.
+        all_decided = int(((block['vote'] == RAW_AGREE) |
+                           (block['vote'] == RAW_DISAGREE)).sum())
+        overall = ((block['vote'] == RAW_AGREE).sum() / all_decided * 100
+                   if all_decided else np.nan)
+        row = {'tid': tid, 'statement': statements['txt'].get(tid, ''),
+               'n_voters': len(block), 'n_decided': all_decided,
+               'agree_pct': round(overall, 1) if overall == overall else np.nan}
+        rates = {}
+        for gid, sub in block.groupby('opinion_group'):
+            decided = int(((sub['vote'] == RAW_AGREE) | (sub['vote'] == RAW_DISAGREE)).sum())
+            rate = (sub['vote'] == RAW_AGREE).sum() / decided * 100 if decided else np.nan
+            rates[int(gid)] = rate
+            row[f'agree_group{int(gid) + 1}'] = round(rate, 1) if rate == rate else np.nan
+            row[f'n_group{int(gid) + 1}'] = len(sub)
+            # The page tells the reader to "check the number of voters beside it", and
+            # the number that matters is how many in that group took a side — a 100%
+            # resting on two votes is the whole problem with the small group.
+            row[f'decided_group{int(gid) + 1}'] = decided
+        valid = [r for r in rates.values() if r == r]
+        row['gap'] = round(max(valid) - min(valid), 1) if len(valid) > 1 else np.nan
+        rows.append(row)
+
+    out = pd.DataFrame(rows)
+    return out.sort_values('gap', ascending=False, na_position='last').reset_index(drop=True)
+
+
+def plot_divergence(divergence: pd.DataFrame, top: int = 16):
+    """A dumbbell per statement: where each group sits, and how far apart they are."""
+    cols = [c for c in divergence.columns if c.startswith('agree_group')]
+    if len(cols) < 2 or divergence.empty:
+        return None
+    data = divergence.dropna(subset=['gap']).head(top).iloc[::-1]
+    if data.empty:
+        return None
+
+    fig, ax = plt.subplots(figsize=(9.5, 0.42 * len(data) + 1.8))
+    y = np.arange(len(data))
+    a, bb = data[cols[0]].values, data[cols[1]].values
+    ax.hlines(y, np.minimum(a, bb), np.maximum(a, bb), color=NEUTRAL, lw=2, zorder=2)
+    ax.scatter(a, y, s=64, c=SERIES[0], marker=MARKERS[0], edgecolors=SURFACE,
+               linewidths=2, zorder=3, label='group 1')
+    ax.scatter(bb, y, s=64, c=SERIES[1], marker=MARKERS[1], edgecolors=SURFACE,
+               linewidths=2, zorder=3, label='group 2')
+
+    ax.set_yticks(y)
+    ax.set_yticklabels([(t[:78] + '…') if len(t) > 78 else t for t in data['statement']],
+                       fontsize=8.5)
+    ax.set_xlim(-2, 102)
+    ax.set_xlabel('agreed, as a share of those who took a side (%)')
+    ax.xaxis.grid(True, zorder=1)
+    ax.legend(frameon=False, ncol=2, fontsize=9, loc='lower right')
+    _finish(ax, 'Where the groups split', 'widest disagreements first')
+    fig.tight_layout()
+    return fig
+
+
+def plot_similarity_distribution(pairs: pd.DataFrame, threshold: float = 0.85):
+    """Is the near-duplicate threshold cutting a real gap, or an arbitrary point?"""
+    if pairs.empty:
+        return None
+    fig, ax = plt.subplots(figsize=(8, 3.4))
+    ax.hist(pairs['similarity'], bins=48, color=SERIES[0], zorder=3)
+    ax.axvline(threshold, color=SERIES[1], lw=2, zorder=4)
+    ax.text(threshold, ax.get_ylim()[1] * 0.94, f'  threshold {threshold}',
+            color=SERIES[1], fontsize=9, va='top')
+    ax.set_xlabel('similarity between two statements')
+    ax.set_ylabel('pairs')
+    ax.yaxis.grid(True, zorder=1)
+    _finish(ax, 'How similar are the statements to each other?',
+            'a clear gap to the right of the threshold means it is cutting a real join')
+    fig.tight_layout()
+    return fig
+
+
+#: Every statistical term the reports use, linked to its Wikipedia article. A reader
+#: who meets "modularity" or "silhouette" for the first time should not have to take
+#: the number on faith, and a footnote they cannot follow is no better than none.
+GLOSSARY = {
+    'k-means': 'https://en.wikipedia.org/wiki/K-means_clustering',
+    'Leiden': 'https://en.wikipedia.org/wiki/Leiden_algorithm',
+    'modularity': 'https://en.wikipedia.org/wiki/Modularity_(networks)',
+    'silhouette': 'https://en.wikipedia.org/wiki/Silhouette_(clustering)',
+    'adjusted Rand index': 'https://en.wikipedia.org/wiki/Rand_index#Adjusted_Rand_index',
+    'principal component analysis':
+        'https://en.wikipedia.org/wiki/Principal_component_analysis',
+    'cosine similarity': 'https://en.wikipedia.org/wiki/Cosine_similarity',
+    'multiple comparisons': 'https://en.wikipedia.org/wiki/Multiple_comparisons_problem',
+    'false discovery rate': 'https://en.wikipedia.org/wiki/False_discovery_rate',
+    'multilayer network': 'https://en.wikipedia.org/wiki/Multidimensional_network',
+    'p-value': 'https://en.wikipedia.org/wiki/P-value',
+    'permutation test': 'https://en.wikipedia.org/wiki/Permutation_test',
+    'outlier': 'https://en.wikipedia.org/wiki/Outlier',
+}
+
+
+def term(name: str, shown: str | None = None) -> str:
+    """Link a statistical term to its Wikipedia article."""
+    url = GLOSSARY.get(name)
+    label = shown or name
+    return (f'<a class="term" href="{url}" target="_blank" rel="noopener">{label}</a>'
+            if url else label)
+
+
+def _family_summary(results, decisive, comparable) -> str:
+    """One phrase describing what a family is worth reading for."""
+    gained = [c for c in results if c['improved']]
+    if gained:
+        return (f'{len(gained)} rewrite{"" if len(gained) == 1 else "s"} gained support'
+                + (f', {len(decisive) - len(gained)} lost it'
+                   if len(decisive) > len(gained) else ''))
+    if decisive:
+        return f'{len(decisive)} rewrite{"" if len(decisive) == 1 else "s"} lost support'
+    if comparable:
+        return f'{len(comparable)} compared, no clear difference'
+    return 'nothing comparable'
+
+
+def word_diff(old: str, new: str) -> str:
+    """Wikipedia-style inline word diff of two statements.
+
+    Word-level rather than character-level, because these are rewrites of prose and
+    a character diff of Dutch compounds is unreadable. Removals and additions carry
+    strikethrough and underline as well as colour, so the diff survives greyscale
+    printing and colour-blind reading.
+    """
+    tokens = lambda t: _re.findall(r'\s+|\w+|[^\w\s]', t or '')
+    a, b = tokens(old), tokens(new)
+    out = []
+    for op, i1, i2, j1, j2 in difflib.SequenceMatcher(None, a, b).get_opcodes():
+        if op == 'equal':
+            out.append(html.escape(''.join(a[i1:i2])))
+        else:
+            if op in ('replace', 'delete'):
+                gone = ''.join(a[i1:i2])
+                if gone.strip():
+                    out.append(f'<del>{html.escape(gone)}</del>')
+            if op in ('replace', 'insert'):
+                added = ''.join(b[j1:j2])
+                if added.strip():
+                    out.append(f'<ins>{html.escape(added)}</ins>')
+    return ''.join(out)
+
+
+# ── HTML report ──────────────────────────────────────────────────────────────
+
+def _with_contents(document: str) -> str:
+    """Give every section an anchor and put a contents list above the first one.
+
+    Done on the finished document rather than at each `parts.append` so that adding a
+    section anywhere cannot forget to register itself — the list is derived, never
+    maintained. Headings that already carry an id keep it, so existing links (#by-chance)
+    stay valid.
+    """
+    used: set[str] = set()
+
+    def slug(text: str) -> str:
+        base = _re.sub(r'[^a-z0-9]+', '-',
+                       html.unescape(_re.sub(r'<[^>]+>', '', text)).lower()).strip('-')
+        base = base[:48] or 'section'
+        candidate, n = base, 2
+        while candidate in used:
+            candidate, n = f'{base}-{n}', n + 1
+        used.add(candidate)
+        return candidate
+
+    entries: list[tuple[int, str, str]] = []
+
+    def register(match):
+        level, attrs, text = int(match.group(1)), match.group(2), match.group(3)
+        existing = _re.search(r'id="([^"]+)"', attrs or '')
+        anchor = existing.group(1) if existing else slug(text)
+        if existing:
+            used.add(anchor)
+        entries.append((level, anchor, text))
+        return (f'<h{level}{attrs} id="{anchor}">{text}</h{level}>' if not existing
+                else match.group(0))
+
+    document = _re.sub(r'<h([23])([^>]*)>(.*?)</h\1>', register, document, flags=_re.S)
+    if len(entries) < 3:
+        return document
+
+    items = []
+    depth = 2
+    for level, anchor, text in entries:
+        label = html.unescape(_re.sub(r'<[^>]+>', '', text)).strip()
+        if level == 3 and depth == 2:
+            items.append('<ol>')
+        elif level == 2 and depth == 3:
+            items.append('</ol>')
+        depth = level
+        items.append(f'<li><a href="#{anchor}">{html.escape(label)}</a></li>')
+    if depth == 3:
+        items.append('</ol>')
+    toc = ('<nav class="toc"><b>On this page</b><ol>' + ''.join(items) + '</ol></nav>')
+
+    first = _re.search(r'<h2', document)
+    return document[:first.start()] + toc + document[first.start():] if first else document
+
+
+def _svg(fig) -> str:
+    if fig is None:
+        return '<p class="missing">Not available for this consultation.</p>'
+    buf = io.StringIO()
+    fig.savefig(buf, format='svg', bbox_inches='tight')
+    plt.close(fig)
+    svg = buf.getvalue()
+    return svg[svg.index('<svg'):]
+
+
+def _table(df: pd.DataFrame, max_rows: int = 40) -> str:
+    if df is None or (hasattr(df, 'empty') and df.empty):
+        return '<p class="missing">Nothing to show.</p>'
+    return df.head(max_rows).to_html(index=False, border=0, na_rep='—',
+                                     classes='data', justify='left')
+
+
+CSS = """
+:root { --surface:#fcfcfb; --ink:#0b0b0b; --soft:#52514e; --muted:#8a8880;
+        --rule:#e5e4e0; --g1:#2a78d6; --g2:#eb6834; --improved:#eef4ea;
+        --quiet:#6e6c63; --good:#1b7f4d; }
+* { box-sizing:border-box; }
+body { margin:0; background:var(--surface); color:var(--ink);
+       font:16px/1.62 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,sans-serif; }
+main { max-width:860px; margin:0 auto; padding:56px 24px 96px; }
+h1 { font-size:2rem; line-height:1.22; margin:0 0 .3em; letter-spacing:-.01em; }
+h2 { font-size:1.32rem; margin:2.8em 0 .6em; padding-top:1.4em; border-top:1px solid var(--rule); }
+h3 { font-size:1.05rem; margin:2em 0 .4em; }
+p, li { color:#1c1c1a; }
+.lede { font-size:1.09rem; color:var(--soft); margin-bottom:2.4em; }
+figure { margin:1.8em 0; }
+figure svg { max-width:100%; height:auto; display:block; }
+.figwrap { overflow-x:auto; }
+table.data { border-collapse:collapse; font-size:.87rem; width:100%; margin:1.2em 0; }
+table.data th { text-align:left; font-weight:600; color:var(--soft);
+                border-bottom:1.5px solid var(--rule); padding:7px 10px 7px 0; }
+table.data td { border-bottom:1px solid var(--rule); padding:7px 10px 7px 0;
+                vertical-align:top; }
+.tablewrap { overflow-x:auto; }
+.check { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:.82rem;
+         color:var(--soft); }
+.check .ok { color:#1b7f4d; } .check .bad { color:#c0362c; font-weight:600; }
+.missing { color:var(--quiet); font-style:italic; }
+.footnote { font-size:.82rem; color:var(--quiet); border-left:2px solid var(--rule);
+            padding-left:12px; max-width:64ch; }
+.toc { border-top:1px solid var(--rule); border-bottom:1px solid var(--rule);
+       padding:.9em 0; margin:2em 0; font-size:.88rem; }
+.toc b { display:block; font-size:.78rem; letter-spacing:.06em; text-transform:uppercase;
+         color:var(--quiet); margin-bottom:.5em; font-weight:600; }
+.toc ol { list-style:none; margin:0; padding:0; }
+.toc li { margin:.25em 0; }
+.toc ol ol { margin:.15em 0 .4em 1.1em; }
+.toc ol ol li { color:var(--quiet); font-size:.95em; }
+.toc a { color:inherit; text-decoration:none; border-bottom:1px solid transparent; }
+.toc a:hover { border-bottom-color:var(--quiet); }
+figcaption { font-size:.82rem; color:var(--quiet); max-width:70ch; margin-top:.6em;
+             line-height:1.5; }
+.temporary { border:1px dashed var(--rule); border-left:3px solid var(--quiet);
+             padding:.2em 1.1em 1em; margin:2.4em 0; }
+.temporary h2 { margin-top:.8em; }
+.tag { display:inline-block; vertical-align:middle; margin-left:.6em; padding:.15em .5em;
+       border:1px solid var(--quiet); border-radius:3px; font-size:.6em;
+       letter-spacing:.08em; text-transform:uppercase; color:var(--quiet);
+       font-weight:600; }
+a.term { color:inherit; text-decoration:underline dotted; text-underline-offset:3px;
+         text-decoration-color:var(--quiet); }
+a.term:hover { text-decoration-style:solid; color:var(--g1); }
+.family { border-top:1px solid var(--rule); padding:.5em 0; }
+.family > summary { cursor:pointer; font-size:.88rem; color:var(--soft); padding:.15em 0; }
+.family > summary:hover { color:var(--ink); }
+.family[open] > summary { margin-bottom:.35em; }
+.diff { margin:.5em 0 .85em; padding-left:12px; border-left:2px solid var(--rule);
+        font-size:.85rem; }
+.diff .ids { font-size:.71rem; color:var(--quiet); font-family:ui-monospace,Menlo,monospace;
+             margin-bottom:.3em; }
+.diff p.text { margin:.15em 0 .3em; line-height:1.55; }
+.diff del { text-decoration:line-through; color:#a8341f; background:#fbeae6;
+            padding:0 2px; border-radius:2px; }
+.diff ins { text-decoration:underline; color:#0f5f3f; background:#e4f2ea;
+            padding:0 2px; border-radius:2px; }
+.parallel { font-size:.78rem; color:var(--quiet); margin:.1em 0 .5em; }
+.parallel > summary { cursor:pointer; color:var(--quiet); }
+.parallel > summary:hover { color:var(--soft); }
+.parallel p { margin:.25em 0 .4em 1.1em; color:var(--quiet); max-width:62ch; }
+.famroot { color:var(--soft); font-size:.83rem; margin:.1em 0 .6em;
+           padding-left:14px; border-left:3px solid var(--rule); }
+.callout { background:var(--improved); border-left:3px solid var(--good);
+           padding:.7em 14px; border-radius:0 5px 5px 0; }
+.callout a { color:var(--good); font-weight:600; }
+.callout .infam { color:var(--quiet); font-size:.86em; font-weight:400; }
+.diff.improved { border-left:3px solid var(--good); background:var(--improved);
+                 padding:.5em 12px .35em; border-radius:0 4px 4px 0; }
+.diff .sim { float:right; font-size:.68rem; color:var(--quiet); }
+.diff .verdictline { font-size:.76rem; color:var(--quiet); margin:.15em 0 0; }
+.diff .badge { display:inline-block; margin-left:8px; padding:1px 7px; border-radius:9px;
+               background:var(--good); color:#fff; font-size:.66rem; letter-spacing:.03em;
+               text-transform:uppercase; vertical-align:1px; }
+.diff .verdict { font-size:.78rem; color:var(--soft); margin:.1em 0 0; }
+.diff .verdict summary { cursor:pointer; color:var(--soft); }
+.diff .verdict summary::marker { color:var(--muted); }
+.diff .verdict p { margin:.4em 0 0; color:var(--quiet); max-width:60ch; }
+@media (prefers-color-scheme: dark) {
+  .diff del { color:#f0a08c; background:#3a1e18; }
+  .diff ins { color:#8fd8b4; background:#16301f; }
+}
+.caveats { background:#f4f3ef; border-radius:10px; padding:20px 24px; margin:2.4em 0; }
+.caveats h2 { border:0; padding:0; margin:0 0 .5em; font-size:1.1rem; }
+.roster { font-size:.8rem; color:var(--quiet); line-height:1.75; }
+.roster summary { cursor:pointer; color:var(--soft); font-size:.92rem; }
+.roster b { color:var(--soft); font-weight:600; }
+.meta { font-size:.82rem; color:var(--quiet); margin-top:3.5em;
+        border-top:1px solid var(--rule); padding-top:1.2em; }
+@media (prefers-color-scheme: dark) {
+  :root { --surface:#1a1a19; --ink:#fff; --soft:#c3c2b7; --muted:#8a8880;
+          --rule:#33322f; --g1:#3987e5; --g2:#d95926; --improved:#15251c;
+          --quiet:#a3a199; --good:#5cc48d; }
+  p, li { color:#e8e7e1; }
+  .caveats { background:#232320; }
+}
+"""
+
+
+
+#: Every statistical term the reports use, linked to its Wikipedia article. A reader
+#: who meets "modularity" or "silhouette" for the first time should not have to take
+#: the number on faith, and a footnote they cannot follow is no better than none.
+GLOSSARY = {
+    'k-means': 'https://en.wikipedia.org/wiki/K-means_clustering',
+    'Leiden': 'https://en.wikipedia.org/wiki/Leiden_algorithm',
+    'modularity': 'https://en.wikipedia.org/wiki/Modularity_(networks)',
+    'silhouette': 'https://en.wikipedia.org/wiki/Silhouette_(clustering)',
+    'adjusted Rand index': 'https://en.wikipedia.org/wiki/Rand_index#Adjusted_Rand_index',
+    'principal component analysis':
+        'https://en.wikipedia.org/wiki/Principal_component_analysis',
+    'cosine similarity': 'https://en.wikipedia.org/wiki/Cosine_similarity',
+    'multiple comparisons': 'https://en.wikipedia.org/wiki/Multiple_comparisons_problem',
+    'false discovery rate': 'https://en.wikipedia.org/wiki/False_discovery_rate',
+    'multilayer network': 'https://en.wikipedia.org/wiki/Multidimensional_network',
+    'p-value': 'https://en.wikipedia.org/wiki/P-value',
+    'permutation test': 'https://en.wikipedia.org/wiki/Permutation_test',
+    'outlier': 'https://en.wikipedia.org/wiki/Outlier',
+}
+
+
+def term(name: str, shown: str | None = None) -> str:
+    """Link a statistical term to its Wikipedia article."""
+    url = GLOSSARY.get(name)
+    label = shown or name
+    return (f'<a class="term" href="{url}" target="_blank" rel="noopener">{label}</a>'
+            if url else label)
+
+
+def _family_summary(results, decisive, comparable) -> str:
+    """One phrase describing what a family is worth reading for."""
+    gained = [c for c in results if c['improved']]
+    if gained:
+        return (f'{len(gained)} rewrite{"" if len(gained) == 1 else "s"} gained support'
+                + (f', {len(decisive) - len(gained)} lost it'
+                   if len(decisive) > len(gained) else ''))
+    if decisive:
+        return f'{len(decisive)} rewrite{"" if len(decisive) == 1 else "s"} lost support'
+    if comparable:
+        return f'{len(comparable)} compared, no clear difference'
+    return 'nothing comparable'
+
+
+def word_diff(old: str, new: str) -> str:
+    """Wikipedia-style inline word diff of two statements.
+
+    Word-level rather than character-level, because these are rewrites of prose and
+    a character diff of Dutch compounds is unreadable. Removals and additions carry
+    strikethrough and underline as well as colour, so the diff survives greyscale
+    printing and colour-blind reading.
+    """
+    tokens = lambda t: _re.findall(r'\s+|\w+|[^\w\s]', t or '')
+    a, b = tokens(old), tokens(new)
+    out = []
+    for op, i1, i2, j1, j2 in difflib.SequenceMatcher(None, a, b).get_opcodes():
+        if op == 'equal':
+            out.append(html.escape(''.join(a[i1:i2])))
+        else:
+            if op in ('replace', 'delete'):
+                gone = ''.join(a[i1:i2])
+                if gone.strip():
+                    out.append(f'<del>{html.escape(gone)}</del>')
+            if op in ('replace', 'insert'):
+                added = ''.join(b[j1:j2])
+                if added.strip():
+                    out.append(f'<ins>{html.escape(added)}</ins>')
+    return ''.join(out)
+
+
+# ── HTML report ──────────────────────────────────────────────────────────────
+
+#: Which sections each audience gets. The two reports answer different questions,
+#: so this is a genuine split rather than one document with bits hidden: an
+#: organiser is choosing statements to carry forward, a participant is trying to
+#: understand where they landed and whether to believe it.
+AUDIENCES = {
+    # 'groups_brief' comes before anything that mentions groups. The organiser
+    # report is full of per-group percentages, and a reader who has not been told
+    # what a group is will reasonably assume it means a faction someone belongs to.
+    'organiser': ['intro', 'participation_brief', 'groups_brief', 'deduplication',
+                  'methods_compared', 'ladder', 'consensus',
+                  'divergence', 'wording', 'families', 'generations', 'shortlist',
+                  'caveats', 'meta'],
+    'participant': ['intro', 'participation', 'groups', 'stability', 'divergence',
+                    'roster', 'caveats', 'meta'],
+}
+
+
+def write_report(*, bundle, conv_key, checks, funnel, server, gate, sweep, stability,
+                 divergence, groups, pairs, head_to_heads, effect, roster,
+                 participation=None, families=None, generations=None,
+                 descendants=None, representatives=None, redundant=None,
+                 comparison_figure=None, method_comparison=None, ladder=None,
+                 significance=None, audience='participant', out='report.html') -> Path:
+    """Render one self-contained HTML file for one audience."""
+    if audience not in AUDIENCES:
+        raise ValueError(f'audience must be one of {sorted(AUDIENCES)}')
+    show = set(AUDIENCES[audience])
+    b = bundle
+    row = b.app['conversations']
+    title = row.loc[row['conv_key'] == conv_key, 'title']
+    title = title.iloc[0] if len(title) else conv_key
+
+    def esc(x):
+        return html.escape(str(x))
+
+    machine = b.machine.get((conv_key, 2), {})
+    n_real = int(b.phase('votes_latest', conv_key, 2)['person_key'].nunique())
+
+    # Whether the grouping survived its own significance test. Two sections below rank
+    # statements by how far apart the groups fall, and they read very differently
+    # depending on the answer — so the answer travels with them instead of staying in
+    # the section that computed it, several screens up. The threshold is corrected for
+    # the number of tests run, matching what that section says in words.
+    grouping_is_weak = False
+    if significance is not None and not significance.empty:
+        p_values = significance['p (permutation test)']
+        grouping_is_weak = bool(p_values.min() > 0.05 / len(p_values))
+    weak_note = ''
+    if grouping_is_weak:
+        where = ('<a href="#by-chance">see <i>Could this have happened by chance?</i></a>'
+                 if 'ladder' in show else 'see <i>How solid is that split?</i> above')
+        weak_note = (
+            f'<p class="footnote"><b>These gaps describe individuals, not camps.</b> '
+            f'The grouping they rest on is not statistically distinguishable from no '
+            f'grouping at all ({where}), and the smaller group is small enough that one '
+            f'person accounts for much of any gap. Read a wide gap as a statement worth '
+            f'discussing, not as evidence of a division in the community.</p>')
+
+    parts = ['<!doctype html><html lang="en"><head><meta charset="utf-8">',
+             '<meta name="viewport" content="width=device-width,initial-scale=1">',
+             f'<title>{esc(title)} — '
+             f'{"choosing statements" if audience == "organiser" else "results"}</title>',
+             f'<style>{CSS}</style></head><body><main>']
+
+    # ── intro ────────────────────────────────────────────────────────────────
+    parts.append(f'<h1>{esc(title)}</h1>')
+    if audience == 'organiser':
+        parts.append(
+            '<p class="lede">Which statements carry support, which divide the room, '
+            'and — where the same idea was written several ways — which wording did '
+            'best. Intended for deciding what goes forward to a draft.</p>')
+        parts.append(
+            '<p>The recommendations come first, below the participation numbers: one '
+            'wording per group of rewrites, plus the statements nobody rewrote. '
+            'Everything after them is the working that produced them — including the '
+            'reason the group columns on this page carry a warning.</p>')
+    else:
+        parts.append(
+            '<p class="lede">What came out of the consultation: how many people took '
+            'part, what the opinion groups are, and how solid that grouping turns out '
+            'to be.</p>')
+
+    # Machine-made accounts are excluded silently: they are a defect in the tool,
+    # not a finding about the consultation. The one exception is when participants
+    # can see the live results page for themselves — then the totals visibly
+    # disagree, and leaving that unexplained is worse than a short note.
+    conv_row = b.app['conversations']
+    public_results = bool(conv_row.loc[conv_row['conv_key'] == conv_key,
+                                       'phase_public_results'].iloc[0]) \
+        if 'phase_public_results' in conv_row.columns and len(conv_row) else False
+    if machine and public_results:
+        parts.append(
+            f'<p>If you have seen the results page in the tool itself, it reports a '
+            f'higher number of participants than this page does. That count includes '
+            f'{len(machine)} entries the software created automatically rather than '
+            f'people — submitting a statement registers an automatic agreement with it. '
+            f'This analysis counts only the {n_real} people.</p>')
+
+    # ── participation ────────────────────────────────────────────────────────
+    if 'participation' in show:
+        parts.append('<h2>Who took part</h2>')
+        parts.append(
+            '<p>“Participants” can mean several things. '
+            'Someone who gave one opinion and someone who worked through eighty are '
+            'both counted once on the results page. The opinion groups are built only '
+            'from people who gave enough opinions for the clustering to place them.</p>')
+        parts.append(f'<div class="tablewrap">{_table(funnel.drop(columns=["pct_of_voters"]))}</div>')
+        parts.append(
+            '<p>How many people opened the page is not recorded — wiki-polis does not '
+            'log page views — so “joined” is the earliest honest number.</p>')
+    statements_all = b.phase('statements', conv_key, 2)
+    prov_all = b.app['statement_provenance']
+    n_seeded = int(statements_all['is_seed'].astype(bool).sum())
+    derived_tids = set(prov_all.loc[prov_all['conv_key'] == conv_key,
+                                    'polis_statement_id']) if not prov_all.empty else set()
+    n_improved = int(statements_all['tid'].isin(derived_tids).sum())
+    n_new = len(statements_all) - n_seeded - n_improved
+    voted_tids = set(b.phase('votes_latest', conv_key, 2)['tid'])
+    n_unvoted = int((~statements_all['tid'].isin(voted_tids)).sum())
+
+    if {'participation', 'participation_brief'} & show:
+        parts.append(
+            f'<p><b>{len(statements_all)} statements</b> were put to participants: '
+            f'{n_seeded} written by the organiser to start the consultation, '
+            f'{n_new} proposed by participants as new ideas, and {n_improved} '
+            f'submitted as an improved wording of an existing statement. '
+            f'{n_unvoted} of the {len(statements_all)} drew no opinion from anyone '
+            f'who was shown them — because they were never shown. This conversation '
+            f'moderates strictly: a statement reaches participants only once the '
+            f'organiser accepts it.</p>')
+        n_accepted = int((statements_all['mod'] == 1).sum())
+        n_rejected = int((statements_all['mod'] == -1).sum())
+        n_pending = int((statements_all['mod'] == 0).sum())
+        # "Of those" used to open this sentence, with the previous paragraph's "43 never
+        # voted on" as its nearest antecedent — but 60 + 28 + 19 is 107. A reader doing
+        # the arithmetic against 43 concludes the page cannot add up.
+        parts.append(
+            f'<p>Across all {len(statements_all)}, the organiser accepted '
+            f'<b>{n_accepted}</b> and rejected {n_rejected}; {n_pending} were never '
+            f'moderated either way. Nothing is shown to participants until it is '
+            f'accepted, so those {n_pending} were never seen by anyone. A rejected '
+            f'statement stops being shown, but opinions already given on it remain in '
+            f'the data.</p>')
+
+        # Submitting a statement casts a vote on it. Whether that vote is inside the
+        # percentages below depends on where it landed, which is a property of a bug
+        # rather than of the consultation — so it is stated from the data each time
+        # rather than assumed, and the wording changes if the bug is fixed.
+        auto = auto_agree_votes(b, conv_key, phase=2)
+        if auto['total']:
+            parts.append(
+                f'<p><b>Submitting a statement also records an opinion on it.</b> The '
+                f'tool records the submitter as agreeing with what they have just '
+                f'written, for new statements and rewordings alike — {auto["total"]} '
+                f'such opinions here, one per statement.</p>')
+            if auto['on_real'] == 0:
+                parts.append(
+                    f'<p>None of them are counted below. Every one was recorded against '
+                    f'an account the software created at the moment of submission rather '
+                    f'than against the person submitting, and those accounts are excluded '
+                    f'from this analysis. So no statement here carries the <i>automatic</i> '
+                    f'agreement generated when it was submitted — every percentage is '
+                    f'made of opinions given by someone who was shown the statement and '
+                    f'responded to it.</p>')
+            elif auto['on_machine'] == 0:
+                parts.append(
+                    f'<p><b>All {auto["on_real"]} are counted below as ordinary '
+                    f'agreements.</b> Each statement therefore starts with one agreement '
+                    f'that nobody chose to give it, which raises its apparent support — '
+                    f'most visibly on statements few people gave an opinion on, and '
+                    f'systematically on rewordings, since every rewording brings one '
+                    f'with it.</p>')
+            else:
+                parts.append(
+                    f'<p>{auto["on_machine"]} of them were recorded against accounts the '
+                    f'software created rather than against people, and are excluded. The '
+                    f'remaining <b>{auto["on_real"]} are counted below as ordinary '
+                    f'agreements</b>, so those statements carry one agreement that '
+                    f'nobody chose to give them.</p>')
+            parts.append(
+                '<p class="footnote">Whether anyone went on to give an opinion on a '
+                'statement they wrote cannot be told apart here, in either direction: who '
+                'wrote which statement was left out of the data this was built from.</p>')
+
+    # Both audiences see 22 analysed and 24 placed, a few lines apart, and both are
+    # entitled to know why one exceeds the other. This used to live in `groups_brief`,
+    # which only the organiser gets — so the participant report showed the discrepancy
+    # bare, under a lede promising the groups are built from people who voted enough.
+    if {'participation', 'participation_brief'} & show and server.get('available'):
+        n_placed = len({p for p in server['labels'] if p not in machine})
+        analysed = funnel.loc[funnel['step'].str.startswith('ANALYSED'), 'n_people']
+        analysed = int(analysed.iloc[0]) if len(analysed) else 0
+        if analysed and n_placed != analysed:
+            parts.append(
+                f'<p class="footnote">Those two rows do not match, and the difference is '
+                f'not people being dropped. The tool placed {n_placed} people into '
+                f'groups using its own count of who had given enough opinions; the checks '
+                f'on this page rerun the grouping on the {analysed} who clear the '
+                f'threshold applied here. It is a disagreement about who counts as having '
+                f'given enough opinions, not about anybody’s opinions.</p>')
+
+    if 'participation_brief' in show:
+        parts.append(
+            f'<p>{n_real} people took part; {int((funnel["step"].str.startswith("ANALYSED")).any() and funnel.loc[funnel["step"].str.startswith("ANALYSED"), "n_people"].iloc[0])} '
+            f'of them gave opinions on enough statements to be included in the group '
+            f'analysis. '
+            f'Everything below rests on those numbers, which are small.</p>')
+
+    # ── groups ───────────────────────────────────────────────────────────────
+    if 'groups' in show and server.get('available'):
+        real_labels = {p: g for p, g in server['labels'].items() if p not in machine}
+        sizes = pd.Series(list(real_labels.values())).value_counts().sort_index()
+        listing = ' and '.join(f'{n} people' for n in sizes.values)
+        parts.append('<h2>The opinion groups</h2>')
+        parts.append(
+            f'<p>The clustering sorted participants into <b>{len(sizes)} groups</b> — '
+            f'{listing} — based only on their opinions, not on anything they said. '
+            f'A group is a set of people whose opinions resemble each other more than '
+            f'they resemble the rest.</p>')
+        parts.append(f'<figure class="figwrap">{_svg(plot_opinion_map(b, conv_key, server))}</figure>')
+        if len(sizes) and sizes.min() < 5:
+            parts.append(
+                f'<p><b>The smaller group has {sizes.min()} people in it.</b> That is few '
+                f'enough that it describes those individuals rather than a faction, and '
+                f'a single person changing a few opinions could dissolve it.</p>')
+
+    # ── stability ────────────────────────────────────────────────────────────
+    if 'stability' in show:
+        parts.append('<h2>How solid is that split?</h2>')
+        parts.append(
+            '<p>The software always reports between two and five groups. It has no way '
+            'of reporting “these people do not really divide”. So the same opinions were '
+            'given to a completely different method and run repeatedly under different '
+            'settings, to see whether the same people keep landing together.</p>')
+        if stability.get('available'):
+            parts.append(
+                f'<p>Across {stability["n_runs"]} runs of the second method — different '
+                f'settings, different starting points — only '
+                f'<b>{stability["pairs_decided"]:.0%}</b> of the pairs of people in '
+                f'{stability["n_people"]} landed together nearly every time, or apart '
+                f'nearly every time. If the consultation really divided into camps this '
+                f'would be close to 100%: two people in the same camp would keep '
+                f'turning up together whatever the settings. Instead almost every pair '
+                f'changes sides depending on how the method is set.</p>')
+            parts.append(f'<figure class="figwrap">'
+                         f'{_svg(plot_stability_heatmap(stability, server))}</figure>')
+        if comparison_figure is not None:
+            parts.append(
+                '<p>The picture that follows is the check itself, and it is worth reading '
+                'slowly. Every small square compares two people: dark means they agreed '
+                'most of the time, pale means they often disagreed. In the '
+                'first two panels the same 22 people appear in both rows and columns — '
+                'first ordered by the groups the tool’s own method produces when rerun '
+                'here, then by the groups the second method found. Black lines mark the '
+                'boundaries between groups.</p>')
+            parts.append(
+                '<p><b>What a real division would look like:</b> dark squares along the '
+                'diagonal, inside the black boxes, against a pale background everywhere '
+                'else — people agreeing with their own group and disagreeing with the '
+                'other. That is not what either panel shows. The shading is much the '
+                'same inside the boxes as outside them, under both orderings.</p>')
+            # The paragraph above describes a pattern that is *absent*, directly over a
+            # figure of real measurements — so a reader cannot tell whether they are
+            # looking at this consultation or at an illustration of one. Say which.
+            parts.append(
+                f'<figure class="figwrap">{_svg(comparison_figure)}'
+                f'<figcaption>Both panels are the opinions actually recorded in this '
+                f'consultation — the same {stability.get("n_people", 22)} people, '
+                f'ordered two different ways. Nothing here is simulated or drawn for '
+                f'illustration. The pattern described above is the one that is '
+                f'<i>absent</i>: were it present, it would show as dark blocks inside '
+                f'the black boxes.</figcaption></figure>')
+            parts.append(
+                f'<p>The third panel explains why. {term("modularity", "Modularity")} asks '
+                'whether people are '
+                'more densely connected to their own group than chance would predict. '
+                'In the shaded stretch on the left the second method declines to split '
+                'at all and puts everyone in one community — a score of zero there means '
+                '“no split attempted”, not “a perfect split”. Once it is pushed to '
+                'divide people, the score goes <i>below</i> zero: the divisions it makes '
+                'are worse than random.</p>')
+            parts.append(
+                '<p>The second method’s own two-way split, when it is forced to make '
+                'one, lands somewhere else entirely — and it scores that split below '
+                'zero. It is not proposing a different line; it is declining to draw '
+                'one. Opinion in this consultation looks '
+                'like a spread — people who mostly agree, differing by degree — rather '
+                'than two camps. The tool reports groups because reporting groups is '
+                'what it does; it has no way to say “these people do not divide”.</p>')
+
+        median_overlap = sweep.attrs.get('median_overlap', float('nan'))
+        if median_overlap == median_overlap and median_overlap < 3:
+            parts.append(
+                f'<p><b>This check could not be completed properly.</b> Two participants '
+                f'shared a median of {median_overlap:.0f} statements that they both gave '
+                f'an opinion on, because there were many statements and most people saw '
+                f'a small share of them. With so little overlap the second method has almost '
+                f'nothing to work from, and its answer here should be disregarded rather '
+                f'than read as disagreement.</p>')
+
+    # The recommendations are written last — they depend on everything above them —
+    # but they are what the organiser opened the page for, and they used to sit at the
+    # foot behind ~1400 lines of method. The section is spliced in here instead, after
+    # the framing numbers and before the working, so skimming for decisions reaches
+    # them first. Everything from here to the significance test then reads as the
+    # reason the picks are hedged the way they are.
+    shortlist_anchor = len(parts)
+
+    # ── what a group is ──────────────────────────────────────────────────────
+    if 'groups_brief' in show and server.get('available'):
+        real_labels = {p: g for p, g in server['labels'].items() if p not in machine}
+        sizes = pd.Series(list(real_labels.values())).value_counts().sort_index()
+        parts.append('<h2>First: what “a group” means here</h2>')
+        parts.append(
+            '<p>Several tables below break results down by group, so it is worth being '
+            'precise about what that word is doing.</p>')
+        parts.append(
+            '<p>A group is <b>not</b> a faction, a camp, or anything participants signed '
+            'up to. Nobody chose a group and nobody was told they were in one. The '
+            'software compared people’s opinions and sorted them so that those who gave '
+            'similar opinions ended up together. A group is therefore a description of '
+            'opinion patterns on <i>these particular statements</i>, and it would very likely '
+            'come out differently on a different set of statements.</p>')
+        if len(sizes):
+            listing = ', '.join(f'<b>group {g + 1}</b> with {n} '
+                                f'{"person" if n == 1 else "people"}'
+                                for g, n in sizes.items())
+            parts.append(
+                f'<p>In this consultation the clustering produced {len(sizes)} groups: '
+                f'{listing}. The numbering is arbitrary — group 1 is not the majority '
+                f'view or the first to arrive; it is just a label.</p>')
+            parts.append(f'<figure class="figwrap">'
+                         f'{_svg(plot_opinion_map(b, conv_key, server))}</figure>')
+            parts.append(
+                f'<p class="footnote">These sizes are the tool’s own, covering '
+                f'{int(sizes.sum())} people. The checks further down rerun the grouping '
+                f'from scratch on the participants who clear the threshold applied here, '
+                f'so the sizes they report differ slightly — see the note under the '
+                f'participation table above.</p>')
+            if sizes.min() < 5:
+                parts.append(
+                    f'<p><b>This matters for how much weight the group columns can '
+                    f'carry.</b> The smaller group has {sizes.min()} people in it, so a '
+                    f'column reporting “0% agreement in group {int(sizes.idxmin()) + 1}” '
+                    f'may rest on two or three opinions. Where a split looks dramatic below, '
+                    f'check the number of people beside it before drawing a conclusion.</p>')
+
+    # ── deduplication, reviewable ────────────────────────────────────────────
+    if 'deduplication' in show and redundant is not None and not redundant.empty:
+        stmts_all = b.phase('statements', conv_key, 2).set_index('tid')['txt'].to_dict()
+        merged = redundant[redundant['verdict'].str.startswith('redundant')]
+        distinct = redundant[redundant['verdict'].str.startswith('distinct')]
+        unknown = redundant[redundant['verdict'].str.startswith('undecided')]
+        # Pairs where one side was never voted on at all. They cannot be judged by
+        # votes and so fall outside the three buckets above — but they are the ones
+        # where the organiser's own reading is the only thing available, so omitting
+        # them would make "every pair is listed below" false.
+        aside = redundant[redundant['verdict'].str.startswith('set aside')]
+
+        parts.append('<h3>How the groups were worked out</h3>')
+        parts.append(
+            '<p>The grouping is computed from opinions alone. One thing has to be settled '
+            'first: when the same idea appears twice in slightly different words, it '
+            'gets counted twice, and the clustering then treats that idea as twice as '
+            'important. So near-identical statements are merged before grouping.</p>')
+        parts.append(
+            '<p>Deciding which are really the same cannot be done on wording alone — '
+            '“at least a thousand edits” and “at least five hundred edits” are almost '
+            'identical as text and quite different as proposals. So each candidate pair '
+            'is judged by the opinions of the people who gave one on <i>both</i>: if '
+            'they agreed nearly every time, the second version adds nothing '
+            'and is merged. The one exception is wording that carries no meaning at all '
+            '— where two statements are word-for-word the same once spelling and number '
+            'format are normalised (“2 weken” and “twee weken”), they are the same '
+            'statement whether or not anybody gave an opinion on them.</p>')
+        parts.append(
+            f'<p><b>Every pair with opinions on both statements is listed below, so the '
+            f'judgement can be overridden</b> — {len(merged) + len(distinct) + len(unknown)} '
+            f'of the {len(redundant)} pairs the wording flagged as similar. On '
+            f'{len(unknown)} of those, too few people gave an opinion on both for the '
+            f'opinions to decide anything. If you can see that two statements are the '
+            f'same and the data could not tell, say so and they can be merged by hand.</p>')
+
+        def pair_rows(frame, note_field=True):
+            out = []
+            for r in frame.itertuples():
+                note = (f'{r.n_common} gave an opinion on both, agreeing '
+                        f'{r.vote_concordance:.0%} of the time'
+                        if r.n_common and r.vote_concordance == r.vote_concordance
+                        else f'only {r.n_common} gave an opinion on both')
+                out.append(
+                    f'<div class="diff"><div class="ids">#{r.tid_a} → #{r.tid_b}'
+                    f'<span class="sim">text {r.similarity:.2f}</span></div>'
+                    f'<p class="text">{word_diff(stmts_all.get(int(r.tid_a), r.text_a), stmts_all.get(int(r.tid_b), r.text_b))}</p>'
+                    f'<p class="verdictline">{esc(note)}</p></div>')
+            return out
+
+        parts.append(
+            f'<details class="family" open><summary><b>Merged — treated as one '
+            f'statement</b> ({len(merged)} pairs)</summary>'
+            + ''.join(pair_rows(merged)) + '</details>')
+        parts.append(
+            f'<details class="family"><summary><b>Kept separate — people gave different '
+            f'opinions on them</b> ({len(distinct)} pairs)</summary>'
+            f'<p class="famroot">These look alike but the opinions say otherwise. Merging '
+            f'them would erase a real disagreement.</p>'
+            + ''.join(pair_rows(distinct)) + '</details>')
+        parts.append(
+            f'<details class="family"><summary><b>Kept separate — too few people gave '
+            f'an opinion on both to tell</b> ({len(unknown)} pairs)</summary>'
+            f'<p class="famroot">No judgement was possible here, so both were kept. '
+            f'This is the list to look through: where you can see two are the same, '
+            f'they should be merged.</p>'
+            + ''.join(pair_rows(unknown)) + '</details>')
+        # The pairs that could not be judged because one side was never voted on are
+        # not worth listing as pairs: what the organiser needs from them is the
+        # statements themselves. Every one of these is a statement that took no part in
+        # anything on this page, and is still available to put to people.
+        if n_unvoted:
+            unvoted_rows = statements_all[~statements_all['tid'].isin(voted_tids)]
+            parts.append(
+                f'<details class="family"><summary><b>Statements nobody gave an opinion '
+                f'on</b> '
+                f'({n_unvoted} of {len(statements_all)}, taking no part in any of the '
+                f'above)</summary>'
+                f'<p class="famroot">Submitted too late to be shown, or never shown. '
+                f'They cannot be compared with anything and they carry no weight in the '
+                f'grouping, so they are simply absent from every number on this page — '
+                f'including the merging judgements above, {len(aside)} of which involve '
+                f'one of them. Nothing has been decided about these: they are still '
+                f'available to put to people in the next round.</p>'
+                + ''.join(
+                    f'<div class="diff"><div class="ids">#{int(r.tid)}</div>'
+                    f'<p class="text">{esc(r.txt)}</p></div>'
+                    for r in unvoted_rows.itertuples())
+                + '</details>')
+
+    # ── two methods, compared ────────────────────────────────────────────────
+    if 'methods_compared' in show and method_comparison is not None:
+        mc = method_comparison
+        parts.append('<h3>Two ways of finding groups, and whether they agree</h3>')
+        parts.append(
+            '<p>Any grouping is the product of a method, so it is worth knowing that '
+            'two quite different methods were tried, and what each concluded.</p>')
+        parts.append(
+            '<p><b>The first is what the tool itself uses:</b> it places every '
+            'participant on a map according to their opinions — people who agreed end '
+            'up near each other — and then cuts that map into a fixed number of pieces '
+            f'({term("k-means", "<i>k-means</i>")}). It is built to produce groups, and will produce them '
+            'from any set of opinions at all. It cannot report that there are none.</p>')
+        parts.append(
+            f'<p><b>The second treats the participants as a network</b> '
+            f'({term("Leiden", "<i>Leiden community detection</i>")}). Each person is '
+            'connected to everyone they tend '
+            'to agree with, and the method looks for clumps that are more tightly '
+            'connected inside than to the rest. Crucially, it <i>can</i> come back and '
+            'say there are no clumps — which is the reason for using it here.</p>')
+        rows = [{'method': 'k-means on the opinion map (what the tool uses)',
+                 'groups found': mc['k_polis'], 'sizes': mc['sizes_polis'],
+                 'its own score for that split':
+                     f'{mc["silhouette_polis"]:.3f} (silhouette)'
+                     if 'silhouette_polis' in mc else ''},
+                {'method': 'Leiden community detection',
+                 'groups found': mc['k_leiden'], 'sizes': mc['sizes_leiden'],
+                 'its own score for that split':
+                     f'{mc["modularity_leiden"]:.3f} (modularity)'
+                     if 'modularity_leiden' in mc else ''}]
+        columns = ['method', 'groups found', 'sizes', 'its own score for that split']
+        if not any(r['its own score for that split'] for r in rows):
+            columns = columns[:-1]
+        parts.append(
+            f'<div class="tablewrap">{_table(pd.DataFrame(rows)[columns])}</div>')
+        if mc.get('n_analysed'):
+            drift = mc.get('ari_vs_server')
+            drift_text = (
+                f' Run on that smaller population the first method draws a slightly '
+                f'different line — it agrees with the published grouping at '
+                f'{drift:.2f} rather than exactly, moving a couple of people across.'
+                if drift is not None and drift == drift else '')
+            exact = (' Given the tool’s own population it reproduces the published '
+                     'grouping exactly.' if gate and gate.get('passed') else '')
+            parts.append(
+                f'<p class="footnote">Both methods were rerun here on the '
+                f'{mc["n_analysed"]} participants who cleared the opinion threshold, which '
+                f'is why the first row’s group sizes are not the tool’s published ones '
+                f'quoted earlier.{drift_text}{exact}</p>')
+        parts.append(
+            f'<p><b>They agree very little.</b> Measured on a scale where 1.0 means '
+            f'identical groupings and 0.0 means no more alike than chance '
+            f'({term("adjusted Rand index")}), the two '
+            f'score <b>{mc["ari"]:.2f}</b>. The table below shows where each person '
+            f'ended up under both methods — if the two were finding the same division, '
+            f'the numbers would sit along a diagonal.</p>')
+        parts.append(f'<div class="tablewrap">{mc["crosstab_html"]}</div>')
+        score = mc.get('modularity_leiden')
+        parts.append(
+            f'<p><b>The second row has to be read with its score.</b> The second method '
+            f'also reports <i>how much</i> group structure it found, and here it found '
+            f'none. It returns two communities in the table above only because it was '
+            f'held to one fixed setting so that the two methods could be compared at '
+            f'all; it scores that division at '
+            f'{f"{score:.3f}" if score is not None else "at or below zero"} — '
+            f'{"below" if (score is None or score < 0) else "at"} zero, meaning the '
+            f'split is no better than dividing the same people at random. Allowed to '
+            f'choose for itself it puts everybody in a single community. So the '
+            f'disagreement above is not two methods drawing the line in different '
+            f'places. It is one method saying there is no line to draw.</p>')
+        if comparison_figure is not None:
+            parts.append(
+                f'<figure class="figwrap">{_svg(comparison_figure)}'
+                f'<figcaption>Real data, not an illustration: these are the opinions '
+                f'recorded in this consultation, the same people ordered two different '
+                f'ways. A genuine division would appear as dark blocks inside the black '
+                f'boxes — which is what to look for, and what is not there.</figcaption>'
+                f'</figure>')
+            parts.append(
+                '<p>In the first two panels every small square compares two people — '
+                'dark means they agreed. People are ordered by their group, first '
+                'under one method then the other, with black lines at the boundaries. A '
+                'real division would show dark blocks inside the boxes against a pale '
+                'background; neither ordering does. The third panel is the structure '
+                'score: in the shaded stretch the method declined to split at all, and '
+                'beyond it the score falls below zero.</p>')
+
+    # ── the refinement ladder + significance ─────────────────────────────────
+    if 'ladder' in show and ladder is not None:
+        parts.append('<h3>How much the answer depends on the choices made</h3>')
+        parts.append(
+            '<p>Neither method is applied only once. Each was run three times, with a '
+            'more careful preparation of the data each time. Statements nobody gave an '
+            'opinion on are removed throughout — they carry no information at any level.</p>')
+        parts.append(
+            '<ul><li><b>naive</b> — the method as the tool applies it</li>'
+            '<li><b>deduplicated</b> — near-identical statements merged, so one idea '
+            'written several ways stops counting several times</li>'
+            f'<li><b>layered</b> — statements split by subject and each subject grouped '
+            f'separately, then combined. Only this level can represent someone who '
+            f'agrees with you about elections and disagrees about blocks; a single '
+            f'grouping cannot ({term("multilayer network", "multilayer methods")})</li></ul>')
+        parts.append(f'<div class="tablewrap">{_table(ladder)}</div>')
+        parts.append(
+            '<p>Read down each method. The number of groups the first method reports '
+            'changes at every level — two, then three, then four — and its agreement '
+            'with its own first answer falls to 0.22. The second method declines to '
+            'divide anyone at all until the layered level forces it to. If the groups '
+            'described something solid about these participants, neither of those '
+            'things would happen.</p>')
+
+    if 'ladder' in show and significance is not None and not significance.empty:
+        parts.append('<h3 id="by-chance">Could this have happened by chance?</h3>')
+        parts.append(
+            '<p>A grouping method always returns an answer and always returns a score. '
+            'The question is whether the score means anything. To find out, the same '
+            'procedure was run 100 times on deliberately scrambled data — each '
+            'statement keeps its own opinions, but they are reassigned to different people '
+            'at random, so any pattern connecting one statement to another is '
+            'destroyed. That is what "no groups" looks like. If the real data scores no '
+            'better than the scrambled data, the grouping cannot be told apart from '
+            'noise.</p>')
+        parts.append(f'<div class="tablewrap">{_table(significance)}</div>')
+        parts.append(
+            f'<p><b>Scrambled data scores almost as well as the real data.</b> The '
+            f'quality score for the first method sits around 0.37 on data with no '
+            f'groups in it at all, against 0.46–0.48 here — a gap small enough that it '
+            f'arises by chance about one time in eleven without deduplication, and about '
+            f'one in twenty with it. The second method scores identically on real and '
+            f'scrambled data, because on both it declines to split anyone — those two '
+            f'rows are degenerate rather than independent evidence. That leaves two real '
+            f'tests, and the better of the two does not survive the usual correction for '
+            f'{term("multiple comparisons", "testing several things at once")}. With 100 '
+            f'shuffles the p-values also come in steps of about 0.01, so 0.049 and 0.05 '
+            f'are not meaningfully different numbers.</p>')
+        parts.append(
+            f'<p class="footnote">The last column is a '
+            f'{term("p-value", "permutation p-value")}: the fraction of 100 scrambled '
+            f'datasets that scored at least as well as the real data, with the standard '
+            f'+1 correction applied to both counts. It is not the '
+            f'same quantity as the {term("adjusted Rand index")} in the table above, '
+            f'which measures how far two groupings agree with each other.</p>')
+        parts.append(
+            '<p>So the honest summary is this: <b>the opinion groups in this '
+            'consultation are not statistically distinguishable from no groups at '
+            'all.</b> That is not a fault of the consultation, and it does not mean '
+            'people agreed about everything — the disagreements shown elsewhere in this '
+            'report are real. It means the disagreements do not line up into camps, and '
+            'the group labels should not be used as though they identify factions.</p>')
+
+    # ── consensus / divergence ───────────────────────────────────────────────
+    if 'consensus' in show and not divergence.empty:
+        # This table used to sort on min(group1, group2). With three people in group 1,
+        # every entry's group-1 figure rested on one to three votes, so the sort never
+        # selected on that group's level — it only dropped statements where one or two
+        # of those three happened to dissent, excluding several of the best-supported
+        # statements in the consultation while admitting one at 69%. Ranked on overall
+        # agreement instead, which is the quantity that does not depend on a grouping
+        # this report goes on to show is indistinguishable from noise.
+        agreed = divergence[divergence['agree_pct'].notna()].copy()
+        cols = [c for c in agreed.columns if c.startswith('agree_group')]
+        floor = max(5, POLIS_VOTE_THRESHOLD)
+        broad = agreed[agreed['n_decided'] >= floor].sort_values(
+            ['agree_pct', 'n_decided'], ascending=False).head(12)
+        if not broad.empty:
+            parts.append('<h2>Statements with the broadest support</h2>')
+            parts.append(
+                f'<p>Ranked by the share of people who agreed, counting only those who '
+                f'took a side, and only statements at least {floor} people decided on. '
+                f'These are the safest candidates to carry forward, and this ranking '
+                f'does not depend on the opinion groups at all — which matters, because '
+                f'the groups do not survive the checks below.</p>')
+            table = broad[['tid', 'statement', 'agree_pct', 'n_decided'] + cols].rename(
+                columns={'agree_pct': 'agreed %', 'n_decided': 'people who took a side'})
+            parts.append(f'<div class="tablewrap">{_table(table)}</div>')
+            small = [c for c in cols
+                     if broad[c.replace('agree_group', 'decided_group')].max() < 5]
+            if small:
+                parts.append(
+                    '<p class="footnote">The group columns are shown for context only. '
+                    'Where a group is very small its percentage can rest on one or two '
+                    'opinions, so read the overall figure first.</p>')
+
+    if 'divergence' in show and not divergence.empty:
+        parts.append('<h2>Where the groups disagree</h2>')
+        parts.append(
+            '<p>Each statement appears once, showing how much each group agreed with it, '
+            'counting only people who took a side. The further apart the marks, the more '
+            'that statement divides the room.</p>')
+        parts.append(f'<figure class="figwrap">{_svg(plot_divergence(divergence))}</figure>')
+        parts.append(weak_note)
+
+    # ── alterations ──────────────────────────────────────────────────────────
+    if 'wording' in show and descendants is not None and not descendants.empty:
+        parts.append('<h2>Statements that were rewritten, and how</h2>')
+        parts.append(
+            '<p>Where a participant proposed a rewording, the change itself is shown '
+            'below: <del>struck-through</del> text was removed, <ins>underlined</ins> '
+            'text was added. Most of these turn on a single qualifier, and that is '
+            'usually where the real decision sits.</p>')
+        parts.append(
+            '<p>Families are listed with the ones where rewriting made a measurable '
+            'difference first, then the largest. Inside each family the same applies: '
+            'the rewrites that moved something come before the ones with too few '
+            'opinions to judge.</p>')
+
+        stmts = b.phase('statements', conv_key, 2).set_index('tid')['txt'].to_dict()
+        votes = b.phase('votes_latest', conv_key, 2)
+
+        def compare(parent: int, child: int):
+            """Verdict for one rewrite, plus what it is worth. None if unusable."""
+            old, new = stmts.get(parent, ''), stmts.get(child, '')
+            if not old or not new:
+                return None
+            decisive = votes['vote'].isin([RAW_AGREE, RAW_DISAGREE])
+            va = votes[(votes['tid'] == parent) & decisive][['person_key', 'vote']]
+            vb = votes[(votes['tid'] == child) & decisive][['person_key', 'vote']]
+            both = va.merge(vb, on='person_key', suffixes=('_old', '_new'))
+            if len(both) < MIN_COMPARABLE:
+                return dict(parent=parent, child=child, old=old, new=new, delta=0.0,
+                            comparable=False, improved=False,
+                            headline='Not enough opinions to compare',
+                            detail=f'{len(both)} {"person" if len(both) == 1 else "people"} '
+                                   f'gave a clear opinion on both wordings. At least '
+                                   f'{MIN_COMPARABLE} are needed before the two can be '
+                                   f'compared at all.')
+            old_pct = (both['vote_old'] == RAW_AGREE).mean() * 100
+            new_pct = (both['vote_new'] == RAW_AGREE).mean() * 100
+            delta = new_pct - old_pct
+            headline = ('No meaningful difference' if abs(delta) < 10 else
+                        'This rewrite did better' if delta > 0 else
+                        'The earlier wording did better')
+            detail = (f'{len(both)} people gave a clear opinion on both. {old_pct:.0f}% '
+                      f'agreed with the earlier wording, {new_pct:.0f}% with this one — a '
+                      f'difference of {abs(delta):.0f} percentage points. ')
+            detail += ('With this few people, a gap this size is not distinguishable from '
+                       'chance.' if abs(delta) < 10 else
+                       'Individually this is still within what chance produces at this '
+                       'number of people; it is a prompt to read the wording, not a result.')
+            return dict(parent=parent, child=child, old=old, new=new, delta=delta,
+                        comparable=True, headline=headline, detail=detail,
+                        improved=delta >= 10)
+
+        # Families are ordered by what they can actually tell an organiser: those with
+        # a measurable difference first, then those measured and found equivalent, then
+        # those nobody voted on enough to compare. Ordering by family size instead would
+        # put the largest pile of unusable diffs at the top.
+        blocks = []
+        for family in (families or []):
+            rewrites = [m for m in family['members'].itertuples()
+                        if m.improves_on is not None and m.improves_on == m.improves_on]
+            results = [c for c in (compare(int(m.improves_on), int(m.tid))
+                                   for m in rewrites) if c]
+            if not results:
+                continue
+            # Within a family, put the rewrites that actually moved something first.
+            # A family of nine is mostly untestable pairs; leading with those buries
+            # the one comparison that carries information.
+            results.sort(key=lambda c: (c['comparable'] and abs(c['delta']) >= 10,
+                                        abs(c['delta']), c['comparable']), reverse=True)
+            decisive = [c for c in results if c['comparable'] and abs(c['delta']) >= 10]
+            comparable = [c for c in results if c['comparable']]
+            # Near-identical siblings: people independently making the same edit.
+            # Grouped by simple transitive closure so a run of three appears once.
+            member_tids = set(int(t) for t in family['members']['tid'])
+            close = [(int(r.tid_a), int(r.tid_b)) for r in pairs.itertuples()
+                     if r.similarity >= NEAR_IDENTICAL
+                     and int(r.tid_a) in member_tids and int(r.tid_b) in member_tids]
+            parent = {t: t for t in member_tids}
+            def _find(x):
+                while parent[x] != x:
+                    parent[x] = parent[parent[x]]
+                    x = parent[x]
+                return x
+            for a, bb in close:
+                ra, rb = _find(a), _find(bb)
+                if ra != rb:
+                    parent[rb] = ra
+            clusters = {}
+            for t in member_tids:
+                clusters.setdefault(_find(t), []).append(t)
+            parallel = [sorted(v) for v in clusters.values() if len(v) > 1]
+
+            blocks.append({
+                'root': family['root'], 'n_versions': family['size'], 'results': results,
+                'parallel': parallel,
+                # Families where rewriting actually gained support come first, then
+                # those where it made any measurable difference, then the largest.
+                # An organiser reading top-down meets the actionable ones first.
+                'sort': (len([c for c in results if c['improved']]),
+                         len(decisive), family['size']),
+                'summary': _family_summary(results, decisive, comparable),
+                'n_decisive': len(decisive),
+            })
+        blocks.sort(key=lambda x: x['sort'], reverse=True)
+        pairs_shown = sum(len(x['results']) for x in blocks)
+
+        improvements = [(block['root'], c) for block in blocks
+                        for c in block['results'] if c['improved']]
+        if pairs_shown:
+            if improvements:
+                named = ', '.join(
+                    f'<a href="#diff-{c["parent"]}-{c["child"]}">#{c["parent"]} → '
+                    f'#{c["child"]}</a> <span class="infam">(#{root} family, '
+                    f'+{c["delta"]:.0f} points)</span>'
+                    for root, c in sorted(improvements, key=lambda x: -x[1]['delta']))
+                # The threshold behind `improvements` is a display cutoff (a 10-point
+                # margin), not a test. Stating it as "drew more support" promoted two
+                # eyeballed gaps to findings, in a report whose own corrected test
+                # clears none of them. The number stays — it is a useful place to look —
+                # but it is now labelled as what it is, with the tested answer beside it.
+                tested = (effect.get('reading') if isinstance(effect, dict) else None) or (
+                    'None of the comparisons with enough opinions survives correction for '
+                    'testing many pairs at once.')
+                parts.append(
+                    f'<p class="callout"><b>{len(improvements)} of {pairs_shown} rewrites '
+                    f'show a margin of 10 points or more over the wording they replaced</b>, '
+                    f'among the people who gave an opinion on both: {named}. That is a '
+                    f'margin, not '
+                    f'a result — {esc(tested)} Read them as the places most worth looking '
+                    f'at by eye.</p>')
+            else:
+                parts.append(
+                    f'<p>None of the {pairs_shown} rewrites drew more support than the '
+                    f'wording it replaced, among the people who gave an opinion on '
+                    f'both.</p>')
+
+        for block in blocks:
+            informative = block['n_decisive'] > 0
+            parts.append(
+                f'<details class="family"{" open" if informative else ""}>'
+                f'<summary><b>#{block["root"]} family</b> — '
+                f'{block["n_versions"]} versions · {block["summary"]}</summary>')
+            parts.append(f'<p class="famroot">{esc(stmts.get(block["root"], ""))}</p>')
+            if block['parallel']:
+                for cluster in block['parallel']:
+                    ids = ', '.join(f'#{t}' for t in cluster)
+                    parts.append(
+                        f'<details class="parallel"><summary>Versions {ids} look '
+                        f'near-identical</summary><p>Separate attempts at the same '
+                        f'change. Worth deciding whether they need to stay separate '
+                        f'options in the next round.</p></details>')
+            for c in block['results']:
+                parts.append(
+                    f'<div class="diff{" improved" if c["improved"] else ""}" '
+                    f'id="diff-{c["parent"]}-{c["child"]}">'
+                    f'<div class="ids">#{c["parent"]} → #{c["child"]}'
+                    + ('<span class="badge">improvement</span>' if c['improved'] else '')
+                    + '</div>'
+                    f'<p class="text">{word_diff(c["old"], c["new"])}</p>'
+                    f'<details class="verdict"><summary>{esc(c["headline"])}</summary>'
+                    f'<p>{esc(c["detail"])}</p></details></div>')
+            parts.append('</details>')
+
+        if not pairs_shown:
+            parts.append('<p class="missing">No declared rewrites in this consultation.</p>')
+        elif effect.get('available') and effect.get('order_effect_share_earlier') is not None:
+            # This was written as a wording effect measured over people. It is neither:
+            # the denominator is discordant pair-instances, not people (one person
+            # inside a large family generates many), and because variants are compared
+            # in submission order it measures order and exposure, not wording.
+            n_disc = effect.get('n_discordant_pairs')
+            parts.append(
+                f'<p><b>Statements submitted earlier drew more agreement than later '
+                f'ones.</b> Across the '
+                f'{f"{n_disc:,} occasions" if n_disc else "occasions"} where somebody '
+                f'gave different opinions on two similar wordings, the earlier one won '
+                f'{effect["order_effect_share_earlier"]:.0%} of the time.</p>')
+            parts.append(
+                '<p>That is an ordering effect, and it is not the same claim as '
+                '“rewriting costs support”. Variants are compared in the order they were '
+                'submitted, and later statements were shown to fewer people, so exposure '
+                'and order are mixed into this number. It also counts occasions, not '
+                'people: one person inside a large family of rewrites contributes many. '
+                'No individual pair above is distinguishable from chance at this number '
+                'of participants, so treat each as a prompt to read the wording rather '
+                'than as a verdict.</p>')
+
+    # ── families ─────────────────────────────────────────────────────────────
+    if 'families' in show and descendants is not None and not descendants.empty:
+        rewritten = int((descendants['n_children'] > 0).sum())
+        derivative = int(descendants['improves_on'].notna().sum())
+        parts.append('<h2>Which statements attracted the most rewriting</h2>')
+        parts.append(
+            f'<p>Participants can propose a rewording of a statement. Here {derivative} '
+            f'of {len(descendants)} statements are declared rewrites of another, and '
+            f'{rewritten} statements prompted at least one rewrite. A statement with many '
+            f'descendants is one people kept trying to get right — a different signal '
+            f'from disagreement, and usually a better guide to what still needs work.</p>')
+        rename = {'n_children': 'direct rewrites', 'n_descendants': 'rewrites incl. later',
+                  'n_voters': 'people', 'agree_pct': 'agreed %', 'text': 'statement'}
+        cols = ['tid', 'n_children', 'n_descendants', 'n_voters', 'agree_pct', 'text']
+        rewritten_rows = descendants[descendants['n_descendants'] > 0]
+        parts.append(f'<div class="tablewrap">'
+                     f'{_table(rewritten_rows.head(5)[cols].rename(columns=rename))}</div>')
+        rest = rewritten_rows.iloc[5:]
+        if not rest.empty:
+            parts.append(
+                f'<details class="family"><summary>The remaining {len(rest)} statements '
+                f'that were rewritten</summary>'
+                f'<div class="tablewrap">{_table(rest[cols].rename(columns=rename), max_rows=60)}</div>'
+                f'</details>')
+
+        # Parallel rewrites: several people separately making the same change. Sits
+        # here rather than inside each family, because the useful question — "where is
+        # effort being duplicated?" — is asked across the whole consultation at once.
+        parallel_rows = []
+        for family in (families or []):
+            member_tids = set(int(t) for t in family['members']['tid'])
+            close = [(int(r.tid_a), int(r.tid_b)) for r in pairs.itertuples()
+                     if r.similarity >= NEAR_IDENTICAL
+                     and int(r.tid_a) in member_tids and int(r.tid_b) in member_tids]
+            if not close:
+                continue
+            parent_of = {t: t for t in member_tids}
+
+            def find(x):
+                while parent_of[x] != x:
+                    parent_of[x] = parent_of[parent_of[x]]
+                    x = parent_of[x]
+                return x
+
+            for a, bb in close:
+                ra, rb = find(a), find(bb)
+                if ra != rb:
+                    parent_of[rb] = ra
+            clusters = {}
+            for t in member_tids:
+                clusters.setdefault(find(t), []).append(t)
+            for members in clusters.values():
+                if len(members) > 1:
+                    parallel_rows.append({
+                        'family': f'#{family["root"]}',
+                        'near-identical versions': ', '.join(f'#{t}' for t in sorted(members)),
+                        'how many': len(members),
+                    })
+        if parallel_rows:
+            parts.append('<h3>Where the same change was made more than once</h3>')
+            parts.append(
+                f'<p>{len(parallel_rows)} sets of versions are near-identical to each '
+                f'other within their family — separate attempts at the same edit, rather '
+                f'than a sequence of improvements. Each set is a candidate for being '
+                f'reduced to one option in the next round.</p>')
+            parts.append(f'<div class="tablewrap">'
+                         f'{_table(pd.DataFrame(parallel_rows), max_rows=40)}</div>')
+
+    if 'generations' in show and generations is not None and not generations.empty:
+        parts.append('<h3>Did rewriting build support?</h3>')
+        parts.append(
+            '<p>Generation 0 is an original statement, generation 1 a rewrite of it, and '
+            'so on. Agreement is weighted by how many people gave a clear opinion, so a '
+            'statement two people saw does not count the same as one twenty people saw.</p>')
+        parts.append(f'<div class="tablewrap">{_table(generations)}</div>')
+        parts.append(
+            '<p class="footnote">Later generations were also shown to fewer people, so '
+            'this decline cannot be separated from falling exposure. It is not evidence '
+            'that rewriting makes statements worse.</p>')
+
+    # ── roster ───────────────────────────────────────────────────────────────
+    # A pseudonym roster was tried here and removed: looking yourself up in a list of
+    # names to learn which group you were put in is a poor thing to ask of a reader,
+    # and it is worse when the page has just finished showing that the groups are not
+    # distinguishable from no groups. It invited people to adopt a label the analysis
+    # does not support. `cluster_roster` is left in place for anyone who needs the
+    # mapping for a different purpose.
+    if 'roster' in show and roster is not None:
+        # Marked as scaffolding rather than as a finding: the honest answer today is
+        # "not yet", and a reader should be able to see at a glance that this is the
+        # part of the page still being built.
+        parts.append('<section class="temporary">')
+        parts.append('<h2>Which group were you in? <span class="tag">temporary</span></h2>')
+        parts.append(
+            '<p><b>This section is temporary and will be replaced when the '
+            'consultation finishes.</b></p>')
+        # Leading with "we won't tell you" reads as withholding. The true reason is a
+        # cannot, not a won't: the analysis was built from data carrying no usernames,
+        # so no individual can be looked up in it — including by whoever wrote this.
+        parts.append(
+            '<p>This page cannot tell you yet. It was built from an export that carries '
+            'no usernames and no record of who wrote which statement, so there is no way '
+            'to look anyone up in it — including by whoever produced this page.</p>')
+        parts.append(
+            '<p>That is a limitation of this draft, not the final position. '
+            '<b>At the end of the process we intend to publish the data in a form that '
+            'lets you find your own opinions in it</b>, through a number the platform '
+            'will show only to you.</p>')
+        parts.append(
+            '<p>Worth being clear about what that will mean: the published data will '
+            'show everyone’s opinions side by side, identified by number rather than by '
+            'name. Yours will be the only number you can place — but the pattern of how '
+            'each person responded will be visible, which is the point of publishing it '
+            'at all.</p>')
+        parts.append(
+            '<p>In the meantime, the groups you would be looking yourself up in are the '
+            'ones shown above to be indistinguishable from no grouping at all, so the '
+            'label would not have told you much. What is solid here is the opinions '
+            'themselves: which statements drew broad agreement and which split the '
+            'room.</p>')
+        parts.append('</section>')
+
+    # ── shortlist ────────────────────────────────────────────────────────────
+    shortlist_start = len(parts)
+    if 'shortlist' in show and representatives is not None and not representatives.empty:
+        parts.append('<h2>What to put in the next round</h2>')
+        parts.append(
+            '<p>Where one idea was written several ways, carrying every version forward '
+            'asks people to give an opinion repeatedly on the same thing. One version '
+            'has to stand '
+            'for each family. Below is the best-supported wording in each, judged only '
+            'on people who took a side, and only where enough of them did.</p>')
+        ready = representatives[representatives['representative_tid'].notna()]
+        undecided = representatives[representatives['representative_tid'].isna()]
+        if not ready.empty:
+            table = ready[['representative_tid', 'n_variants', 'n_decided',
+                           'agree_pct', 'is_rewrite', 'status', 'text']].rename(columns={
+                'representative_tid': 'statement', 'n_variants': 'versions written',
+                'n_decided': 'people', 'agree_pct': 'agreed %',
+                'is_rewrite': 'is a rewrite', 'status': 'note'})
+            parts.append(f'<div class="tablewrap">{_table(table, max_rows=40)}</div>')
+        if not undecided.empty:
+            parts.append(
+                f'<p><b>{len(undecided)} families still need a decision.</b> No version '
+                f'in them was seen by enough people to choose between the wordings — '
+                f'these are the ones to put in front of participants again, not to '
+                f'resolve from this data.</p>')
+            parts.append(f'<div class="tablewrap">'
+                         f'{_table(undecided[["best_seen_tid", "n_variants", "n_decided", "text"]].rename(columns={"best_seen_tid": "statement", "n_variants": "versions written", "n_decided": "people"}), max_rows=40)}</div>')
+
+        # The two tables above only cover statements that sit in a declared rewrite
+        # family. Statements nobody rewrote were therefore absent from the whole
+        # section — including the most-voted statement in the consultation — which made
+        # "what to put in the next round" quietly incomplete rather than merely
+        # family-scoped.
+        if not divergence.empty:
+            in_families = set()
+            for family in (families or []):
+                in_families.update(int(t) for t in family['members']['tid'])
+            alone = divergence[(~divergence['tid'].isin(in_families))
+                               & divergence['agree_pct'].notna()]
+            alone = alone.sort_values(['agree_pct', 'n_decided'], ascending=False)
+            if not alone.empty:
+                parts.append(
+                    f'<p><b>{len(alone)} statements carry opinions and were never '
+                    f'rewritten</b>, so no wording choice arises — they either go '
+                    f'forward as written or they do not. They belong on the same '
+                    f'slate as the picks above.</p>')
+                table = alone[['tid', 'agree_pct', 'n_decided', 'statement']].rename(
+                    columns={'tid': 'statement id', 'agree_pct': 'agreed %',
+                             'n_decided': 'people who took a side',
+                             'statement': 'text'})
+                parts.append(f'<div class="tablewrap">{_table(table, max_rows=40)}</div>')
+
+    if 'shortlist' in show and not divergence.empty:
+        parts.append('<h3>The most divisive statements</h3>')
+        parts.append(
+            '<p>These split the groups most sharply. They are not necessarily the ones '
+            'to drop — a consultation exists to find them — but they are the ones that '
+            'will need argument rather than a count.</p>')
+        cols = [c for c in divergence.columns if c.startswith('agree_group')]
+        # Interleave each group's rate with how many in that group actually took a
+        # side. Without it the visible denominator is n_voters (12, 22…), while the
+        # 100-point gaps are one or two people in the small group.
+        interleaved = []
+        for c in cols:
+            interleaved.append(c)
+            n_col = c.replace('agree_group', 'decided_group')
+            if n_col in divergence.columns:
+                interleaved.append(n_col)
+        top = divergence.dropna(subset=['gap']).head(8)[
+            ['tid'] + interleaved + ['gap', 'statement']]
+        parts.append(f'<div class="tablewrap">{_table(top)}</div>')
+        parts.append(weak_note)
+
+    # Lift the whole recommendations block to the anchor set just after the intro.
+    # Built here because it depends on everything above; read there because that is
+    # where the organiser looks first.
+    if len(parts) > shortlist_start:
+        moved = parts[shortlist_start:]
+        del parts[shortlist_start:]
+        parts[shortlist_anchor:shortlist_anchor] = moved
+
+    # ── caveats ──────────────────────────────────────────────────────────────
+    if 'caveats' in show:
+        items = ['<li><b>This was not a poll.</b> Everyone here chose to take part, so '
+                 'none of it generalises to the wider community, however clean a '
+                 'split looks.</li>',
+                 '<li><b>Different people saw different statements.</b> Later statements '
+                 'were seen by fewer people, so percentages are not directly comparable '
+                 'between statements.</li>',
+                 f'<li><b>The numbers are small.</b> With {n_real} participants, a '
+                 f'handful of opinions moves any percentage here substantially.</li>']
+        if audience == 'participant':
+            items.append('<li><b>A group label is not an identity.</b> It describes the '
+                         'opinions you gave on these statements, in this consultation, '
+                         'and nothing else.</li>')
+        else:
+            items.append('<li><b>Support is not endorsement.</b> A statement can draw '
+                         'agreement because it is uncontroversial rather than because '
+                         'it is worth adopting.</li>')
+        parts.append('<div class="caveats"><h2>How to read this</h2><ul>'
+                     + ''.join(items) + '</ul></div>')
+
+    # ── meta ─────────────────────────────────────────────────────────────────
+    if 'meta' in show:
+        ok = sum(1 for c in checks if c.passed)
+        parts.append(
+            f'<p class="meta">Generated from an export taken '
+            f'{esc(b.manifest_polis["exported_at"])}; {ok} of {len(checks)} data checks '
+            f'passed. The grouping shown is the tool\'s own, reproduced independently to '
+            f'confirm it. No usernames, and no record of who wrote which statement, were '
+            f'included in the data this was built from.</p>')
+
+    parts.append('</main></body></html>')
+    path = Path(out)
+    path.write_text(_with_contents('\n'.join(parts)), encoding='utf-8')
+    return path
+
+
+def plot_method_comparison(b, conv_key: str, polis_labels: dict, leiden_labels: dict,
+                           sweep: pd.DataFrame, matrix, eligible: list[int]):
+    """The same agreement matrix, sorted two ways, beside how modularity behaves.
+
+    The point is to let the reader check the grouping rather than trust it. Sorting
+    people by their assigned group is the fairest possible test of a clustering: if
+    the groups capture something real, the blocks on the diagonal must be visibly
+    darker than everything off them. Showing both methods' orderings side by side
+    makes it obvious when neither produces blocks — which no summary statistic
+    conveys as directly.
+
+    The third panel is why: modularity measures how much more densely a community
+    is connected internally than chance would predict. At or below zero there is no
+    community structure to find, whatever number of groups gets reported.
+    """
+    import methods as _m
+
+    pids, weights, _ = _m.agreement_graph(matrix, restrict_pids=eligible)
+    fig, axes = plt.subplots(1, 3, figsize=(12.4, 4.3),
+                             gridspec_kw={'width_ratios': [1, 1, 0.95]})
+
+    # Both panels are ordered by groupings computed *here*, on the analysed subset —
+    # not by the tool's published labels. Titling the first one "the groups Polis
+    # reported" invited the reader to check 3/21 against boundary boxes that split
+    # 5/17.
+    for ax, labels, title in ((axes[0], polis_labels,
+                               "Sorted by the tool's method, rerun here"),
+                              (axes[1], leiden_labels, 'Sorted by Leiden communities')):
+        order = sorted(range(len(pids)), key=lambda i: (labels.get(pids[i], 99), pids[i]))
+        shown = weights[np.ix_(order, order)].copy()
+        np.fill_diagonal(shown, 1.0)
+        im = ax.imshow(shown, cmap=SEQUENTIAL, vmin=0, vmax=1, interpolation='nearest')
+        previous = labels.get(pids[order[0]], 99)
+        for position, i in enumerate(order):
+            current = labels.get(pids[i], 99)
+            if current != previous:
+                ax.axhline(position - 0.5, color=INK, lw=1.1)
+                ax.axvline(position - 0.5, color=INK, lw=1.1)
+                previous = current
+        ax.set_xticks([]); ax.set_yticks([]); ax.grid(False)
+        ax.set_title(title, loc='left', fontsize=10, color=INK)
+
+    cbar = fig.colorbar(im, ax=axes[1], fraction=0.045, pad=0.03)
+    cbar.set_label('how often the two agreed', fontsize=8.5, color=INK_SOFT)
+    cbar.outline.set_visible(False)
+
+    ax = axes[2]
+    ax.axhline(0, color=INK_SOFT, lw=1.2, zorder=2)
+    ax.plot(sweep['resolution'], sweep['modularity'], color=SERIES[1], lw=2,
+            marker='o', markersize=5, markeredgecolor=SURFACE, markeredgewidth=1.5,
+            zorder=3)
+    ax.set_xlabel('Leiden resolution setting')
+    ax.set_ylabel('modularity')
+    ax.yaxis.grid(True, zorder=1)
+    # A single community scores exactly 0 by definition, so the flat left-hand
+    # stretch is Leiden declining to split at all — not evidence of structure.
+    single = sweep[sweep.get('K_leiden', pd.Series([2] * len(sweep))) <= 1]
+    if len(single):
+        ax.axvspan(sweep['resolution'].min(), single['resolution'].max(),
+                   color=GRID, alpha=0.55, zorder=0)
+        ax.text(single['resolution'].max(), ax.get_ylim()[0],
+                ' everyone in one\n community here', fontsize=8, color=INK_SOFT,
+                va='bottom', ha='left')
+    ax.text(0.97, 0.93, 'above 0 = real communities', transform=ax.transAxes,
+            fontsize=8.5, color=INK_SOFT, va='top', ha='right')
+    ax.text(0.97, 0.06, 'below 0 = none to find', transform=ax.transAxes,
+            fontsize=8.5, color=INK_SOFT, va='bottom', ha='right')
+    ax.set_title('Is there community structure at all?', loc='left', fontsize=10,
+                 color=INK)
+    fig.tight_layout()
+    return fig

--- a/private/analysis/report.py
+++ b/private/analysis/report.py
@@ -468,6 +468,51 @@ def _svg(fig) -> str:
     return svg[svg.index('<svg'):]
 
 
+def _merge_map(redundant: pd.DataFrame | None) -> dict[int, int]:
+    """{tid: representative tid} over the pairs judged redundant. Union-find, so a
+    chain of pairwise merges collapses to one representative."""
+    if redundant is None or redundant.empty:
+        return {}
+    parent: dict[int, int] = {}
+
+    def find(x):
+        parent.setdefault(x, x)
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for row in redundant[redundant['verdict'].str.startswith('redundant')].itertuples():
+        a, b = find(int(row.tid_a)), find(int(row.tid_b))
+        if a != b:
+            parent[max(a, b)] = min(a, b)
+    return {tid: find(tid) for tid in parent}
+
+
+def _collapse_duplicates(frame: pd.DataFrame, merge: dict[int, int]) -> pd.DataFrame:
+    """One row per proposition, not per wording.
+
+    The deduplication section merges near-identical statements before the grouping is
+    computed, and then the selection tables listed every wording separately again — so
+    the eight most divisive statements were four propositions, and an organiser reading
+    down the list saw the same argument three times. Collapse by the same map the
+    clustering uses, keep the wording with the most opinions behind it, and say which
+    others it stands for.
+    """
+    if frame.empty or not merge:
+        return frame
+    out = frame.copy()
+    out['_rep'] = out['tid'].map(lambda t: merge.get(int(t), int(t)))
+    order = 'n_decided' if 'n_decided' in out.columns else 'n_voters'
+    out = out.sort_values(order, ascending=False)
+    kept = out.drop_duplicates('_rep', keep='first').copy()
+    others = (out.groupby('_rep')['tid']
+              .apply(lambda s: list(s)[1:]).to_dict())
+    kept['also submitted as'] = kept['_rep'].map(
+        lambda r: ', '.join(f'#{int(t)}' for t in others.get(r, [])) or '')
+    return kept.drop(columns='_rep')
+
+
 def _table(df: pd.DataFrame, max_rows: int = 40) -> str:
     if df is None or (hasattr(df, 'empty') and df.empty):
         return '<p class="missing">Nothing to show.</p>'
@@ -695,6 +740,11 @@ def write_report(*, bundle, conv_key, checks, funnel, server, gate, sweep, stabi
     # depending on the answer — so the answer travels with them instead of staying in
     # the section that computed it, several screens up. The threshold is corrected for
     # the number of tests run, matching what that section says in words.
+    # One row per proposition in every selection table and figure below. Built here
+    # so the three consumers of `divergence` cannot drift apart on it.
+    merge = _merge_map(redundant)
+    deduped = _collapse_duplicates(divergence, merge) if not divergence.empty else divergence
+
     grouping_is_weak = False
     if significance is not None and not significance.empty:
         p_values = significance['p (permutation test)']
@@ -1248,7 +1298,7 @@ def write_report(*, bundle, conv_key, checks, funnel, server, gate, sweep, stabi
         # statements in the consultation while admitting one at 69%. Ranked on overall
         # agreement instead, which is the quantity that does not depend on a grouping
         # this report goes on to show is indistinguishable from noise.
-        agreed = divergence[divergence['agree_pct'].notna()].copy()
+        agreed = deduped[deduped['agree_pct'].notna()].copy()
         cols = [c for c in agreed.columns if c.startswith('agree_group')]
         floor = max(5, POLIS_VOTE_THRESHOLD)
         broad = agreed[agreed['n_decided'] >= floor].sort_values(
@@ -1278,7 +1328,7 @@ def write_report(*, bundle, conv_key, checks, funnel, server, gate, sweep, stabi
             '<p>Each statement appears once, showing how much each group agreed with it, '
             'counting only people who took a side. The further apart the marks, the more '
             'that statement divides the room.</p>')
-        parts.append(f'<figure class="figwrap">{_svg(plot_divergence(divergence))}</figure>')
+        parts.append(f'<figure class="figwrap">{_svg(plot_divergence(deduped))}</figure>')
         parts.append(weak_note)
 
     # ── alterations ──────────────────────────────────────────────────────────
@@ -1646,7 +1696,9 @@ def write_report(*, bundle, conv_key, checks, funnel, server, gate, sweep, stabi
         parts.append(
             '<p>These split the groups most sharply. They are not necessarily the ones '
             'to drop — a consultation exists to find them — but they are the ones that '
-            'will need argument rather than a count.</p>')
+            'will need argument rather than a count. One row per proposition: where the '
+            'same idea was written several ways, the wording with the most opinions '
+            'behind it stands for the rest, which are named beside it.</p>')
         cols = [c for c in divergence.columns if c.startswith('agree_group')]
         # Interleave each group's rate with how many in that group actually took a
         # side. Without it the visible denominator is n_voters (12, 22…), while the
@@ -1657,8 +1709,10 @@ def write_report(*, bundle, conv_key, checks, funnel, server, gate, sweep, stabi
             n_col = c.replace('agree_group', 'decided_group')
             if n_col in divergence.columns:
                 interleaved.append(n_col)
-        top = divergence.dropna(subset=['gap']).head(8)[
-            ['tid'] + interleaved + ['gap', 'statement']]
+        extra = ['also submitted as'] if 'also submitted as' in deduped.columns else []
+        top = deduped.dropna(subset=['gap']).sort_values(
+            'gap', ascending=False).head(8)[
+            ['tid'] + interleaved + ['gap', 'statement'] + extra]
         parts.append(f'<div class="tablewrap">{_table(top)}</div>')
         parts.append(weak_note)
 

--- a/private/analysis/report.py
+++ b/private/analysis/report.py
@@ -35,6 +35,13 @@ from pipeline import (POLIS_VOTE_THRESHOLD, RAW_AGREE, RAW_DISAGREE,
 #: rather than 'not enough people'. Matches the engine's own participation cutoff.
 MIN_COMPARABLE = POLIS_VOTE_THRESHOLD
 
+#: Decisive responses a proposition needs before its agreement figure is printed
+#: for participants. Below this a percentage is arithmetic rather than a finding:
+#: with four people, one more vote moves it 20 points. Derived from the engine's
+#: own cutoff rather than picked, and floored at 5 — the same rule already applied
+#: to representative selection below.
+MIN_DECIDED_TO_REPORT = max(5, POLIS_VOTE_THRESHOLD)
+
 #: Similarity above which two versions inside one family are near-identical to each
 #: other. Higher than the threshold that forms the families themselves: this flags
 #: parallel effort — two people separately narrowing the same statement the same
@@ -712,8 +719,8 @@ AUDIENCES = {
     # 'wording_brief' comes before 'groups': the grouping is computed on merged
     # statements, so a reader meeting the group results first has already been
     # given a statement count they cannot reconcile with what they voted on.
-    'participant': ['intro', 'participation', 'wording_brief', 'groups', 'stability',
-                    'divergence', 'roster', 'caveats', 'meta'],
+    'participant': ['intro', 'participation', 'wording_brief', 'families_brief',
+                    'groups', 'stability', 'divergence', 'roster', 'caveats', 'meta'],
 }
 
 
@@ -947,6 +954,49 @@ def write_report(*, bundle, conv_key, checks, funnel, server, gate, sweep, stabi
             parts.append(
                 '<p>No statements were merged in this consultation: no two were close '
                 'enough to be treated as one.</p>')
+
+    # ── what was actually proposed (participant version) ──────────────────────
+    # One row per proposition rather than per statement: a family is one idea
+    # written several ways, and listing every wording asks the reader to work out
+    # for themselves which are the same. The organiser gets the full variant
+    # trees under 'families' and 'generations'; a participant wants the list.
+    if 'families_brief' in show and representatives is not None and not representatives.empty:
+        parts.append('<h2>What was proposed</h2>')
+        parts.append(
+            '<p>One row per proposition. Where the same idea was written several '
+            'ways, the wording shown is the one that best represents the group.</p>')
+        rows = []
+        for r in representatives.itertuples():
+            variants = int(r.n_variants)
+            wording = (f'{variants} wordings' if variants > 1 else 'one wording')
+            decided = int(r.n_decided)
+            if decided >= MIN_DECIDED_TO_REPORT:
+                agreement = (f'<b>{r.agree_pct:.0f}%</b> agreed, '
+                             f'of {decided} who took a side')
+            else:
+                # A percentage from three people reads as a finding and is not one.
+                # Say why it is withheld rather than leaving an empty cell.
+                agreement = f'<span class="footnote">too few responses ({decided})</span>'
+            rows.append(
+                f'<tr><td>{html.escape(str(r.text))}</td>'
+                f'<td class="footnote">{wording}</td>'
+                f'<td>{agreement}</td></tr>')
+        # Explicit widths: left to itself the proposition text takes almost all
+        # the width and "of 20 who took a side" wraps onto three lines.
+        parts.append(
+            '<div class="tablewrap"><table class="propositions">'
+            '<colgroup><col style="width:58%"><col style="width:11%">'
+            '<col style="width:31%"></colgroup>'
+            '<thead><tr>'
+            '<th>Proposition</th><th>Written as</th><th>Agreement</th>'
+            '</tr></thead><tbody>' + ''.join(rows) + '</tbody></table></div>')
+        withheld = int((representatives['n_decided'] < MIN_DECIDED_TO_REPORT).sum())
+        if withheld:
+            parts.append(
+                f'<p class="footnote">{withheld} of {len(representatives)} propositions '
+                f'drew fewer than {MIN_DECIDED_TO_REPORT} responses either way. A '
+                f'percentage from that few people moves by tens with one more vote, '
+                f'so no figure is given for them — they were proposed, not settled.</p>')
 
     # ── groups ───────────────────────────────────────────────────────────────
     if 'groups' in show and server.get('available'):

--- a/private/analysis/report.py
+++ b/private/analysis/report.py
@@ -46,6 +46,12 @@ MIN_COMPARABLE = POLIS_VOTE_THRESHOLD
 #: clustered — and says nothing about how many responses a statement needs.
 MIN_DECIDED_TO_REPORT = 5
 
+#: How far apart the wordings of one idea must land before the range is shown
+#: next to the representative's figure. Matches the 'clear' vs 'close' cutoff
+#: used for representative status, so the report calls a spread significant in
+#: one place exactly when it does in the other.
+WORDING_SPREAD_WORTH_SHOWING = 15
+
 #: Similarity above which two versions inside one family are near-identical to each
 #: other. Higher than the threshold that forms the families themselves: this flags
 #: parallel effort — two people separately narrowing the same statement the same
@@ -968,7 +974,24 @@ def write_report(*, bundle, conv_key, checks, funnel, server, gate, sweep, stabi
         parts.append('<h2>What was proposed</h2>')
         parts.append(
             '<p>One row per proposition. Where the same idea was written several '
-            'ways, the wording shown is the one that best represents the group.</p>')
+            'ways, the wording shown is the one that best represents the group, and '
+            'the figure is for that wording — not pooled across the alternatives.</p>')
+        # agree_pct and n_decided describe the representative wording alone, not
+        # the family. The representative is chosen as the highest-agreement
+        # variant, so printing it unqualified shows every proposition at its most
+        # flattering — and in this consultation nine families have variants
+        # differing by 15 points or more. Print the range alongside when the
+        # wordings genuinely disagree.
+        spread_by_root = {}
+        for family in (families or []):
+            members = family['members']
+            eligible = members[members['n_decided'] >= MIN_DECIDED_TO_REPORT]
+            if len(eligible) > 1:
+                low = float(eligible['agree_pct'].min())
+                high = float(eligible['agree_pct'].max())
+                if high - low >= WORDING_SPREAD_WORTH_SHOWING:
+                    spread_by_root[family['root']] = (low, high)
+
         rows = []
         for r in representatives.itertuples():
             variants = int(r.n_variants)
@@ -976,7 +999,11 @@ def write_report(*, bundle, conv_key, checks, funnel, server, gate, sweep, stabi
             decided = int(r.n_decided)
             if decided >= MIN_DECIDED_TO_REPORT:
                 agreement = (f'<b>{r.agree_pct:.0f}%</b> agreed, '
-                             f'of {decided} who took a side')
+                             f'of {decided} who responded to this wording')
+                spread = spread_by_root.get(r.family)
+                if spread:
+                    agreement += (f'<br><span class="footnote">other wordings of this '
+                                  f'idea ran {spread[0]:.0f}–{spread[1]:.0f}%</span>')
             else:
                 # A percentage from three people reads as a finding and is not one.
                 # Say why it is withheld rather than leaving an empty cell.

--- a/private/analysis/report.py
+++ b/private/analysis/report.py
@@ -709,8 +709,11 @@ AUDIENCES = {
                   'methods_compared', 'ladder', 'consensus',
                   'divergence', 'wording', 'families', 'generations', 'shortlist',
                   'caveats', 'meta'],
-    'participant': ['intro', 'participation', 'groups', 'stability', 'divergence',
-                    'roster', 'caveats', 'meta'],
+    # 'wording_brief' comes before 'groups': the grouping is computed on merged
+    # statements, so a reader meeting the group results first has already been
+    # given a statement count they cannot reconcile with what they voted on.
+    'participant': ['intro', 'participation', 'wording_brief', 'groups', 'stability',
+                    'divergence', 'roster', 'caveats', 'meta'],
 }
 
 
@@ -909,6 +912,41 @@ def write_report(*, bundle, conv_key, checks, funnel, server, gate, sweep, stabi
             f'of them gave opinions on enough statements to be included in the group '
             f'analysis. '
             f'Everything below rests on those numbers, which are small.</p>')
+
+    # ── how the same idea, worded twice, was handled (participant version) ────
+    # The organiser gets 'deduplication', which argues the case at length because
+    # they are deciding which wording carries forward. A participant only needs to
+    # know it happened, and that the numbers below already account for it —
+    # otherwise "22 statements" silently contradicts the count they remember
+    # voting on. Deliberately no naive-vs-deduplicated comparison: that is the
+    # organiser's evidence, and showing a reader two numbers for one quantity
+    # invites the question of which is the real one.
+    if 'wording_brief' in show:
+        merged_pairs = 0
+        if redundant is not None and not redundant.empty:
+            merged_pairs = int(redundant['verdict'].str.startswith('redundant').sum())
+        parts.append('<h2>The same idea, worded more than once</h2>')
+        parts.append(
+            '<p>People could rewrite each other’s statements, so the same idea often '
+            'appears several times in slightly different words. Counted as they stand, '
+            'a popular idea phrased five ways would weigh five times as much as one '
+            'phrased once.</p>')
+        parts.append(
+            '<p>So before anything was counted, near-identical statements were grouped '
+            'together and treated as one. Whether two are really the same is judged by '
+            'the opinions of people who responded to <i>both</i> — not by how similar '
+            'the wording looks, because “at least a thousand edits” and “at least five '
+            'hundred edits” read almost the same and mean quite different things.</p>')
+        if merged_pairs:
+            parts.append(
+                f'<p>{merged_pairs} pair{"s" if merged_pairs != 1 else ""} of statements '
+                f'were merged this way. Every number on this page already accounts for '
+                f'that, so the statement count here is smaller than the number you were '
+                f'shown while voting.</p>')
+        else:
+            parts.append(
+                '<p>No statements were merged in this consultation: no two were close '
+                'enough to be treated as one.</p>')
 
     # ── groups ───────────────────────────────────────────────────────────────
     if 'groups' in show and server.get('available'):

--- a/private/analysis/run-on-toolforge.sh
+++ b/private/analysis/run-on-toolforge.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Export both halves of an analysis bundle, from inside a Toolforge job.
+#
+# Must run as a JOB, not on the bastion. Toolforge injects the tool's envvars
+# (DATABASE_URL, POLIS_DATABASE_URL) into jobs and the webservice — an interactive
+# bastion shell does NOT get them, so the same commands typed there would silently
+# receive empty connection strings. Same reasoning as v2/bin/phase-scheduler.sh.
+#
+# Setup (once, on the bastion as the tool user):
+#     become wiki-polis
+#     mkdir -p ~/analysis-export
+#     # scp bundle.py, export_app_bundle.py, export_polis_bundle.py and this file there
+#     chmod +x ~/analysis-export/run-on-toolforge.sh
+#     openssl rand -hex 32 > ~/.wiki-polis-export-salt && chmod 600 ~/.wiki-polis-export-salt
+#
+# Run:
+#     toolforge jobs run arbcom-export \
+#         --image python3.13 \
+#         --command "$HOME/analysis-export/run-on-toolforge.sh 2026-nlwiki-arbcom" \
+#         --wait
+#
+# Then read the log and copy the result back (from your own machine):
+#     cat ~/arbcom-export.out ~/arbcom-export.err
+#     scp -r <tool>@bastion:~/analysis-export/<slug>_bundle ./
+set -euo pipefail
+
+SLUG="${1:?usage: run-on-toolforge.sh <conversation-slug> [--no-text]}"
+shift || true
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+OUT="$HERE/${SLUG}_bundle"
+SALT="$HOME/.wiki-polis-export-salt"
+
+# The app's own venv — it already has psycopg2 and PyMySQL, because the admin stats
+# panel and the app itself use them. Nothing needs installing.
+PY="$HOME/www/python/venv/bin/python"
+
+[ -x "$PY" ]      || { echo "no interpreter at $PY — is the webservice venv set up?" >&2; exit 1; }
+[ -r "$SALT" ]    || { echo "no salt file at $SALT — see the setup block above" >&2; exit 1; }
+: "${DATABASE_URL:?DATABASE_URL is empty — are you running this as a Toolforge job?}"
+: "${POLIS_DATABASE_URL:?POLIS_DATABASE_URL is empty — are you running this as a Toolforge job?}"
+
+# Prove both connections and every table we need BEFORE exporting anything, so a
+# missing grant or an empty connection string fails here rather than half way
+# through a bundle.
+echo "=== preflight ==="
+if ! "$PY" "$HERE/preflight.py" \
+        --app-db-url "$DATABASE_URL" \
+        --polis-db-url "$POLIS_DATABASE_URL" \
+        --slug "$SLUG"; then
+    echo "preflight failed — nothing exported" >&2
+    exit 1
+fi
+
+echo
+echo "=== app database (ToolsDB) ==="
+"$PY" "$HERE/export_app_bundle.py" \
+    --db-url "$DATABASE_URL" \
+    --slug "$SLUG" \
+    --salt-file "$SALT" \
+    --with-pseudonyms \
+    --env prod --out "$OUT" "$@"
+
+echo
+echo "=== Polis database (VPS, over the private network) ==="
+"$PY" "$HERE/export_polis_bundle.py" \
+    --db-url "$POLIS_DATABASE_URL" \
+    --conversations "$OUT/conversations.tsv" \
+    --salt-file "$SALT" \
+    --env prod --out "$OUT" "$@"
+
+echo
+echo "done — bundle at $OUT"
+du -sh "$OUT"

--- a/private/analysis/subset_search.py
+++ b/private/analysis/subset_search.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Is there ANY set of statements on which real communities appear?
+
+Searching for a subset that produces good modularity will always succeed given
+enough attempts — with 22 people, some subset of votes will look clustered by luck
+alone. The search on its own therefore proves nothing.
+
+So the same search is run twice: once on the real votes, and once on data where each
+statement's votes have been shuffled across people. Shuffling destroys any relationship
+*between* statements while preserving each statement's own agree/disagree balance and
+each person's number of votes — so the shuffled data is what "no communities, same
+overall shape" looks like. If the best subset of real votes scores no better than the
+best subset of shuffled votes, there is nothing to find.
+"""
+from __future__ import annotations
+
+import sys
+import warnings
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, '.')
+warnings.filterwarnings('ignore')
+
+import methods as M  # noqa: E402
+import pipeline as P  # noqa: E402
+
+RESOLUTIONS = (0.8, 1.0, 1.2)
+SIZES = (8, 16, 24, 32, 48)
+SAMPLES = 150
+
+
+def best_modularity(values, pids, tids_idx, rng):
+    sub = values[:, tids_idx]
+    matrix = P.Matrix(conv_key='x', phase=2, values=sub, pids=pids,
+                      tids=list(range(sub.shape[1])), person_keys=[])
+    graph_pids, weights, _ = M.agreement_graph(matrix, min_overlap=3)
+    if (weights > 0).sum() == 0:
+        return float('nan')
+    best = -1.0
+    for resolution in RESOLUTIONS:
+        labels, modularity = M.leiden_communities(graph_pids, weights,
+                                                  resolution=resolution,
+                                                  seed=int(rng.integers(1, 10_000)))
+        if len(set(labels.values())) > 1:
+            best = max(best, modularity)
+    return best if best > -1 else float('nan')
+
+
+def shuffle_within_statements(values, rng):
+    """Permute each column independently, keeping its votes but breaking any
+    relationship between statements."""
+    out = values.copy()
+    for j in range(out.shape[1]):
+        column = out[:, j]
+        voted = ~np.isnan(column)
+        if voted.sum() > 1:
+            picks = column[voted].copy()
+            rng.shuffle(picks)
+            column[voted] = picks
+    return out
+
+
+def main() -> int:
+    rng = np.random.default_rng(20260606)
+    b = P.load_bundles('2026-nlwiki-arbcom_bundle')
+    conv = b.conversations[0]
+    matrix = P.build_matrix(b, conv, 2)
+    counts = P.real_vote_counts(b, conv, 2)
+    eligible = [p for p in matrix.pids if counts.get(p, 0) >= P.POLIS_VOTE_THRESHOLD]
+    idx = [i for i, p in enumerate(matrix.pids) if p in set(eligible)]
+    real = matrix.values[idx, :]
+    print(f'{real.shape[0]} people x {real.shape[1]} statements\n')
+
+    shuffled = shuffle_within_statements(real, rng)
+    rows = []
+    for size in SIZES:
+        if size > real.shape[1]:
+            continue
+        for label, values in (('real votes', real), ('shuffled votes', shuffled)):
+            scores = []
+            for _ in range(SAMPLES):
+                pick = rng.choice(values.shape[1], size=size, replace=False)
+                score = best_modularity(values, eligible, pick, rng)
+                if score == score:
+                    scores.append(score)
+            if scores:
+                rows.append({'statements in subset': size, 'data': label,
+                             'subsets tried': len(scores),
+                             'best modularity found': round(max(scores), 4),
+                             '95th percentile': round(float(np.percentile(scores, 95)), 4),
+                             'median': round(float(np.median(scores)), 4),
+                             'any above zero': int(sum(1 for s in scores if s > 0))})
+    table = pd.DataFrame(rows).sort_values(['statements in subset', 'data'])
+    print(table.to_string(index=False))
+
+    real_best = table[table['data'] == 'real votes']['best modularity found'].max()
+    null_best = table[table['data'] == 'shuffled votes']['best modularity found'].max()
+    print(f'\nbest over every real subset tried    : {real_best:+.4f}')
+    print(f'best over every shuffled subset tried: {null_best:+.4f}')
+    print('\n' + ('Real votes do no better than shuffled ones — no subset of statements '
+                  'reveals communities that are not there.'
+                  if real_best <= null_best else
+                  'Some subset of real votes beats the shuffled baseline — worth '
+                  'inspecting which statements it uses.'))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/private/analysis/wiki_polis_analysis.ipynb
+++ b/private/analysis/wiki_polis_analysis.ipynb
@@ -1,0 +1,498 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# nl.wikipedia arbitragecommissie \u2014 consultation analysis\n",
+    "\n",
+    "This notebook takes the raw votes and statements from a wiki-polis consultation and\n",
+    "asks three questions:\n",
+    "\n",
+    "1. **Who actually took part?** The results page reports a single participant number.\n",
+    "   That number is more ambiguous than it looks, and the groups shown alongside it are\n",
+    "   drawn over a smaller set of people.\n",
+    "2. **How much clustering is really there?** Polis always reports between two and five\n",
+    "   opinion groups. It never reports \"there are no groups\". So a second, independent\n",
+    "   method is needed to tell a real division from a tidy partition of noise.\n",
+    "3. **Does phrasing change the answer?** Consultations accumulate near-duplicate\n",
+    "   statements \u2014 one proposition in three wordings. For anyone choosing which phrasing\n",
+    "   to put to a vote, the comparison between those variants *is* the decision.\n",
+    "\n",
+    "**How to read this.** Every section starts with plain prose saying what is being done\n",
+    "and why. The code cells are thin: the work lives in `pipeline.py` and `methods.py`\n",
+    "next to this file. Where a result is uncertain, the notebook says so rather than\n",
+    "rounding it into a conclusion.\n",
+    "\n",
+    "No usernames were exported, and nothing here records who wrote which statement. For\n",
+    "the export queries, the exclusions and the data checks, see the companion notebook\n",
+    "`data_provenance.ipynb`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import warnings; warnings.filterwarnings('ignore')\n",
+    "import pandas as pd, numpy as np\n",
+    "import pipeline as P, methods as M, report as R\n",
+    "\n",
+    "pd.set_option('display.width', 160)\n",
+    "pd.set_option('display.max_colwidth', 70)\n",
+    "\n",
+    "BUNDLE = '2026-nlwiki-arbcom_bundle'   # \u2190 the directory copied back from Toolforge\n",
+    "CONV    = None                          # set below from the bundle itself\n",
+    "\n",
+    "b = P.load_bundles(BUNDLE)\n",
+    "CONV = b.conversations[0]\n",
+    "\n",
+    "print(f'conversation : {CONV}')\n",
+    "print(f'exported     : {b.manifest_polis[\"exported_at\"]}  (env={b.manifest_polis[\"env\"]})')\n",
+    "print(f'salt id      : {b.manifest_polis[\"salt_id\"]}  \u2014 matches across both halves')\n",
+    "print(f'statement text included: {b.manifest_polis[\"with_text\"]}')\n",
+    "print(f'pseudonyms included    : {b.manifest_app.get(\"with_pseudonyms\", False)}')\n",
+    "for conv in b.manifest_polis['conversations']:\n",
+    "    print(f'\\n  phase {conv[\"phase\"]}: {conv[\"n_participants\"]} participants, '\n",
+    "          f'{conv[\"n_statements\"]} statements, {conv[\"n_votes_latest\"]:,} current votes, '\n",
+    "          f'math_main={\"yes\" if conv[\"has_math_main\"] else \"MISSING\"}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "checks = P.integrity_checks(b)\n",
+    "failed = [c for c in checks if not c.passed]\n",
+    "print(f'data checks: {len(checks) - len(failed)}/{len(checks)} passed'\n",
+    "      + ('' if not failed else '  \u2014 see data_provenance.ipynb'))\n",
+    "for check in failed:\n",
+    "    print(' ', check)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Who actually took part?\n",
+    "\n",
+    "The results page shows one number. It counts everyone with **at least one vote,\n",
+    "passes included** \u2014 not everyone who joined, and not the people the clustering\n",
+    "actually used.\n",
+    "\n",
+    "Polis only clusters participants who voted on at least `min(7, number of statements)`\n",
+    "statements (topping up to 15 if too few qualify). Everyone below that line is present\n",
+    "in the consultation but absent from the opinion groups. The funnel makes each step\n",
+    "explicit.\n",
+    "\n",
+    "One step is missing and cannot be recovered: **how many people opened the page**.\n",
+    "wiki-polis deliberately does not log passive page views, so \"joined\" is the earliest\n",
+    "honest number."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "funnel = P.participation_funnel(b, CONV)\n",
+    "display(funnel)\n",
+    "fig = R.plot_funnel(funnel)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The opinion groups Polis found\n",
+    "\n",
+    "The headline result is **the server's own**, read straight out of `math_main` \u2014 the\n",
+    "table the Polis math service writes. This notebook does not recompute it and does not\n",
+    "substitute its own clustering for it.\n",
+    "\n",
+    "The map below is Polis's own geometry: the two-dimensional projection it computed,\n",
+    "with each participant placed where Polis placed them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "server = P.server_labels(b, CONV, 2)\n",
+    "if server['available']:\n",
+    "    sizes = pd.Series(list(server['labels'].values())).value_counts().sort_index()\n",
+    "    print(f'K = {server[\"K\"]} opinion groups over {server[\"n_labelled\"]} clustered participants')\n",
+    "    for gid, n in sizes.items():\n",
+    "        print(f'  group {gid + 1}: {n} participants')\n",
+    "    print(f'\\nin-conv (met the vote threshold): {len(server[\"in_conv\"])}')\n",
+    "else:\n",
+    "    print('no clustering available:', server['reason'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "fig = R.plot_opinion_map(b, CONV, server)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Can we reproduce it?\n",
+    "\n",
+    "Before drawing any conclusion about *alternatives* to the server's clustering, we have\n",
+    "to show we can reproduce the clustering itself. `polis_replica` is a line-by-line port\n",
+    "of the Polis math service's own PCA and k-means code, pinned to a specific upstream\n",
+    "commit. Running it on the same votes should return the same groups.\n",
+    "\n",
+    "If it does, the counterfactuals further down mean something. If it does not, this\n",
+    "notebook reports the server's answer and stops \u2014 a model we cannot reproduce is not a\n",
+    "model we can ask \"what if\" of."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "gate = P.reproduction_gate(b, CONV, 2)\n",
+    "print(f'reproduced : {\"yes\" if gate[\"passed\"] else \"NO \u2014 \" + gate[\"reason\"]}')\n",
+    "print(f'  K         : server {gate[\"K_server\"]}   replica {gate[\"K_replica\"]}')\n",
+    "print(f'  agreement : ARI {gate[\"ari\"]:.3f} over {gate[\"n_common\"]} participants '\n",
+    "      f'(1.0 = identical grouping)')\n",
+    "print(f'  matrix    : {gate[\"n_participants\"]} people \u00d7 {gate[\"n_statements\"]} statements, '\n",
+    "      f'{gate[\"density\"]:.0%} filled')\n",
+    "print(f'  in-conv   : {gate[\"n_in_conv\"]}  \u2192  the engine could have returned up to '\n",
+    "      f'K={gate[\"max_k_allowed\"]}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That last line matters for reading K. The engine caps the number of groups at\n",
+    "`min(5, 2 + in-conv \u00f7 12)`. With very few participants that cap is 2 \u2014 and then\n",
+    "\"we found two groups\" is a fact about the cap, not about the participants. The line\n",
+    "above says which situation this consultation is in."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How much clustering is really there?\n",
+    "\n",
+    "Polis partitions people into groups because that is what it is for. It does not report\n",
+    "a confidence, and it has no way to say \"these people don't really divide\". So we ask a\n",
+    "different method, built on a different principle, and see whether it recovers the same\n",
+    "division.\n",
+    "\n",
+    "**Leiden community detection** works on a graph rather than a projection. Each\n",
+    "participant is a node; two participants are linked when they voted the same way on the\n",
+    "statements they both voted on. Passes are excluded \u2014 a pass is not an opinion \u2014 and\n",
+    "pairs with too little overlap are not linked at all, because agreeing on two votes is\n",
+    "not evidence of anything.\n",
+    "\n",
+    "Leiden's *resolution* parameter, not the data, decides how many communities come back.\n",
+    "So a single run proves nothing. What is informative is the shape of the sweep: if the\n",
+    "division is real, the number of communities should hold steady across a broad band of\n",
+    "resolutions and agreement with Polis should be high across that band."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "sweep = M.leiden_sweep(b, gate)\n",
+    "print(f'graph: {sweep.attrs[\"n_nodes\"]} people, {sweep.attrs[\"n_edges\"]} links, '\n",
+    "      f'median overlap {sweep.attrs[\"median_overlap\"]:.0f} shared votes per pair\\n')\n",
+    "display(sweep)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Watch the median overlap.** In a consultation with many statements and modest\n",
+    "turnout, two people may have voted on very few of the same statements, and then this\n",
+    "whole graph rests on thin evidence. If that number is small, treat the Leiden result\n",
+    "as a weak second opinion rather than a verdict, and lean on the reproduction gate\n",
+    "above instead."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "stability = M.cluster_stability(b, gate)\n",
+    "if stability['available']:\n",
+    "    print(f'{stability[\"n_runs\"]} runs across resolutions and random seeds, '\n",
+    "          f'{stability[\"n_people\"]} people')\n",
+    "    print(f'  pairs that land together (or apart) every single time: '\n",
+    "          f'{stability[\"pairs_decided\"]:.0%}')\n",
+    "    print(f'  people sitting on a boundary between groups: {stability[\"n_on_boundary\"]}')\n",
+    "else:\n",
+    "    print(stability['reason'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The heatmap below is the visual form of that number. Every clustered participant\n",
+    "appears on both axes; a cell is dark when those two people ended up in the same\n",
+    "community in nearly every run, pale when they nearly never did.\n",
+    "\n",
+    "**Two solid dark blocks means the division is real** \u2014 the same people keep finding\n",
+    "each other regardless of how the method is tuned. A washed-out or speckled square\n",
+    "means the grouping is an artefact of the settings, and the two \"opinion groups\" should\n",
+    "not be described as two camps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "fig = R.plot_stability_heatmap(stability, server)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Where do people agree, and where do they split?\n",
+    "\n",
+    "Two different things get called \"consensus\", and they are worth separating:\n",
+    "\n",
+    "- **Broad agreement** \u2014 most people agree, and the opinion groups agree *with each\n",
+    "  other*. These are the statements a proposal can safely build on.\n",
+    "- **Division** \u2014 the groups disagree with each other. These are the real fault lines,\n",
+    "  and they are what the consultation exists to surface.\n",
+    "\n",
+    "Each statement below is drawn once, showing how much each group agreed with it. The\n",
+    "further apart the two marks, the more that statement divides the room."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "divergence = R.statement_divergence(b, CONV, server)\n",
+    "display(divergence.head(12))\n",
+    "fig = R.plot_divergence(divergence)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Near-duplicate statements \u2014 the head-to-head\n",
+    "\n",
+    "Participants can propose a rewording of an existing statement, and this consultation\n",
+    "accumulated a good number of them. That creates sets of statements saying almost the\n",
+    "same thing with one qualifier changed.\n",
+    "\n",
+    "This matters twice over:\n",
+    "\n",
+    "- **For the clustering**, near-duplicates are strongly correlated columns. A\n",
+    "  proposition stated three ways carries three times the weight of one stated once, and\n",
+    "  the axis it sits on gets pulled accordingly. That is a property of the wording, not\n",
+    "  of what people think.\n",
+    "- **For whoever writes the final text**, these are the actual decision. If one\n",
+    "  phrasing draws noticeably more support than its near-twin, that is the phrasing to\n",
+    "  put forward \u2014 and it is invisible on a results page that lists statements separately.\n",
+    "\n",
+    "Groups are formed two ways at once: statements a participant *declared* as an\n",
+    "improvement on another (recorded at submission time), and statements the embedding\n",
+    "model judges near-identical. Declared links are trusted outright; the model catches\n",
+    "rewordings nobody flagged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "groups, pairs = M.similar_statement_groups(b, CONV, threshold=0.85)\n",
+    "print(f'{len(groups)} near-duplicate group(s) found\\n')\n",
+    "for g in groups:\n",
+    "    print(f'group {g.group_id}: {len(g)} variants, {g.n_declared if hasattr(g, \"n_declared\") else len(g.declared_links)} declared as improvements')\n",
+    "    for tid in g.tids:\n",
+    "        print(f'   [{tid}] {g.texts[tid][:96]}')\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The similarity distribution is worth a look before trusting the threshold \u2014 it should\n",
+    "show a clear gap between \"same proposition, reworded\" and \"different proposition on a\n",
+    "related topic\". If there is no gap, the threshold is doing arbitrary work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "display(pairs.head(12)[['tid_a', 'tid_b', 'similarity', 'text_a', 'text_b']])\n",
+    "fig = R.plot_similarity_distribution(pairs, threshold=0.85)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "head_to_heads = [M.head_to_head(b, CONV, g) for g in groups]\n",
+    "for h in head_to_heads:\n",
+    "    print(f'\u2550\u2550 group {h[\"group_id\"]} ' + '\u2550' * 60)\n",
+    "    display(h['variants'])\n",
+    "    if not h['comparisons'].empty:\n",
+    "        display(h['comparisons'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Read the **common voters** columns, not the raw agreement percentages. Different\n",
+    "variants were submitted at different times, so they were seen by different numbers of\n",
+    "people \u2014 comparing their overall agreement compares different populations. Restricting\n",
+    "to people who voted on both makes each person their own control, and that comparison\n",
+    "can carry a claim."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "effect = M.wording_effect(head_to_heads)\n",
+    "if effect['available']:\n",
+    "    print(f'{effect[\"n_pairs_compared\"]} variant pairs, '\n",
+    "          f'{effect[\"n_discordant_votes\"]} people voted differently on two wordings '\n",
+    "          f'of the same proposition')\n",
+    "    print(f'  median shift: {effect[\"median_abs_shift_pct_points\"]} percentage points')\n",
+    "    print(f'  largest shift: {effect[\"max_abs_shift_pct_points\"]} percentage points')\n",
+    "    print(f'  p = {effect[\"p_value\"]}\\n')\n",
+    "    print(effect['reading'])\n",
+    "else:\n",
+    "    print(effect['reason'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Which group did each pseudonym land in?\n",
+    "\n",
+    "Included so participants can find themselves. Pseudonyms only \u2014 no usernames are\n",
+    "exported, and nothing here says who wrote which statement.\n",
+    "\n",
+    "Everyone who joined appears exactly once, including people the clustering did not\n",
+    "place. Being unplaced is a normal outcome \u2014 it means fewer votes than the engine's\n",
+    "threshold \u2014 not an omission."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "roster = P.cluster_roster(b, CONV)\n",
+    "if roster is None:\n",
+    "    print('no pseudonyms in this bundle (exported without --with-pseudonyms)')\n",
+    "else:\n",
+    "    for placement, rows in roster.groupby('placement'):\n",
+    "        print(f'{placement} \u2014 {len(rows)}')\n",
+    "        print(textwrap.fill(', '.join(sorted(rows['pseudonym'])), 96,\n",
+    "                            initial_indent='    ', subsequent_indent='    '))\n",
+    "        print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What this analysis cannot tell you\n",
+    "\n",
+    "Stated plainly, because a report that only lists findings invites more weight than the\n",
+    "data can carry.\n",
+    "\n",
+    "- **A consultation is not a poll.** Participants chose to take part. Nothing here\n",
+    "  generalises to the wider community, no matter how clear a group split looks.\n",
+    "- **Different people saw different statements.** Statements submitted later were seen\n",
+    "  by fewer people. Agreement percentages across statements are therefore not directly\n",
+    "  comparable, which is why the head-to-heads restrict to common voters.\n",
+    "- **Group labels are not identities.** \"Group 1\" is a position on a set of statements\n",
+    "  in this consultation, nothing more. The stability figure above says how firm even\n",
+    "  that is.\n",
+    "- **An inconclusive wording effect is not evidence that wording does not matter.** At\n",
+    "  this number of participants, only a large effect would be detectable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Write the report\n",
+    "\n",
+    "Renders everything above as a single self-contained HTML file \u2014 no external files, no\n",
+    "network \u2014 suitable for sharing with people who will not run this notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "path = R.write_report(\n",
+    "    bundle=b, conv_key=CONV, checks=checks, funnel=funnel, server=server, gate=gate,\n",
+    "    sweep=sweep, stability=stability, divergence=divergence, groups=groups,\n",
+    "    pairs=pairs, head_to_heads=head_to_heads, effect=effect, roster=roster,\n",
+    "    out='report_2026-nlwiki-arbcom.html')\n",
+    "print(f'written: {path}')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "wiki-polis analysis",
+   "language": "python",
+   "name": "wiki-polis-analysis"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## What this does

Tracks the analysis pipeline that produces the organiser and participant consultation reports, and fixes an identity bug that made half of it silently useless.

## Why track the code

The whole pipeline was git-ignored, so `CALCULATIONS.md` documented how every reported number is derived while nobody but one laptop could re-run it. The reproducibility argument behind that document is the same argument for tracking the code that implements it.

`.gitignore` admits only `*.py`, `*.ipynb`, `*.md` and `*.sh` under `private/analysis/`. Everything the pipeline reads or writes stays ignored: export bundles and built HTML reports carry participant-authored statement text, and the export salt and sub-secret are credentials. Verified by dry-run — 17 source and doc files, nothing else.

The notebooks are committed without outputs.

## The person_key bug

Since #246, wiki-polis asserts a **conversation-scoped subject** to Particiapi — `HMAC(PARTICIAPI_SUB_SECRET, "<xid>:<conversation_id>")`, at `v2/app.py:1785-1795` — and that value is what Particiapi stores in `particiapi_users.subject`. The app exporter was still hashing the raw `xid`.

The result: `app/people.csv` and `polis/votes_latest.csv` keyed into disjoint spaces.

```
app person_keys: 29 | polis identity-linked: 29 | in common: 0
```

Both halves used the same salt file, so the existing `salt_id` check passed — they simply hashed different values under it. Nothing else looked wrong: keys were well-formed on both sides, row counts matched 1:1. Every pseudonym-linked result came out **empty rather than incorrect**, which is why it survived: `cluster_roster` classified all 29 participants as "joined, did not vote", and a report section rendered that as a group listing.

### Changes

- **`bundle.py`** — `conversation_subject()`, a byte-for-byte mirror of `_conversation_subject`, kept here rather than imported because the exporters run without Flask on the path. `secret_id()` for the manifest. `person_key`'s docstring asserted the pre-#246 invariant as fact; it now documents what actually holds.
- **`export_app_bundle.py`** — keys by `(participant, conversation)` rather than participant alone, since the subject is conversation-scoped. That also fixes a latent bug where one person participating in two conversations collapsed into a single key. New `--sub-secret-file` (defaulting to the Toolforge secret path, then `$PARTICIAPI_SUB_SECRET`); the exporter **refuses to run without it** instead of falling back to the xid. `sub_secret_id` goes in the manifest so a rotated secret is visible.
- **`pipeline.py`** — asserts at load that the two halves actually share person_keys. Bundles predating this fix can never join, so they warn rather than fail; a bundle built by the fixed exporter that still fails to join is an error.

## After merging

Existing bundles need the **app half** re-exported on Toolforge, where the secret lives. The polis half is unaffected and still joins. Same salt file (`salt_id aaecfcd5`).

## Known follow-up

`make_test_bundle.py` hashes the same synthetic string on both sides, so the test bundle models this bug away and could never have caught it — and cannot exercise the new guard either. It should derive its app-side keys through `conversation_subject` like the real exporter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)