### PR TITLE
Polish ProtoWiki landing and conversation overview

### DIFF
--- a/v2/figures/flowchart/wiki-polis-flow.svg
+++ b/v2/figures/flowchart/wiki-polis-flow.svg
@@ -69,7 +69,7 @@
 <rect x="48" y="506" width="1104" height="64" rx="14" fill="#eef3fb" stroke="#c9d6ef"></rect>
 <rect x="68" y="520" width="36" height="36" rx="9" fill="#ffffff" stroke="#c9d6ef"></rect>
 <g transform="translate(75,527)" fill="none" stroke="#3d6dba" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><path d="M14 2v6h6"></path><path d="M9 14l2 2 4-4" stroke="#15734a"></path>
+  <path d="M5 2h9l5 5v15H5z"></path><path d="M14 2v5h5"></path><path d="M9 14l2 2 4-4" stroke="#15734a"></path>
 </g>
 <text x="124" y="544" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="19" font-weight="700" letter-spacing="-0.4" fill="#0c0c0e">A more balanced policy draft</text>
 </svg>

--- a/v2/frontend/src/app.test.tsx
+++ b/v2/frontend/src/app.test.tsx
@@ -20,11 +20,64 @@ test('renders a conversation lane from the API contract', async () => {
 
   expect(screen.getByRole('status')).toHaveTextContent('Loading conversations');
   expect(await screen.findByRole('heading', {name: 'Needs attention'})).toBeVisible();
+  expect(screen.getByRole('heading', {name: 'How a ProtoWiki conversation works'})).toBeVisible();
+  expect(screen.getByRole('heading', {name: 'Explore the questions'})).toBeVisible();
+  expect(screen.getByRole('heading', {name: 'Map the arguments'})).toBeVisible();
+  expect(screen.getByRole('heading', {name: 'Express informed opinions'})).toBeVisible();
   expect(await screen.findByRole('link', {name: /Community strategy.*continue/}))
     .toHaveAttribute('href', '/c/community-strategy');
   expect(screen.getByRole('button', {name: 'Your conversations'})).toHaveAttribute('aria-pressed', 'true');
   fireEvent.click(screen.getByRole('button', {name: 'Browse'}));
   expect(screen.getByText('No consultations open to you right now.')).toBeVisible();
+});
+
+test('persists dismissal of the site-wide development notice', async () => {
+  const firstView = render(
+    <QueryClientProvider client={createQueryClient()}>
+      <MemoryRouter initialEntries={['/app/real']}><App /></MemoryRouter>
+    </QueryClientProvider>,
+  );
+
+  const dismiss = await screen.findByRole('button', {name: 'Dismiss site notice'});
+  fireEvent.click(dismiss);
+  expect(screen.queryByLabelText('Prototype notice')).not.toBeInTheDocument();
+  expect(localStorage.getItem('proto-wiki.site-notice.development.v1')).toBe('dismissed');
+
+  firstView.unmount();
+  render(
+    <QueryClientProvider client={createQueryClient()}>
+      <MemoryRouter initialEntries={['/app/real']}><App /></MemoryRouter>
+    </QueryClientProvider>,
+  );
+  await screen.findByRole('heading', {name: 'Needs attention'});
+  expect(screen.queryByLabelText('Prototype notice')).not.toBeInTheDocument();
+});
+
+test('persists the conversation overview display preference', async () => {
+  const firstView = render(
+    <QueryClientProvider client={createQueryClient()}>
+      <MemoryRouter initialEntries={['/app/real']}><App /></MemoryRouter>
+    </QueryClientProvider>,
+  );
+
+  const hideOverview = await screen.findByRole('button', {name: 'Hide conversation overview'});
+  fireEvent.click(hideOverview);
+  expect(hideOverview).toHaveAttribute('aria-expanded', 'false');
+  expect(screen.queryByRole('heading', {name: 'Explore the questions'})).not.toBeInTheDocument();
+  expect(localStorage.getItem('proto-wiki.conversation-flow.collapsed.v1')).toBe('collapsed');
+
+  firstView.unmount();
+  render(
+    <QueryClientProvider client={createQueryClient()}>
+      <MemoryRouter initialEntries={['/app/real']}><App /></MemoryRouter>
+    </QueryClientProvider>,
+  );
+
+  const showOverview = await screen.findByRole('button', {name: 'Show conversation overview'});
+  expect(screen.queryByRole('heading', {name: 'Explore the questions'})).not.toBeInTheDocument();
+  fireEvent.click(showOverview);
+  expect(await screen.findByRole('heading', {name: 'Explore the questions'})).toBeVisible();
+  expect(localStorage.getItem('proto-wiki.conversation-flow.collapsed.v1')).toBe('expanded');
 });
 
 test('keeps the current route painted while the next route loads', async () => {

--- a/v2/frontend/src/features/legacy/argument-mapping-panel.tsx
+++ b/v2/frontend/src/features/legacy/argument-mapping-panel.tsx
@@ -191,7 +191,7 @@ function ArgumentColumn({mapping, slug, csrfToken, card, side}: {
       <Contribution slug={slug} csrfToken={csrfToken} featuredId={card.id} side={side} value={value.contribution} />
       {!gate && value.arguments.length === 0 && <p className="at-col-note">Other arguments appear here once you've added yours or skipped — so you form your own view first.</p>}
       {value.arguments.map((item) => <ArgumentCard key={item.id} mapping={mapping} slug={slug} csrfToken={csrfToken} side={side} item={item} prioritization={value.prioritization} />)}
-      {card.contributionsComplete && !voteReady && <div className="at-volnote" id={`volnote-${side}-${card.id}`}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M12 9v4M12 17h.01" /><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" /></svg><span>Prioritising unlocks once there are more than {value.prioritization.selectionBudget} {copy.adjective}-arguments ({value.arguments.length} so far).</span></div>}
+      {card.contributionsComplete && !voteReady && <div className="at-volnote" id={`volnote-${side}-${card.id}`}><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><path d="M12 3.5 22.5 20.5h-21z" /><path d="M12 10v4.5" /><circle cx="12" cy="17.8" r="1.05" fill="currentColor" stroke="none" /></svg><span>Prioritising unlocks once there are more than {value.prioritization.selectionBudget} {copy.adjective}-arguments ({value.arguments.length} so far).</span></div>}
     </div>
   );
 }

--- a/v2/frontend/src/features/legacy/conversation-flow.tsx
+++ b/v2/frontend/src/features/legacy/conversation-flow.tsx
@@ -1,0 +1,220 @@
+import {useState} from 'react';
+
+type FlowPhase = 'explore' | 'arguments' | 'informed';
+
+const FLOW_STORAGE_KEY = 'proto-wiki.conversation-flow.collapsed.v1';
+
+function PhaseIllustration({phase}: {phase: FlowPhase}) {
+  if (phase === 'explore') {
+    return (
+      <svg className="flow-rebuild__illustration" viewBox="0 0 190 120" aria-hidden="true">
+        <rect x="26" y="14" width="138" height="46" rx="9" className="flow-svg-surface" />
+        <path d="M42 31h78M42 43h54" className="flow-svg-copy" />
+        <g transform="rotate(38 150 44)">
+          <rect x="120" y="38" width="40" height="12" rx="2" className="flow-svg-pencil" />
+          <rect x="116" y="38" width="8" height="12" className="flow-svg-pencil-band" />
+          <path d="m160 38 10 6-10 6Z" className="flow-svg-ink" />
+        </g>
+        <g transform="translate(58 78)">
+          <rect width="30" height="30" rx="7" className="flow-svg-agree-box" />
+          <path d="m9 15 4 4 8-9" className="flow-svg-agree-mark" />
+        </g>
+        <g transform="translate(102 78)">
+          <rect width="30" height="30" rx="7" className="flow-svg-disagree-box" />
+          <path d="m10 10 10 10m0-10L10 20" className="flow-svg-disagree-mark" />
+        </g>
+      </svg>
+    );
+  }
+
+  if (phase === 'arguments') {
+    return (
+      <svg className="flow-rebuild__illustration" viewBox="0 0 190 120" aria-hidden="true">
+        <rect x="26" y="6" width="138" height="34" rx="8" className="flow-svg-surface" />
+        <path d="M40 18h78M40 28h54" className="flow-svg-copy" />
+        <rect x="30" y="52" width="118" height="24" rx="7" className="flow-svg-pro-box" />
+        <path d="M40 64h10m-5-5v10" className="flow-svg-pro-mark" />
+        <g transform="rotate(34 150 64)">
+          <rect x="120" y="59" width="30" height="9" rx="1.5" className="flow-svg-pencil" />
+          <rect x="117" y="59" width="6" height="9" className="flow-svg-pencil-band" />
+          <path d="m150 59 8 4.5-8 4.5Z" className="flow-svg-ink" />
+        </g>
+        <rect x="30" y="84" width="118" height="24" rx="7" className="flow-svg-con-box" />
+        <path d="M40 96h10" className="flow-svg-con-mark" />
+        <g transform="rotate(34 150 96)">
+          <rect x="120" y="91" width="30" height="9" rx="1.5" className="flow-svg-pencil" />
+          <rect x="117" y="91" width="6" height="9" className="flow-svg-pencil-band" />
+          <path d="m150 91 8 4.5-8 4.5Z" className="flow-svg-ink" />
+        </g>
+      </svg>
+    );
+  }
+
+  return (
+    <svg className="flow-rebuild__illustration" viewBox="0 0 190 120" aria-hidden="true">
+      <rect x="26" y="4" width="138" height="30" rx="8" className="flow-svg-surface" />
+      <path d="M40 14h78M40 24h54" className="flow-svg-copy" />
+      <g transform="translate(34 44)">
+        <rect width="56" height="20" rx="6" className="flow-svg-agree-box" />
+        <path d="M12 10h9m-4.5-4.5v9M30 10h18" className="flow-svg-agree-mark" />
+      </g>
+      <g transform="translate(100 44)">
+        <rect width="56" height="20" rx="6" className="flow-svg-con-box" />
+        <path d="M12 10h9m9 0h18" className="flow-svg-con-mark" />
+      </g>
+      <g transform="translate(58 78)">
+        <rect width="30" height="30" rx="7" className="flow-svg-agree-box" />
+        <path d="m9 15 4 4 8-9" className="flow-svg-agree-mark" />
+      </g>
+      <g transform="translate(102 78)">
+        <rect width="30" height="30" rx="7" className="flow-svg-disagree-box" />
+        <path d="m10 10 10 10m0-10L10 20" className="flow-svg-disagree-mark" />
+      </g>
+    </svg>
+  );
+}
+
+function LearningIcon({phase}: {phase: FlowPhase}) {
+  if (phase === 'explore') {
+    return (
+      <svg viewBox="0 0 40 36" aria-hidden="true">
+        <circle cx="9" cy="11" r="3.2" /><circle cx="20" cy="7" r="3.2" />
+        <circle cx="16" cy="19" r="3.2" /><circle cx="28" cy="15" r="3.2" opacity=".55" />
+        <circle cx="11" cy="25" r="3.2" opacity=".55" /><circle cx="30" cy="26" r="3.2" opacity=".55" />
+      </svg>
+    );
+  }
+  if (phase === 'arguments') {
+    return (
+      <svg viewBox="0 0 40 36" aria-hidden="true">
+        <rect x="4" y="5" width="14" height="10" rx="2.5" className="flow-learn-pro" />
+        <path d="M8 10h6m-3-3v6" className="flow-learn-pro-mark" />
+        <rect x="22" y="6" width="14" height="8" rx="2.5" opacity=".12" />
+        <rect x="4" y="20" width="14" height="10" rx="2.5" className="flow-learn-con" />
+        <path d="M8 25h6" className="flow-learn-con-mark" />
+        <rect x="22" y="21" width="14" height="8" rx="2.5" opacity=".08" />
+      </svg>
+    );
+  }
+  return (
+    <svg viewBox="0 0 40 36" aria-hidden="true">
+      <rect x="5" y="16" width="8" height="14" rx="2" />
+      <rect x="16" y="8" width="8" height="22" rx="2" />
+      <rect x="27" y="20" width="8" height="10" rx="2" opacity=".55" />
+    </svg>
+  );
+}
+
+function FlowCard({
+  phase,
+  title,
+  instruction,
+  learning,
+}: {
+  phase: FlowPhase;
+  title: string;
+  instruction: string;
+  learning: string;
+}) {
+  return (
+    <article className="flow-rebuild__card">
+      <h3>{title}</h3>
+      <PhaseIllustration phase={phase} />
+      <p className="flow-rebuild__instruction">{instruction}</p>
+      <div className="flow-rebuild__learning">
+        <p className="flow-rebuild__learning-label">What we learn</p>
+        <div className="flow-rebuild__learning-body">
+          <LearningIcon phase={phase} />
+          <p>{learning}</p>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function StepArrow() {
+  return <span className="flow-rebuild__step-arrow" aria-hidden="true" />;
+}
+
+export function ConversationFlow() {
+  const [collapsed, setCollapsed] = useState(() => {
+    try {
+      return localStorage.getItem(FLOW_STORAGE_KEY) === 'collapsed';
+    } catch {
+      return false;
+    }
+  });
+
+  function toggleOverview() {
+    const nextCollapsed = !collapsed;
+    try {
+      localStorage.setItem(FLOW_STORAGE_KEY, nextCollapsed ? 'collapsed' : 'expanded');
+    } catch {
+      // Storage can be unavailable in privacy-restricted browsers; the control
+      // still works for the lifetime of the current page.
+    }
+    setCollapsed(nextCollapsed);
+  }
+
+  return (
+    <section className={`flow-rebuild${collapsed ? ' flow-rebuild--collapsed' : ''}`} aria-labelledby="flow-rebuild-title">
+      <header className="flow-rebuild__heading">
+        <h2 id="flow-rebuild-title">How a ProtoWiki conversation works</h2>
+        <button
+          className="flow-rebuild__toggle"
+          type="button"
+          aria-expanded={!collapsed}
+          aria-controls="flow-rebuild-content"
+          aria-label={`${collapsed ? 'Show' : 'Hide'} conversation overview`}
+          onClick={toggleOverview}
+        >
+          <span>{collapsed ? 'Show' : 'Hide'}</span>
+          <span className="flow-rebuild__toggle-chevron" aria-hidden="true" />
+        </button>
+      </header>
+
+      <div id="flow-rebuild-content" hidden={collapsed}>
+        <p className="flow-rebuild__intro">Not a decision exercise — a shared picture of where a community agrees, disagrees, and why.</p>
+
+        <div className="flow-rebuild__steps">
+          <FlowCard
+            phase="explore"
+            title="Explore the questions"
+            instruction="Vote yes / no — and edit or add statements"
+            learning="Clusters of statements that inform the topic"
+          />
+          <StepArrow />
+          <FlowCard
+            phase="arguments"
+            title="Map the arguments"
+            instruction="Write the pro & con arguments that matter"
+            learning="A map of the arguments that matter, pro & con"
+          />
+          <StepArrow />
+          <FlowCard
+            phase="informed"
+            title="Express informed opinions"
+            instruction="Vote again, with the key arguments shown"
+            learning="How different parts of the community feel"
+          />
+        </div>
+
+        <svg className="flow-rebuild__merge" viewBox="0 0 1104 54" preserveAspectRatio="none" aria-hidden="true">
+          <path d="M174 0c0 26 378 18 378 36M552 0v36M930 0c0 26-378 18-378 36M552 36v14m-6-6 6 6 6-6" />
+          <circle cx="552" cy="36" r="2.6" />
+        </svg>
+
+        <div className="flow-rebuild__outcome">
+          <span className="flow-rebuild__outcome-icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24">
+              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+              <path d="M14 2v6h6" />
+              <path d="m9 14 2 2 4-4" className="flow-outcome-check" />
+            </svg>
+          </span>
+          <strong>A more balanced policy draft</strong>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/v2/frontend/src/features/legacy/conversation-flow.tsx
+++ b/v2/frontend/src/features/legacy/conversation-flow.tsx
@@ -209,8 +209,8 @@ export function ConversationFlow() {
         <div className="flow-rebuild__outcome">
           <span className="flow-rebuild__outcome-icon" aria-hidden="true">
             <svg viewBox="0 0 24 24">
-              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-              <path d="M14 2v6h6" />
+              <path d="M5 2h9l5 5v15H5z" />
+              <path d="M14 2v5h5" />
               <path d="m9 14 2 2 4-4" className="flow-outcome-check" />
             </svg>
           </span>

--- a/v2/frontend/src/features/legacy/conversation-flow.tsx
+++ b/v2/frontend/src/features/legacy/conversation-flow.tsx
@@ -54,19 +54,21 @@ function PhaseIllustration({phase}: {phase: FlowPhase}) {
     <svg className="flow-rebuild__illustration" viewBox="0 0 190 120" aria-hidden="true">
       <rect x="26" y="4" width="138" height="30" rx="8" className="flow-svg-surface" />
       <path d="M40 14h78M40 24h54" className="flow-svg-copy" />
-      <g transform="translate(34 44)">
-        <rect width="56" height="20" rx="6" className="flow-svg-agree-box" />
-        <path d="M12 10h9m-4.5-4.5v9M30 10h18" className="flow-svg-agree-mark" />
+      <g transform="translate(30 44)">
+        <rect width="60" height="24" rx="6" className="flow-svg-agree-box" />
+        <path d="M11 12h9m-4.5-4.5v9" className="flow-svg-agree-mark" />
+        <path d="M28 8.5h22M28 15.5h14" className="flow-svg-rowcopy" />
       </g>
       <g transform="translate(100 44)">
-        <rect width="56" height="20" rx="6" className="flow-svg-con-box" />
-        <path d="M12 10h9m9 0h18" className="flow-svg-con-mark" />
+        <rect width="60" height="24" rx="6" className="flow-svg-con-box" />
+        <path d="M11 12h9" className="flow-svg-con-mark" />
+        <path d="M28 8.5h22M28 15.5h14" className="flow-svg-rowcopy" />
       </g>
-      <g transform="translate(58 78)">
+      <g transform="translate(58 82)">
         <rect width="30" height="30" rx="7" className="flow-svg-agree-box" />
         <path d="m9 15 4 4 8-9" className="flow-svg-agree-mark" />
       </g>
-      <g transform="translate(102 78)">
+      <g transform="translate(102 82)">
         <rect width="30" height="30" rx="7" className="flow-svg-disagree-box" />
         <path d="m10 10 10 10m0-10L10 20" className="flow-svg-disagree-mark" />
       </g>
@@ -89,10 +91,10 @@ function LearningIcon({phase}: {phase: FlowPhase}) {
       <svg viewBox="0 0 40 36" aria-hidden="true">
         <rect x="4" y="5" width="14" height="10" rx="2.5" className="flow-learn-pro" />
         <path d="M8 10h6m-3-3v6" className="flow-learn-pro-mark" />
-        <rect x="22" y="6" width="14" height="8" rx="2.5" opacity=".12" />
+        <path d="M25 7.5h13M25 12.5h8" className="flow-learn-copy" />
         <rect x="4" y="20" width="14" height="10" rx="2.5" className="flow-learn-con" />
         <path d="M8 25h6" className="flow-learn-con-mark" />
-        <rect x="22" y="21" width="14" height="8" rx="2.5" opacity=".08" />
+        <path d="M25 22.5h13M25 27.5h8" className="flow-learn-copy" />
       </svg>
     );
   }

--- a/v2/frontend/src/features/legacy/conversation-flow.tsx
+++ b/v2/frontend/src/features/legacy/conversation-flow.tsx
@@ -64,11 +64,11 @@ function PhaseIllustration({phase}: {phase: FlowPhase}) {
         <path d="M11 12h9" className="flow-svg-con-mark" />
         <path d="M28 8.5h22M28 15.5h14" className="flow-svg-rowcopy" />
       </g>
-      <g transform="translate(58 82)">
+      <g transform="translate(58 78)">
         <rect width="30" height="30" rx="7" className="flow-svg-agree-box" />
         <path d="m9 15 4 4 8-9" className="flow-svg-agree-mark" />
       </g>
-      <g transform="translate(102 82)">
+      <g transform="translate(102 78)">
         <rect width="30" height="30" rx="7" className="flow-svg-disagree-box" />
         <path d="m10 10 10 10m0-10L10 20" className="flow-svg-disagree-mark" />
       </g>

--- a/v2/frontend/src/features/legacy/conversation-lane-page.tsx
+++ b/v2/frontend/src/features/legacy/conversation-lane-page.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../api/queries';
 import {LegacyShell} from './legacy-shell';
 import {InternalLink} from '../../internal-link';
+import {ConversationFlow} from './conversation-flow';
 
 type ConversationCard = components['schemas']['ConversationCard'];
 type ConversationOutput = components['schemas']['ConversationOutput'];
@@ -426,18 +427,11 @@ export function ConversationLanePage({space}: {space: ConversationSpace}) {
   return (
     <LegacyShell headerMode={space}>
       <div className="container home-container">
-        <div className="home-banner">
-          Prototype in active development — things may change.{' '}
-          <InternalLink href="https://github.com/lgelauff/wiki-polis/issues/new" target="_blank" rel="noopener">
-            Open an issue<span className="sr-only"> (opens in a new tab)</span>
-          </InternalLink>{' '}if you find a bug.
-        </div>
-
         {!data.authenticated ? (
           <AnonymousLane conversations={groups.available} developerLogins={session.developerLogins} loginHref={session.links.login} />
         ) : <>
           <h1 className="sr-only">Consultations</h1>
-          <img src="/static/wiki-polis-flow.svg" alt="How a ProtoWiki conversation works" style={{width: '100%', maxWidth: 900, display: 'block', margin: '0 auto 1.5rem'}} />
+          <ConversationFlow />
           <PhaseLegend />
           <div className="home-mode-toggle" role="group" aria-label="View mode">
             <button className={`home-mode-btn${mode === 'yours' ? ' home-mode-btn--active' : ''}`} data-target="yours" type="button" aria-pressed={mode === 'yours'} onClick={() => changeMode('yours')}>Your conversations</button>

--- a/v2/frontend/src/features/legacy/legacy-shell.tsx
+++ b/v2/frontend/src/features/legacy/legacy-shell.tsx
@@ -1,4 +1,4 @@
-import {useLayoutEffect, type ReactNode} from 'react';
+import {useLayoutEffect, useState, type ReactNode} from 'react';
 import {useSuspenseQuery} from '@tanstack/react-query';
 
 import {sessionQuery} from '../../api/queries';
@@ -6,6 +6,39 @@ import {InternalLink} from '../../internal-link';
 import {SpaModeToggle} from '../../strict-spa-mode';
 
 type HeaderMode = 'fork' | 'demo' | 'real' | 'conversation-demo' | 'conversation-real' | 'admin' | 'plain';
+
+const SITE_NOTICE_STORAGE_KEY = 'proto-wiki.site-notice.development.v1';
+
+function SiteNotice() {
+  const [visible, setVisible] = useState(() => {
+    try { return localStorage.getItem(SITE_NOTICE_STORAGE_KEY) !== 'dismissed'; }
+    catch { return true; }
+  });
+
+  if (!visible) return null;
+
+  function dismiss() {
+    try { localStorage.setItem(SITE_NOTICE_STORAGE_KEY, 'dismissed'); }
+    catch { /* Dismiss for this view even when browser storage is unavailable. */ }
+    setVisible(false);
+  }
+
+  return (
+    <aside className="site-notice" aria-label="Prototype notice">
+      <div className="site-notice__inner">
+        <p>
+          Prototype in active development. Things may change.{' '}
+          <InternalLink href="https://github.com/lgelauff/wiki-polis/issues/new" target="_blank" rel="noopener">
+            Open an issue<span className="sr-only"> (opens in a new tab)</span>
+          </InternalLink>{' '}if you find a bug.
+        </p>
+        <button className="site-notice__dismiss" type="button" aria-label="Dismiss site notice" onClick={dismiss}>
+          <span aria-hidden="true">×</span>
+        </button>
+      </div>
+    </aside>
+  );
+}
 
 function OrbitMark() {
   return (
@@ -81,6 +114,8 @@ export function LegacyShell({
 
   return (
     <>
+      <SiteNotice />
+
       <header className={`site-header ${headerMode === 'admin' ? 'site-header--admin' : 'site-header--participant'}`}>
         <div className="header-inner">
           <div className="header-left">

--- a/v2/frontend/src/features/legacy/public-pages.test.tsx
+++ b/v2/frontend/src/features/legacy/public-pages.test.tsx
@@ -22,9 +22,14 @@ test('renders the entry fork with the legacy shell and card contract', async () 
   renderRoute('/app/parity/fork');
 
   expect(await screen.findByRole('heading', {name: 'Where the community actually stands.'})).toBeVisible();
+  expect(screen.getByText(/Choose the playground to try the platform/)).toBeVisible();
   expect(screen.getByRole('link', {name: 'ProtoWiki'})).toHaveClass('header-logo');
-  expect(screen.getByRole('link', {name: /Try out the platform/})).toHaveClass('fork-card--demo');
+  expect(screen.getByRole('link', {name: /Try the platform in a playground/})).toHaveClass('fork-card--demo');
   expect(screen.getByRole('link', {name: /Participate in real consultations/})).toHaveClass('fork-card--real');
+  expect(Array.from(document.querySelectorAll('.fork-grid > .fork-card')).map((card) => card.className)).toEqual([
+    'fork-card fork-card--demo',
+    'fork-card fork-card--real',
+  ]);
   expect(screen.getByRole('link', {name: /Open an issue/})).toHaveAttribute('target', '_blank');
   expect(screen.getByText('test-version')).toBeVisible();
   expect(document.querySelector('link[data-react-legacy-styles]')).toBeNull();

--- a/v2/frontend/src/features/legacy/public-pages.tsx
+++ b/v2/frontend/src/features/legacy/public-pages.tsx
@@ -9,52 +9,46 @@ export function ForkPage() {
 
   return (
     <LegacyShell headerMode="fork">
-      <div className="container home-container">
-        <div className="home-banner">
-          Prototype in active development — things may change.{' '}
-          <InternalLink href="https://github.com/lgelauff/wiki-polis/issues/new" target="_blank" rel="noopener">
-            Open an issue<span className="sr-only"> (opens in a new tab)</span>
-          </InternalLink>{' '}if you find a bug.
-        </div>
-
-        <div className="landing-section">
-          <h1 style={{fontSize: 26, fontWeight: 600, letterSpacing: '-0.02em', lineHeight: 1.15, marginBottom: 12}}>Where the community actually stands.</h1>
-          <p style={{fontSize: 15, lineHeight: 1.6, color: 'var(--body)', maxWidth: 520}}>
-            Vote on short statements, and suggest improvements. Learn how your views
-            compare to other community members — which statements already have
-            consensus, and what topics are divisive, and why.
+      <div className="container home-container fork-page">
+        <div className="landing-section fork-intro">
+          <h1 className="fork-intro__title">Where the community actually stands.</h1>
+          <p className="fork-intro__copy">
+            ProtoWiki makes agreement, disagreement, and the reasons behind both
+            easier to see.<br />Choose the playground to try the platform at your own pace,
+            or join a real consultation where your contribution becomes part of the
+            community’s shared picture.
           </p>
         </div>
 
         <div className="fork-grid">
-          <InternalLink href="/demo" className="fork-card fork-card--demo" aria-label="Try out the platform — a demonstration conversation where you can try the full flow">
+          <InternalLink href="/demo" className="fork-card fork-card--demo" aria-label="Try the platform in a playground conversation">
             <svg className="fork-card-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
               <path d="M9 3h6M10 3v6l-5 8a2 2 0 0 0 1.7 3h10.6a2 2 0 0 0 1.7-3l-5-8V3" />
             </svg>
-            <h2 className="fork-card-title">Try out the platform</h2>
-            <div className="fork-card-sub">Demonstration conversations — try the full flow.</div>
+            <h2 className="fork-card-title">Try the playground</h2>
+            <div className="fork-card-sub">Explore the full platform in a demonstration conversation.</div>
             <span className="fork-card-cta">Try it →</span>
           </InternalLink>
 
-          <InternalLink href="/consultations" className="fork-card fork-card--real" aria-label="Participate in real consultations — your votes count">
+          <InternalLink href="/consultations" className="fork-card fork-card--real" aria-label="Participate in real consultations, where your contribution counts">
             <svg className="fork-card-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
               <circle cx="9" cy="8" r="3" /><path d="M3 20a6 6 0 0 1 12 0" />
               <circle cx="17" cy="9" r="2.4" /><path d="M15.5 20a5.5 5.5 0 0 1 6.5-5.4" />
             </svg>
             <h2 className="fork-card-title">Participate in real consultations</h2>
-            <div className="fork-card-sub">Your votes count.</div>
+            <div className="fork-card-sub">Join an active conversation. Your contribution counts.</div>
             <span className="fork-card-cta">Participate →</span>
           </InternalLink>
         </div>
 
         {session.developerLogins.length > 0 && (
-          <div style={{marginTop: '1.25rem', padding: '10px 14px', border: '1px dashed var(--spot)', borderRadius: 8, background: 'rgba(245,158,11,0.05)', display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap'}}>
-            <span style={{fontFamily: 'var(--mono)', fontSize: 10, textTransform: 'uppercase', letterSpacing: '0.08em', color: 'var(--spot)'}}>Dev</span>
+          <div className="fork-dev-tools">
+            <span className="fork-dev-label">Dev</span>
             {session.developerLogins.map((login) => (
               <InternalLink
                 key={login.username}
                 href={login.href}
-                style={{fontFamily: 'var(--mono)', fontSize: 11, padding: '2px 8px', borderRadius: 4, background: 'var(--surface2)', border: '1px solid var(--hairline)', color: 'var(--ink)', textDecoration: 'none'}}
+                className="fork-dev-login"
                 title={`Log in as ${login.username}`}
               >{login.username}</InternalLink>
             ))}

--- a/v2/parity/routes.json
+++ b/v2/parity/routes.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "goal": "100% route, feature, behavior, permission-state, accessibility, and visual parity with the Jinja frontend",
   "statusValues": ["missing", "partial", "implemented-unverified", "parity"],
-  "sharedTemplates": ["_reveal_timeline.html", "base.html", "forbidden_eligibility.html", "forbidden_invite_only.html"],
+  "sharedTemplates": ["_conversation_flow.html", "_reveal_timeline.html", "base.html", "forbidden_eligibility.html", "forbidden_invite_only.html"],
   "conditionalEndpoints": ["dev_login", "dev_fake_login"],
   "serverSupportEndpoints": ["login", "logout", "oauth_callback", "dev_login", "dev_fake_login"],
   "pages": [

--- a/v2/static/img/phases/arguments.svg
+++ b/v2/static/img/phases/arguments.svg
@@ -1,9 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
   <g fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M12 4v15"/>
-    <path d="M6 20h12"/>
-    <path d="M5 8h14"/>
-    <path d="M7 8 4 14h6L7 8Z"/>
-    <path d="m17 8-3 6h6l-3-6Z"/>
+    <path d="M12 6v13"/>
+    <path d="M8.5 19h7"/>
+    <path d="M4.5 6 19.5 9"/>
+    <path d="M5 7v2"/>
+    <path d="M19 9v2"/>
   </g>
+  <path d="M2 9a3 3 0 0 0 6 0Z"/>
+  <path d="M16 11a3 3 0 0 0 6 0Z"/>
 </svg>

--- a/v2/static/img/phases/informed-vote.svg
+++ b/v2/static/img/phases/informed-vote.svg
@@ -1,12 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
   <g fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M4 7h7"/>
-    <path d="M4 12h6"/>
-    <path d="M4 17h5"/>
-    <path d="M16 5v13"/>
-    <path d="M13 19h6"/>
-    <path d="M12 9h8"/>
-    <path d="m13.5 9-2 4h4l-2-4Z"/>
-    <path d="m18.5 9-2 4h4l-2-4Z"/>
+    <path d="M9 3.5h9"/>
+    <path d="M9 9.5h9"/>
+    <path d="M9 15.5h6"/>
+    <path d="M3.5 4.5v4"/>
+    <path d="M1.5 6.5h4"/>
+    <path d="M1.5 12.5h4"/>
+    <path d="m15.5 19 2 2 5-5.2"/>
   </g>
 </svg>

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -3985,6 +3985,10 @@ a { color: var(--pass); }
   margin: 0 auto 1.5rem;
   padding: 2.25rem 3rem 1.9rem;
   background: var(--bg);
+  /* Gives the section a visible edge, so the Hide control at its top-right
+     reads as belonging to it rather than floating against the page. */
+  border: 1px solid var(--hairline);
+  border-radius: 16px;
 }
 
 .flow-rebuild__heading {
@@ -4228,6 +4232,8 @@ a { color: var(--pass); }
 .flow-learn-pro-mark { fill: none; stroke: var(--agree); stroke-width: 1.6; stroke-linecap: round; }
 .flow-learn-con { fill: var(--surface2); stroke: var(--muted); stroke-width: 1.3; }
 .flow-learn-con-mark { fill: none; stroke: var(--muted); stroke-width: 1.6; stroke-linecap: round; }
+.flow-learn-copy { fill: none; stroke: #b9c2d2; stroke-width: 1.8; stroke-linecap: round; }
+.flow-svg-rowcopy { fill: none; stroke: #cfcdc6; stroke-width: 2.4; stroke-linecap: round; }
 
 @media (max-width: 900px) {
   .flow-rebuild { padding: 1.75rem 1rem 1.25rem; }
@@ -4275,6 +4281,10 @@ a { color: var(--pass); }
   align-items: center;
   gap: 6px;
   flex-shrink: 0;
+  /* Uniform width so the connector marker lands exactly midway between two
+     icons. Sized by their labels the nodes differ (Explore ~44px, Informed
+     vote ~78px) and the marker drifts toward the narrower neighbour. */
+  width: 104px;
 }
 
 .phase-legend-icon {
@@ -4328,17 +4338,34 @@ a { color: var(--pass); }
 .phase-legend-line {
   flex: 1;
   height: 1px;
-  background: var(--hairline);
+  background: var(--muted);
 }
 
+/* Between-phase marker: the same clock face the per-conversation input
+   timeline uses (.conv-input-clock), at the legend's heavier weight. */
 .phase-legend-mid-dot {
-  width: 6px;
-  height: 6px;
+  width: 11px;
+  height: 11px;
   border-radius: 50%;
-  border: 1.5px dashed var(--hairline);
+  border: 1.5px solid var(--muted);
   flex-shrink: 0;
   margin: 0 3px;
+  position: relative;
 }
+
+.phase-legend-mid-dot::before,
+.phase-legend-mid-dot::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 1px;
+  background: var(--body);
+  transform-origin: top center;
+}
+
+.phase-legend-mid-dot::before { height: 3px; transform: translate(-50%, -50%); }
+.phase-legend-mid-dot::after { height: 4px; transform: translate(-50%, -50%) rotate(90deg); }
 
 /* ── Homepage: mode toggle ─────────────────────────────────────────────────── */
 

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -4287,6 +4287,15 @@ a { color: var(--pass); }
   width: 104px;
 }
 
+/* The uniform width puts the strip's minimum around 525px, which would force
+   the legend into its own horizontal scroll on a phone. Narrow viewports fall
+   back to label-sized nodes: the centring is a full-width refinement, and a
+   scrollbar costs more than a few px of drift. The strip needs ~574px of
+   viewport to fit, so the fallback starts above that rather than at 560. */
+@media (max-width: 600px) {
+  .phase-legend-node { width: auto; }
+}
+
 .phase-legend-icon {
   display: flex;
   align-items: center;
@@ -4359,13 +4368,24 @@ a { color: var(--pass); }
   position: absolute;
   left: 50%;
   top: 50%;
-  width: 1px;
   background: var(--body);
-  transform-origin: top center;
 }
 
-.phase-legend-mid-dot::before { height: 3px; transform: translate(-50%, -50%); }
-.phase-legend-mid-dot::after { height: 4px; transform: translate(-50%, -50%) rotate(90deg); }
+/* Both hands pivot on the dot's centre. .conv-input-clock rotates about
+   `top center`, which lands its second hand above and left of the centre
+   instead of through it — a near-invisible quirk at hairline weight, but a
+   visible elbow at the weight this marker carries. */
+.phase-legend-mid-dot::before {
+  width: 1px;
+  height: 3px;
+  transform: translate(-50%, -100%);
+}
+
+.phase-legend-mid-dot::after {
+  width: 4px;
+  height: 1px;
+  transform: translate(0, -50%);
+}
 
 /* ── Homepage: mode toggle ─────────────────────────────────────────────────── */
 

--- a/v2/static/style.css
+++ b/v2/static/style.css
@@ -30,6 +30,9 @@
   /* Type stacks */
   --sans: "Inter Tight", "Inter", system-ui, -apple-system, sans-serif;
   --mono: "JetBrains Mono", "Geist Mono", ui-monospace, monospace;
+  /* Broad on laptop screens, capped so the interface does not keep stretching
+     on desktop monitors. Participant and header chrome share this alignment. */
+  --page-canvas: min(80vw, 1280px);
 }
 
 * {
@@ -122,7 +125,7 @@ header {
 
 .header-inner {
   width: 100%;
-  max-width: 900px;
+  max-width: var(--page-canvas);
   margin: 0 auto;
   display: flex;
   justify-content: space-between;
@@ -298,6 +301,18 @@ header {
   border-color: var(--accent);
 }
 
+@media (max-width: 600px) {
+  header { padding-inline: 1rem; }
+  .header-inner { gap: .75rem; }
+  .header-right { gap: .6rem; flex-shrink: 0; }
+
+  /* Preserve the brand, space switch, and authentication action. These are
+     supplemental or redundant in the constrained mobile header. */
+  .spa-dev-toggle,
+  .header-user-chip,
+  .header-admin-link { display: none; }
+}
+
 .content-flag {
   display: inline-block;
   position: relative;
@@ -393,7 +408,8 @@ header {
 /* ── Main container ── */
 
 .container {
-  max-width: 900px;
+  width: var(--page-canvas);
+  max-width: none;
   margin: 2rem auto;
   padding: 0 1.5rem;
 }
@@ -492,10 +508,6 @@ header {
 }
 
 /* ── Home page — Cluster card layout ── */
-
-.home-container {
-  max-width: 820px;
-}
 
 @media (max-width: 600px) {
   .home-container { padding: 0 1rem; }
@@ -3921,19 +3933,325 @@ a { color: var(--pass); }
   .reveal-what { font-size: 11px; }
 }
 
-/* ── Homepage: dev banner ──────────────────────────────────────────────────── */
+/* ── Site-wide development notice ─────────────────────────────────────────── */
 
-.home-banner {
-  margin-bottom: 1.25rem;
-  padding: 10px 14px;
-  border: 1px solid var(--hairline);
-  border-radius: 8px;
-  background: var(--surface);
-  font-size: 13px;
-  color: var(--muted);
-  line-height: 1.6;
+.site-notice {
+  background: var(--surface2);
+  border-bottom: 1px solid var(--hairline);
 }
-.home-banner a { color: var(--pass); }
+
+.site-notice__inner {
+  width: var(--page-canvas);
+  margin: 0 auto;
+  padding: 2px 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: .3rem;
+  font-size: 11px;
+  color: var(--muted);
+  line-height: 1.45;
+  text-align: center;
+}
+
+.site-notice__inner p { margin: 0; }
+.site-notice a { color: var(--pass); }
+
+.site-notice__dismiss {
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--muted);
+  font: 400 17px/1 var(--sans);
+  cursor: pointer;
+}
+
+.site-notice__dismiss:hover {
+  background: var(--surface);
+  color: var(--ink);
+}
+
+/* ── Editable HTML/CSS reconstruction of the conversation flow ───────────── */
+
+.flow-rebuild {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto 1.5rem;
+  padding: 2.25rem 3rem 1.9rem;
+  background: var(--bg);
+}
+
+.flow-rebuild__heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  height: auto;
+  padding: 0;
+  background: transparent;
+  border: 0;
+}
+
+.flow-rebuild__heading h2 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 30px;
+  line-height: 1.15;
+  letter-spacing: -.025em;
+}
+
+.flow-rebuild__intro {
+  margin: .55rem 0 0;
+  color: var(--muted);
+  font-size: 16px;
+  line-height: 1.45;
+}
+
+.flow-rebuild__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+  flex: 0 0 auto;
+  margin-top: .05rem;
+  padding: .4rem .65rem;
+  border: 1px solid var(--hairline);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  font: 700 10.5px/1 var(--mono);
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.flow-rebuild__toggle[hidden] { display: none; }
+
+.flow-rebuild__toggle:hover {
+  border-color: var(--muted);
+  color: var(--ink);
+}
+
+.flow-rebuild__toggle:focus-visible {
+  outline: 2px solid var(--pass);
+  outline-offset: 2px;
+}
+
+.flow-rebuild__toggle-chevron {
+  width: 7px;
+  height: 7px;
+  border-top: 1.5px solid currentColor;
+  border-left: 1.5px solid currentColor;
+  transform: translateY(2px) rotate(45deg);
+}
+
+.flow-rebuild--collapsed {
+  padding-block: 1.2rem;
+}
+
+.flow-rebuild--collapsed .flow-rebuild__toggle-chevron {
+  transform: translateY(-2px) rotate(225deg);
+}
+
+.flow-rebuild__steps {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 30px minmax(0, 1fr) 30px minmax(0, 1fr);
+  align-items: stretch;
+  margin-top: 1.5rem;
+}
+
+.flow-rebuild__card {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 0 1.35rem 1.2rem;
+  background: var(--surface);
+  border: 1px solid var(--hairline);
+  border-radius: 14px;
+}
+
+.flow-rebuild__card h3 {
+  margin: 0;
+  padding: 1.15rem 0 1rem;
+  border-bottom: 1px solid var(--hairline);
+  color: var(--ink);
+  font-size: 19px;
+  line-height: 1.25;
+  letter-spacing: -.02em;
+}
+
+.flow-rebuild__illustration {
+  width: 190px;
+  max-width: 100%;
+  height: 120px;
+  display: block;
+  margin: .7rem auto .35rem;
+  overflow: visible;
+}
+
+.flow-rebuild__instruction {
+  min-height: 2.4em;
+  margin: 0 0 .8rem;
+  color: var(--muted);
+  font-size: 12.5px;
+  font-style: italic;
+  line-height: 1.35;
+  text-align: center;
+}
+
+.flow-rebuild__learning {
+  margin-top: auto;
+  padding: .65rem .85rem .7rem;
+  background: #eef3fb;
+  border: 1px solid #c9d6ef;
+  border-radius: 10px;
+}
+
+.flow-rebuild__learning-label {
+  margin: 0 0 .25rem;
+  color: var(--pass);
+  font: 700 10.5px/1.2 var(--mono);
+  letter-spacing: .13em;
+  text-transform: uppercase;
+}
+
+.flow-rebuild__learning-body {
+  display: flex;
+  align-items: center;
+  gap: .7rem;
+}
+
+.flow-rebuild__learning-body > svg {
+  width: 40px;
+  height: 36px;
+  flex: 0 0 40px;
+  overflow: visible;
+  fill: var(--pass);
+}
+
+.flow-rebuild__learning-body p {
+  margin: 0;
+  color: var(--body);
+  font-size: 13px;
+  line-height: 1.3;
+}
+
+.flow-rebuild__step-arrow {
+  width: 17px;
+  height: 17px;
+  align-self: center;
+  justify-self: center;
+  border-top: 2px solid var(--muted);
+  border-right: 2px solid var(--muted);
+  transform: rotate(45deg);
+}
+
+.flow-rebuild__merge {
+  width: calc(100% - 2.7rem);
+  height: 54px;
+  display: block;
+  margin: 0 auto;
+  overflow: visible;
+  fill: var(--pass);
+  stroke: var(--pass);
+  stroke-width: 1.75;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.flow-rebuild__merge path { fill: none; vector-effect: non-scaling-stroke; }
+.flow-rebuild__merge circle { stroke: none; }
+
+.flow-rebuild__outcome {
+  display: flex;
+  align-items: center;
+  gap: 1.1rem;
+  min-height: 64px;
+  padding: .65rem 1.2rem;
+  background: #eef3fb;
+  border: 1px solid #c9d6ef;
+  border-radius: 14px;
+  color: var(--ink);
+}
+
+.flow-rebuild__outcome strong {
+  font-size: 19px;
+  line-height: 1.25;
+  letter-spacing: -.02em;
+}
+
+.flow-rebuild__outcome-icon {
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 36px;
+  background: var(--surface);
+  border: 1px solid #c9d6ef;
+  border-radius: 9px;
+}
+
+.flow-rebuild__outcome-icon svg {
+  width: 22px;
+  height: 22px;
+  fill: none;
+  stroke: var(--pass);
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.flow-rebuild__outcome-icon .flow-outcome-check { stroke: var(--agree); }
+
+/* Small SVG fragments inherit the product palette from CSS instead of
+   hard-coding presentation throughout their markup. */
+.flow-svg-surface { fill: var(--surface); stroke: var(--hairline); stroke-width: 1.5; }
+.flow-svg-copy { fill: none; stroke: #cfcdc6; stroke-width: 3.2; stroke-linecap: round; }
+.flow-svg-pencil { fill: var(--pass); }
+.flow-svg-pencil-band { fill: var(--spot); }
+.flow-svg-ink { fill: var(--ink); }
+.flow-svg-agree-box { fill: rgba(21, 115, 74, .12); stroke: var(--agree); stroke-width: 1.5; }
+.flow-svg-agree-mark { fill: none; stroke: var(--agree); stroke-width: 2.4; stroke-linecap: round; stroke-linejoin: round; }
+.flow-svg-disagree-box { fill: rgba(178, 58, 58, .1); stroke: var(--disagree); stroke-width: 1.5; }
+.flow-svg-disagree-mark { fill: none; stroke: var(--disagree); stroke-width: 2.4; stroke-linecap: round; }
+.flow-svg-pro-box { fill: rgba(21, 115, 74, .06); stroke: var(--agree); stroke-width: 1.5; stroke-dasharray: 4 3; }
+.flow-svg-pro-mark { fill: none; stroke: var(--agree); stroke-width: 2.4; stroke-linecap: round; }
+.flow-svg-con-box { fill: var(--surface2); stroke: var(--muted); stroke-width: 1.5; stroke-dasharray: 4 3; }
+.flow-svg-con-mark { fill: none; stroke: var(--muted); stroke-width: 2.4; stroke-linecap: round; }
+.flow-learn-pro { fill: rgba(21, 115, 74, .14); stroke: var(--agree); stroke-width: 1.3; }
+.flow-learn-pro-mark { fill: none; stroke: var(--agree); stroke-width: 1.6; stroke-linecap: round; }
+.flow-learn-con { fill: var(--surface2); stroke: var(--muted); stroke-width: 1.3; }
+.flow-learn-con-mark { fill: none; stroke: var(--muted); stroke-width: 1.6; stroke-linecap: round; }
+
+@media (max-width: 900px) {
+  .flow-rebuild { padding: 1.75rem 1rem 1.25rem; }
+  .flow-rebuild__steps {
+    grid-template-columns: 1fr;
+    gap: .8rem;
+  }
+  .flow-rebuild__step-arrow { transform: rotate(135deg); margin: .1rem 0; }
+  .flow-rebuild__merge { display: none; }
+  .flow-rebuild__outcome { margin-top: .9rem; }
+}
+
+@media (max-width: 520px) {
+  .flow-rebuild__heading h2 { font-size: 25px; }
+  .flow-rebuild__intro { font-size: 14px; }
+  .flow-rebuild__heading { gap: .75rem; }
+  .flow-rebuild__card { padding-inline: 1rem; }
+  .flow-rebuild__outcome strong { font-size: 17px; }
+}
+
+@media (max-width: 900px) {
+  :root { --page-canvas: 100%; }
+  .site-notice__inner { padding-inline: 1rem; }
+}
 
 /* ── Homepage: phase journey legend ───────────────────────────────────────── */
 
@@ -4383,6 +4701,34 @@ body[data-demo] {
 }
 
 /* Fork landing: the two lanes */
+.fork-page .landing-section,
+.fork-page .fork-card {
+  border: 0;
+}
+
+.fork-intro {
+  padding: 1.75rem 1.8rem 1.85rem;
+  background: transparent;
+  text-align: center;
+}
+
+.fork-intro__title {
+  max-width: 680px;
+  margin: 0 auto .8rem;
+  font-size: 30px;
+  font-weight: 600;
+  line-height: 1.12;
+  letter-spacing: -.025em;
+}
+
+.fork-intro__copy {
+  max-width: 720px;
+  margin: 0 auto;
+  color: var(--body);
+  font-size: 15px;
+  line-height: 1.65;
+}
+
 .fork-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -4403,6 +4749,7 @@ body[data-demo] {
 .fork-card--demo {
   background: #eaf1fb;
   border-color: #b5d4f4;
+  text-align: right;
 }
 .fork-card-icon { color: var(--blue-dark); }
 .fork-card--real .fork-card-icon { color: var(--accent); }
@@ -4419,6 +4766,40 @@ body[data-demo] {
   background: var(--accent);
 }
 .fork-card--demo .fork-card-cta { background: var(--blue-dark); }
+
+.fork-dev-tools {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 1.25rem;
+  padding: 10px 14px;
+  border: 1px dashed var(--spot);
+  border-radius: 8px;
+  background: rgba(245, 158, 11, .05);
+}
+
+.fork-dev-label,
+.fork-dev-login {
+  font-family: var(--mono);
+}
+
+.fork-dev-label {
+  color: var(--spot);
+  font-size: 10px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.fork-dev-login {
+  padding: 2px 8px;
+  border: 1px solid var(--hairline);
+  border-radius: 4px;
+  background: var(--surface2);
+  color: var(--ink);
+  font-size: 11px;
+  text-decoration: none;
+}
 
 .conv-card-badge--demo {
   color: var(--blue-dark);

--- a/v2/static/wiki-polis-flow.svg
+++ b/v2/static/wiki-polis-flow.svg
@@ -69,7 +69,7 @@
 <rect x="48" y="506" width="1104" height="64" rx="14" fill="#eef3fb" stroke="#c9d6ef"></rect>
 <rect x="68" y="520" width="36" height="36" rx="9" fill="#ffffff" stroke="#c9d6ef"></rect>
 <g transform="translate(75,527)" fill="none" stroke="#3d6dba" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><path d="M14 2v6h6"></path><path d="M9 14l2 2 4-4" stroke="#15734a"></path>
+  <path d="M5 2h9l5 5v15H5z"></path><path d="M14 2v5h5"></path><path d="M9 14l2 2 4-4" stroke="#15734a"></path>
 </g>
 <text x="124" y="544" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="19" font-weight="700" letter-spacing="-0.4" fill="#0c0c0e">A more balanced policy draft</text>
 </svg>

--- a/v2/static/wiki-polis-flow.svg
+++ b/v2/static/wiki-polis-flow.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="600" viewBox="0 0 1200 600" role="img" aria-label="How a wiki-polis conversation works">
 <title>How a wiki-polis conversation works</title>
 <desc>Three phases — Explore the questions, Map the arguments, Express informed opinions — each producing data that converges into a more balanced policy draft.</desc>
-<rect x="0.5" y="0.5" width="1199" height="599" rx="18" fill="#fafaf9" stroke="#e5e5e6"></rect>
+<rect x="0.5" y="0.5" width="1199" height="599" rx="18" fill="#fafaf9"></rect>
 <text x="48" y="62" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="30" font-weight="700" letter-spacing="-0.7" fill="#0c0c0e">How a wiki-polis conversation works</text>
 <text x="48" y="94" font-family="&#39;Inter Tight&#39;,sans-serif" font-size="16" fill="#5f5f68">Not a decision exercise — a shared picture of where a community agrees, disagrees, and why.</text>
 <g transform="translate(48,124)">

--- a/v2/templates/_conversation_flow.html
+++ b/v2/templates/_conversation_flow.html
@@ -1,0 +1,176 @@
+<section class="flow-rebuild" aria-labelledby="flow-rebuild-title">
+  <header class="flow-rebuild__heading">
+    <h2 id="flow-rebuild-title">How a ProtoWiki conversation works</h2>
+    <button class="flow-rebuild__toggle"
+            id="flow-rebuild-toggle"
+            type="button"
+            aria-expanded="true"
+            aria-controls="flow-rebuild-content"
+            aria-label="Hide conversation overview"
+            hidden>
+      <span class="flow-rebuild__toggle-label">Hide</span>
+      <span class="flow-rebuild__toggle-chevron" aria-hidden="true"></span>
+    </button>
+  </header>
+
+  <div id="flow-rebuild-content">
+  <p class="flow-rebuild__intro">Not a decision exercise — a shared picture of where a community agrees, disagrees, and why.</p>
+
+  <div class="flow-rebuild__steps">
+    <article class="flow-rebuild__card">
+      <h3>Explore the questions</h3>
+      <svg class="flow-rebuild__illustration" viewBox="0 0 190 120" aria-hidden="true">
+        <rect x="26" y="14" width="138" height="46" rx="9" class="flow-svg-surface"/>
+        <path d="M42 31h78M42 43h54" class="flow-svg-copy"/>
+        <g transform="rotate(38 150 44)">
+          <rect x="120" y="38" width="40" height="12" rx="2" class="flow-svg-pencil"/>
+          <rect x="116" y="38" width="8" height="12" class="flow-svg-pencil-band"/>
+          <path d="m160 38 10 6-10 6Z" class="flow-svg-ink"/>
+        </g>
+        <g transform="translate(58 78)">
+          <rect width="30" height="30" rx="7" class="flow-svg-agree-box"/>
+          <path d="m9 15 4 4 8-9" class="flow-svg-agree-mark"/>
+        </g>
+        <g transform="translate(102 78)">
+          <rect width="30" height="30" rx="7" class="flow-svg-disagree-box"/>
+          <path d="m10 10 10 10m0-10L10 20" class="flow-svg-disagree-mark"/>
+        </g>
+      </svg>
+      <p class="flow-rebuild__instruction">Vote yes / no — and edit or add statements</p>
+      <div class="flow-rebuild__learning">
+        <p class="flow-rebuild__learning-label">What we learn</p>
+        <div class="flow-rebuild__learning-body">
+          <svg viewBox="0 0 40 36" aria-hidden="true">
+            <circle cx="9" cy="11" r="3.2"/><circle cx="20" cy="7" r="3.2"/>
+            <circle cx="16" cy="19" r="3.2"/><circle cx="28" cy="15" r="3.2" opacity=".55"/>
+            <circle cx="11" cy="25" r="3.2" opacity=".55"/><circle cx="30" cy="26" r="3.2" opacity=".55"/>
+          </svg>
+          <p>Clusters of statements that inform the topic</p>
+        </div>
+      </div>
+    </article>
+
+    <span class="flow-rebuild__step-arrow" aria-hidden="true"></span>
+
+    <article class="flow-rebuild__card">
+      <h3>Map the arguments</h3>
+      <svg class="flow-rebuild__illustration" viewBox="0 0 190 120" aria-hidden="true">
+        <rect x="26" y="6" width="138" height="34" rx="8" class="flow-svg-surface"/>
+        <path d="M40 18h78M40 28h54" class="flow-svg-copy"/>
+        <rect x="30" y="52" width="118" height="24" rx="7" class="flow-svg-pro-box"/>
+        <path d="M40 64h10m-5-5v10" class="flow-svg-pro-mark"/>
+        <g transform="rotate(34 150 64)">
+          <rect x="120" y="59" width="30" height="9" rx="1.5" class="flow-svg-pencil"/>
+          <rect x="117" y="59" width="6" height="9" class="flow-svg-pencil-band"/>
+          <path d="m150 59 8 4.5-8 4.5Z" class="flow-svg-ink"/>
+        </g>
+        <rect x="30" y="84" width="118" height="24" rx="7" class="flow-svg-con-box"/>
+        <path d="M40 96h10" class="flow-svg-con-mark"/>
+        <g transform="rotate(34 150 96)">
+          <rect x="120" y="91" width="30" height="9" rx="1.5" class="flow-svg-pencil"/>
+          <rect x="117" y="91" width="6" height="9" class="flow-svg-pencil-band"/>
+          <path d="m150 91 8 4.5-8 4.5Z" class="flow-svg-ink"/>
+        </g>
+      </svg>
+      <p class="flow-rebuild__instruction">Write the pro &amp; con arguments that matter</p>
+      <div class="flow-rebuild__learning">
+        <p class="flow-rebuild__learning-label">What we learn</p>
+        <div class="flow-rebuild__learning-body">
+          <svg viewBox="0 0 40 36" aria-hidden="true">
+            <rect x="4" y="5" width="14" height="10" rx="2.5" class="flow-learn-pro"/>
+            <path d="M8 10h6m-3-3v6" class="flow-learn-pro-mark"/>
+            <rect x="22" y="6" width="14" height="8" rx="2.5" opacity=".12"/>
+            <rect x="4" y="20" width="14" height="10" rx="2.5" class="flow-learn-con"/>
+            <path d="M8 25h6" class="flow-learn-con-mark"/>
+            <rect x="22" y="21" width="14" height="8" rx="2.5" opacity=".08"/>
+          </svg>
+          <p>A map of the arguments that matter, pro &amp; con</p>
+        </div>
+      </div>
+    </article>
+
+    <span class="flow-rebuild__step-arrow" aria-hidden="true"></span>
+
+    <article class="flow-rebuild__card">
+      <h3>Express informed opinions</h3>
+      <svg class="flow-rebuild__illustration" viewBox="0 0 190 120" aria-hidden="true">
+        <rect x="26" y="4" width="138" height="30" rx="8" class="flow-svg-surface"/>
+        <path d="M40 14h78M40 24h54" class="flow-svg-copy"/>
+        <g transform="translate(34 44)">
+          <rect width="56" height="20" rx="6" class="flow-svg-agree-box"/>
+          <path d="M12 10h9m-4.5-4.5v9M30 10h18" class="flow-svg-agree-mark"/>
+        </g>
+        <g transform="translate(100 44)">
+          <rect width="56" height="20" rx="6" class="flow-svg-con-box"/>
+          <path d="M12 10h9m9 0h18" class="flow-svg-con-mark"/>
+        </g>
+        <g transform="translate(58 78)">
+          <rect width="30" height="30" rx="7" class="flow-svg-agree-box"/>
+          <path d="m9 15 4 4 8-9" class="flow-svg-agree-mark"/>
+        </g>
+        <g transform="translate(102 78)">
+          <rect width="30" height="30" rx="7" class="flow-svg-disagree-box"/>
+          <path d="m10 10 10 10m0-10L10 20" class="flow-svg-disagree-mark"/>
+        </g>
+      </svg>
+      <p class="flow-rebuild__instruction">Vote again, with the key arguments shown</p>
+      <div class="flow-rebuild__learning">
+        <p class="flow-rebuild__learning-label">What we learn</p>
+        <div class="flow-rebuild__learning-body">
+          <svg viewBox="0 0 40 36" aria-hidden="true">
+            <rect x="5" y="16" width="8" height="14" rx="2"/>
+            <rect x="16" y="8" width="8" height="22" rx="2"/>
+            <rect x="27" y="20" width="8" height="10" rx="2" opacity=".55"/>
+          </svg>
+          <p>How different parts of the community feel</p>
+        </div>
+      </div>
+    </article>
+  </div>
+
+  <svg class="flow-rebuild__merge" viewBox="0 0 1104 54" preserveAspectRatio="none" aria-hidden="true">
+    <path d="M174 0c0 26 378 18 378 36M552 0v36M930 0c0 26-378 18-378 36M552 36v14m-6-6 6 6 6-6"/>
+    <circle cx="552" cy="36" r="2.6"/>
+  </svg>
+
+  <div class="flow-rebuild__outcome">
+    <span class="flow-rebuild__outcome-icon" aria-hidden="true">
+      <svg viewBox="0 0 24 24">
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+        <path d="M14 2v6h6"/>
+        <path d="m9 14 2 2 4-4" class="flow-outcome-check"/>
+      </svg>
+    </span>
+    <strong>A more balanced policy draft</strong>
+  </div>
+  </div>
+</section>
+
+<script nonce="{{ csp_nonce }}">
+  (function () {
+    var section = document.querySelector('.flow-rebuild');
+    var button = document.getElementById('flow-rebuild-toggle');
+    var content = document.getElementById('flow-rebuild-content');
+    var label = button && button.querySelector('.flow-rebuild__toggle-label');
+    var key = 'proto-wiki.conversation-flow.collapsed.v1';
+    if (!section || !button || !content || !label) return;
+
+    function setCollapsed(collapsed) {
+      section.classList.toggle('flow-rebuild--collapsed', collapsed);
+      content.hidden = collapsed;
+      button.setAttribute('aria-expanded', String(!collapsed));
+      button.setAttribute('aria-label', (collapsed ? 'Show' : 'Hide') + ' conversation overview');
+      label.textContent = collapsed ? 'Show' : 'Hide';
+    }
+
+    var collapsed = false;
+    try { collapsed = localStorage.getItem(key) === 'collapsed'; } catch (e) {}
+    setCollapsed(collapsed);
+    button.hidden = false;
+    button.addEventListener('click', function () {
+      collapsed = !collapsed;
+      setCollapsed(collapsed);
+      try { localStorage.setItem(key, collapsed ? 'collapsed' : 'expanded'); } catch (e) {}
+    });
+  }());
+</script>

--- a/v2/templates/_conversation_flow.html
+++ b/v2/templates/_conversation_flow.html
@@ -138,8 +138,8 @@
   <div class="flow-rebuild__outcome">
     <span class="flow-rebuild__outcome-icon" aria-hidden="true">
       <svg viewBox="0 0 24 24">
-        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
-        <path d="M14 2v6h6"/>
+        <path d="M5 2h9l5 5v15H5z"/>
+        <path d="M14 2v5h5"/>
         <path d="m9 14 2 2 4-4" class="flow-outcome-check"/>
       </svg>
     </span>

--- a/v2/templates/_conversation_flow.html
+++ b/v2/templates/_conversation_flow.html
@@ -79,10 +79,10 @@
           <svg viewBox="0 0 40 36" aria-hidden="true">
             <rect x="4" y="5" width="14" height="10" rx="2.5" class="flow-learn-pro"/>
             <path d="M8 10h6m-3-3v6" class="flow-learn-pro-mark"/>
-            <rect x="22" y="6" width="14" height="8" rx="2.5" opacity=".12"/>
+            <path d="M25 7.5h13M25 12.5h8" class="flow-learn-copy"/>
             <rect x="4" y="20" width="14" height="10" rx="2.5" class="flow-learn-con"/>
             <path d="M8 25h6" class="flow-learn-con-mark"/>
-            <rect x="22" y="21" width="14" height="8" rx="2.5" opacity=".08"/>
+            <path d="M25 22.5h13M25 27.5h8" class="flow-learn-copy"/>
           </svg>
           <p>A map of the arguments that matter, pro &amp; con</p>
         </div>
@@ -96,19 +96,21 @@
       <svg class="flow-rebuild__illustration" viewBox="0 0 190 120" aria-hidden="true">
         <rect x="26" y="4" width="138" height="30" rx="8" class="flow-svg-surface"/>
         <path d="M40 14h78M40 24h54" class="flow-svg-copy"/>
-        <g transform="translate(34 44)">
-          <rect width="56" height="20" rx="6" class="flow-svg-agree-box"/>
-          <path d="M12 10h9m-4.5-4.5v9M30 10h18" class="flow-svg-agree-mark"/>
+        <g transform="translate(30 44)">
+          <rect width="60" height="24" rx="6" class="flow-svg-agree-box"/>
+          <path d="M11 12h9m-4.5-4.5v9" class="flow-svg-agree-mark"/>
+          <path d="M28 8.5h22M28 15.5h14" class="flow-svg-rowcopy"/>
         </g>
         <g transform="translate(100 44)">
-          <rect width="56" height="20" rx="6" class="flow-svg-con-box"/>
-          <path d="M12 10h9m9 0h18" class="flow-svg-con-mark"/>
+          <rect width="60" height="24" rx="6" class="flow-svg-con-box"/>
+          <path d="M11 12h9" class="flow-svg-con-mark"/>
+          <path d="M28 8.5h22M28 15.5h14" class="flow-svg-rowcopy"/>
         </g>
-        <g transform="translate(58 78)">
+        <g transform="translate(58 82)">
           <rect width="30" height="30" rx="7" class="flow-svg-agree-box"/>
           <path d="m9 15 4 4 8-9" class="flow-svg-agree-mark"/>
         </g>
-        <g transform="translate(102 78)">
+        <g transform="translate(102 82)">
           <rect width="30" height="30" rx="7" class="flow-svg-disagree-box"/>
           <path d="m10 10 10 10m0-10L10 20" class="flow-svg-disagree-mark"/>
         </g>

--- a/v2/templates/_conversation_flow.html
+++ b/v2/templates/_conversation_flow.html
@@ -106,11 +106,11 @@
           <path d="M11 12h9" class="flow-svg-con-mark"/>
           <path d="M28 8.5h22M28 15.5h14" class="flow-svg-rowcopy"/>
         </g>
-        <g transform="translate(58 82)">
+        <g transform="translate(58 78)">
           <rect width="30" height="30" rx="7" class="flow-svg-agree-box"/>
           <path d="m9 15 4 4 8-9" class="flow-svg-agree-mark"/>
         </g>
-        <g transform="translate(102 82)">
+        <g transform="translate(102 78)">
           <rect width="30" height="30" rx="7" class="flow-svg-disagree-box"/>
           <path d="m10 10 10 10m0-10L10 20" class="flow-svg-disagree-mark"/>
         </g>

--- a/v2/templates/base.html
+++ b/v2/templates/base.html
@@ -12,6 +12,38 @@
 {% set is_demo_view = header_mode == 'demo' or (header_mode == 'conversation' and conversation is defined and conversation.access_policy == 'demo') %}
 <body{% if is_demo_view %} data-demo="true"{% endif %}>
   <a class="skip-link" href="#main">Skip to main content</a>
+  <aside class="site-notice" id="site-notice" aria-label="Prototype notice"
+         data-storage-key="proto-wiki.site-notice.development.v1">
+    <div class="site-notice__inner">
+      <p>
+        Prototype in active development. Things may change.
+        <a href="https://github.com/lgelauff/wiki-polis/issues/new"
+           target="_blank" rel="noopener">Open an issue<span class="sr-only"> (opens in a new tab)</span></a> if you find a bug.
+      </p>
+      <button class="site-notice__dismiss" id="site-notice-dismiss" type="button"
+              aria-label="Dismiss site notice" hidden><span aria-hidden="true">×</span></button>
+    </div>
+  </aside>
+  <script nonce="{{ csp_nonce }}">
+  (function () {
+    var notice = document.getElementById('site-notice');
+    var dismiss = document.getElementById('site-notice-dismiss');
+    if (!notice || !dismiss) return;
+    var key = notice.getAttribute('data-storage-key');
+    try {
+      if (localStorage.getItem(key) === 'dismissed') {
+        notice.remove();
+        return;
+      }
+    } catch (e) {}
+    dismiss.hidden = false;
+    dismiss.addEventListener('click', function () {
+      try { localStorage.setItem(key, 'dismissed'); } catch (e) {}
+      notice.remove();
+    });
+  }());
+  </script>
+
   <header class="site-header {% if request.blueprint == 'admin' %}site-header--admin{% else %}site-header--participant{% endif %}">
     <div class="header-inner">
       <div class="header-left">

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -734,7 +734,7 @@
 
           {% if both_gate and not pro_vote_ready %}
           <div class="at-volnote" id="volnote-pro-{{ fs.id }}">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 9v4M12 17h.01"/><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/></svg>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3.5 22.5 20.5h-21z"/><path d="M12 10v4.5"/><circle cx="12" cy="17.8" r="1.05" fill="currentColor" stroke="none"/></svg>
             <span>Prioritising unlocks once there are more than {{ item.k }} for-arguments ({{ item.pro_args | length }} so far).</span>
           </div>
           {% endif %}
@@ -865,7 +865,7 @@
 
           {% if both_gate and not con_vote_ready %}
           <div class="at-volnote" id="volnote-con-{{ fs.id }}">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 9v4M12 17h.01"/><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/></svg>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3.5 22.5 20.5h-21z"/><path d="M12 10v4.5"/><circle cx="12" cy="17.8" r="1.05" fill="currentColor" stroke="none"/></svg>
             <span>Prioritising unlocks once there are more than {{ item.k }} against-arguments ({{ item.con_args | length }} so far).</span>
           </div>
           {% endif %}

--- a/v2/templates/fork.html
+++ b/v2/templates/fork.html
@@ -2,54 +2,49 @@
 {% block title %}ProtoWiki{% endblock %}
 {% block content %}
 
-<div class="container home-container">
+<div class="container home-container fork-page">
 
-  <div class="home-banner">
-    Prototype in active development — things may change.
-    <a href="https://github.com/lgelauff/wiki-polis/issues/new"
-       target="_blank" rel="noopener">Open an issue<span class="sr-only"> (opens in a new tab)</span></a> if you find a bug.
-  </div>
-
-  <div class="landing-section">
-    <h1 style="font-size:26px;font-weight:600;letter-spacing:-0.02em;line-height:1.15;margin-bottom:12px">Where the community actually stands.</h1>
-    <p style="font-size:15px;line-height:1.6;color:var(--body);max-width:520px">
-      Vote on short statements, and suggest improvements. Learn how your views
-      compare to other community members — which statements already have
-      consensus, and what topics are divisive, and why.
+  <div class="landing-section fork-intro">
+    <h1 class="fork-intro__title">Where the community actually stands.</h1>
+    <p class="fork-intro__copy">
+      ProtoWiki makes agreement, disagreement, and the reasons behind both
+      easier to see.<br>Choose the playground to try the platform at your own pace,
+      or join a real consultation where your contribution becomes part of the
+      community’s shared picture.
     </p>
   </div>
 
   <div class="fork-grid">
     <a href="{{ url_for('demo_lane') }}" class="fork-card fork-card--demo"
-       aria-label="Try out the platform — a demonstration conversation where you can try the full flow">
+       aria-label="Try the platform in a playground conversation">
       <svg class="fork-card-icon" width="24" height="24" viewBox="0 0 24 24" fill="none"
            stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <path d="M9 3h6M10 3v6l-5 8a2 2 0 0 0 1.7 3h10.6a2 2 0 0 0 1.7-3l-5-8V3"/>
       </svg>
-      <h2 class="fork-card-title">Try out the platform</h2>
-      <div class="fork-card-sub">Demonstration conversations — try the full flow.</div>
+      <h2 class="fork-card-title">Try the playground</h2>
+      <div class="fork-card-sub">Explore the full platform in a demonstration conversation.</div>
       <span class="fork-card-cta">Try it →</span>
     </a>
 
     <a href="{{ url_for('consultations') }}" class="fork-card fork-card--real"
-       aria-label="Participate in real consultations — your votes count">
+       aria-label="Participate in real consultations, where your contribution counts">
       <svg class="fork-card-icon" width="24" height="24" viewBox="0 0 24 24" fill="none"
            stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <circle cx="9" cy="8" r="3"/><path d="M3 20a6 6 0 0 1 12 0"/>
         <circle cx="17" cy="9" r="2.4"/><path d="M15.5 20a5.5 5.5 0 0 1 6.5-5.4"/>
       </svg>
       <h2 class="fork-card-title">Participate in real consultations</h2>
-      <div class="fork-card-sub">Your votes count.</div>
+      <div class="fork-card-sub">Join an active conversation. Your contribution counts.</div>
       <span class="fork-card-cta">Participate →</span>
     </a>
   </div>
 
   {% if dev_test_users %}
-  <div style="margin-top:1.25rem;padding:10px 14px;border:1px dashed var(--spot);border-radius:8px;background:rgba(245,158,11,0.05);display:flex;align-items:center;gap:10px;flex-wrap:wrap">
-    <span style="font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:0.08em;color:var(--spot)">Dev</span>
+  <div class="fork-dev-tools">
+    <span class="fork-dev-label">Dev</span>
     {% for u in dev_test_users %}
     <a href="{{ url_for('dev_fake_login', username=u.username) }}"
-       style="font-family:var(--mono);font-size:11px;padding:2px 8px;border-radius:4px;background:var(--surface2);border:1px solid var(--hairline);color:var(--ink);text-decoration:none"
+       class="fork-dev-login"
        title="Log in as {{ u.username }}">{{ u.username }}</a>
     {% endfor %}
   </div>

--- a/v2/templates/home.html
+++ b/v2/templates/home.html
@@ -133,12 +133,6 @@
 
 <div class="container home-container">
 
-  <div class="home-banner">
-    Prototype in active development — things may change.
-    <a href="https://github.com/lgelauff/wiki-polis/issues/new"
-       target="_blank" rel="noopener">Open an issue<span class="sr-only"> (opens in a new tab)</span></a> if you find a bug.
-  </div>
-
 {% if not username %}
 
   {# ── Unauthenticated landing (demo or real lane — same UI, tinted background) ── #}
@@ -205,9 +199,7 @@
   <h1 class="sr-only">Consultations</h1>
 
   {# ── Flow diagram ─────────────────────────────────────────────────────── #}
-  <img src="{{ url_for('static', filename='wiki-polis-flow.svg') }}"
-       alt="How a ProtoWiki conversation works"
-       style="width:100%;max-width:900px;display:block;margin:0 auto 1.5rem">
+  {% include '_conversation_flow.html' %}
 
   {# ── Phase journey legend ──────────────────────────────────────────────── #}
   <div class="phase-legend" role="img" aria-label="Consultation phases: Explore, Arguments, Informed vote, Report">

--- a/v2/tests/test_a11y_markup.py
+++ b/v2/tests/test_a11y_markup.py
@@ -48,6 +48,16 @@ def test_skip_link_and_main_landmark(client, conv):
     assert b'<main id="main" tabindex="-1">' in resp.data
 
 
+def test_site_notice_is_global_and_dismissible(client, conv):
+    """The development notice precedes site navigation and exposes a named control."""
+    resp = client.get('/')
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+    assert html.index('id="site-notice"') < html.index('<header class="site-header')
+    assert 'aria-label="Dismiss site notice"' in html
+    assert "localStorage.setItem(key, 'dismissed')" in html
+
+
 # ── Page headings (1.3.1 / 2.4.6) ──────────────────────────────────────────────
 
 def test_home_has_h1_logged_out(client, conv):
@@ -89,6 +99,16 @@ def test_anonymous_lane_uses_functional_consultations_heading(client, conv):
 def test_authenticated_lane_uses_same_functional_heading(auth_client, conv):
     authenticated = auth_client.get('/consultations').get_data(as_text=True)
     assert '<h1 class="sr-only">Consultations</h1>' in authenticated
+
+
+def test_authenticated_lane_exposes_editable_flow_as_semantic_content(auth_client, conv):
+    html = auth_client.get('/consultations').get_data(as_text=True)
+    assert '<section class="flow-rebuild" aria-labelledby="flow-rebuild-title">' in html
+    assert '<h2 id="flow-rebuild-title">How a ProtoWiki conversation works</h2>' in html
+    assert html.count('<article class="flow-rebuild__card">') == 3
+    assert 'aria-controls="flow-rebuild-content"' in html
+    assert "localStorage.setItem(key, collapsed ? 'collapsed' : 'expanded')" in html
+    assert 'wiki-polis-flow.svg' not in html
 
 
 # ── No hidden API-proxy controls (4.1.2 / #159) ───────────────────────────────

--- a/v2/tests/test_conversations.py
+++ b/v2/tests/test_conversations.py
@@ -39,7 +39,7 @@ def test_index_shows_fork_between_demo_and_real(client):
     # The homepage is the explicit demo/real fork (#293).
     resp = client.get('/')
     assert resp.status_code == 200
-    assert b'Try out the platform' in resp.data
+    assert b'Try the playground' in resp.data
     assert b'Participate in real consultations' in resp.data
 
 


### PR DESCRIPTION
## Summary

This PR gives the ProtoWiki entry and consultation-listing interfaces a focused visual-polish pass. The previous layouts constrained the main canvas, placed the development notice inside the site header, and represented the conversation flow as one large SVG that was difficult to maintain. The entry fork also did not clearly explain the choice between the playground and real consultations.

For users, the result is a wider but still bounded page, a lighter site notice above navigation, a clearer entry choice, and an editable explanation of how a ProtoWiki conversation works. The playground remains the left-hand choice with its contents aligned right, while real consultations remain on the right. The introductory copy is centered and unframed, and the three main fork sections no longer display border strokes.

## Implementation

- Widen the shared page canvas while preserving a maximum width on large displays.
- Move the development notice above the site header, reduce its visual weight, and persist dismissal in browser local storage.
- Replace the rendered monolithic conversation-flow image with semantic HTML, CSS, and small inline SVG illustrations in both React and Jinja.
- Keep the original SVG file in the repository as a reference asset without loading it at runtime.
- Add an accessible Hide/Show control for the conversation overview and persist the preference locally without server-side storage.
- Rename the overview to “How a ProtoWiki conversation works.”
- Rewrite and realign the entry fork so it clearly distinguishes the playground from real consultations.
- Preserve parity between the SPA and server-rendered fallback and extend regression coverage for both.

## Validation

- `npm test` — 72 passed
- `npm run build` — passed
- `.venv/bin/pytest tests/test_a11y_markup.py tests/test_conversations.py -q` — 67 passed
- `git diff --check` — passed

The Python test run reports the existing development-only warning about Flask-Limiter using in-memory storage.
