### PR TITLE
fix(phase6): store informed votes with the same sign as every other vote

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -2334,7 +2334,7 @@ def _informed_vote_api_payload(
         abort(404, description='Featured statement is not available in this round.')
     gateway, key = _phase6_gateway(conv, participant)
     try:
-        polis_values = {'agree': 1, 'pass': 0, 'disagree': -1}
+        polis_values = {'agree': -1, 'pass': 0, 'disagree': 1}
         gateway.vote(
             conv.phase6_polis_conversation_id,
             featured.phase6_polis_statement_id,

--- a/v2/frontend/src/features/legacy/informed-voting-panel.tsx
+++ b/v2/frontend/src/features/legacy/informed-voting-panel.tsx
@@ -112,6 +112,9 @@ export function LegacyInformedVotingPanel({workspace, csrfToken, onSelectPrelimi
         }, 400);
       }
     },
+    // Clear any previous failure before the new attempt, so a retry that succeeds
+    // does not leave the error badge standing.
+    onMutate: () => setNetworkErrorId(null),
     onError: (_error, variables) => setNetworkErrorId(variables.card.featuredStatementId),
   });
 
@@ -125,13 +128,19 @@ export function LegacyInformedVotingPanel({workspace, csrfToken, onSelectPrelimi
         <div tabIndex={-1} data-focus-anchor className="sr-only" />
         <div className="p6-card-header">
           <span className="stmt-meta-left"><span className="stmt-dot" />INFORMED VOTE · {index + 1} of {data.cards.length}</span>
-          <span className={`p6-voted-badge${selected ? ` p6-voted-badge--${selected}` : ''}`} role="alert" hidden={!selected && !error}>{selected ? <><span aria-hidden="true">✓</span> {selected === 'agree' ? 'Agreed' : selected === 'disagree' ? 'Disagreed' : 'Passed'}</> : 'Network error — try again'}</span>
+          {/* Error branch first. `selected` survives a failed re-vote, so testing it
+              first makes the error unreachable once a card has been voted — and a
+              rejected re-vote (a 409 on a paused round, which is the state the repair
+              runbook puts the tool in) would silently keep showing the old choice. */}
+          <span className={`p6-voted-badge${!error && selected ? ` p6-voted-badge--${selected}` : ''}`} role="alert" hidden={!selected && !error}>{error ? 'Vote not recorded — try again' : <><span aria-hidden="true">✓</span> {selected === 'agree' ? 'Agreed' : selected === 'disagree' ? 'Disagreed' : 'Passed'}</>}</span>
         </div>
         <div className="p6-card-inner">
           <div className="p6-statement-col">
             <p className="p6-statement-text">{card.statement}</p>
             {card.canVote && <div className="vote-choice-row p6-vote-row">
-              {voteValues.map((item) => <button type="button" className={`vote-choice btn-p6-vote${selected === item.choice ? ' p6-voted' : ''}`} data-vote={item.value} disabled={vote.isPending && vote.variables?.card.featuredStatementId === card.featuredStatementId} onClick={() => vote.mutate({card, choice: item.choice})} key={item.choice}><span className={`vote-dot vote-dot--${item.choice}`} />{item.label}</button>)}
+              {/* aria-pressed carries the recorded choice: without it the selection is
+                  conveyed only by opacity, which no assistive technology reports. */}
+              {voteValues.map((item) => <button type="button" className={`vote-choice btn-p6-vote${selected === item.choice ? ' p6-voted' : ''}`} data-vote={item.value} aria-pressed={selected === item.choice} disabled={vote.isPending && vote.variables?.card.featuredStatementId === card.featuredStatementId} onClick={() => vote.mutate({card, choice: item.choice})} key={item.choice}><span className={`vote-dot vote-dot--${item.choice}`} />{item.label}</button>)}
             </div>}
           </div>
           <div className="p6-args-panel">

--- a/v2/frontend/src/features/legacy/informed-voting-panel.tsx
+++ b/v2/frontend/src/features/legacy/informed-voting-panel.tsx
@@ -9,10 +9,13 @@ type Workspace = components['schemas']['ConversationWorkspace'];
 type Card = components['schemas']['InformedVotingCard'];
 type Choice = components['schemas']['InformedVoteRequest']['choice'];
 
+// `value` is only the rendered data-vote attribute — the wire payload is the
+// `choice` string, mapped server-side. It still follows the Polis convention
+// (-1 = agree) so the SPA and the legacy template emit identical DOM.
 const voteValues: Array<{choice: Choice; value: number; label: string}> = [
-  {choice: 'agree', value: 1, label: 'Agree'},
+  {choice: 'agree', value: -1, label: 'Agree'},
   {choice: 'pass', value: 0, label: 'Pass'},
-  {choice: 'disagree', value: -1, label: 'Disagree'},
+  {choice: 'disagree', value: 1, label: 'Disagree'},
 ];
 
 function ArgumentSide({side, items}: {

--- a/v2/ops/phase6-vote-sign-repair.md
+++ b/v2/ops/phase6-vote-sign-repair.md
@@ -1,0 +1,145 @@
+# Phase 6 vote-sign: verify, then repair
+
+Two parts. **Verification runs first and proves the bug on your own data** — repair nothing
+until step 2 shows the mismatch.
+
+Polis Postgres lives on the **Cloud VPS**. ToolsDB — which knows *which* Polis conversations
+are phase 6 — lives on the **Toolforge bastion**. You need both. All shell access is yours to
+initiate; nothing here should be run by an agent.
+
+---
+
+## 1. Bastion — which conversations have a phase 6?
+
+Log into the bastion and `become wiki-polis`, then `sql tools`:
+
+```sql
+USE `s57499__wiki-polis`; SELECT id, slug, polis_id AS phase2_zinvite, phase6_polis_conversation_id AS phase6_zinvite FROM conversations WHERE phase6_polis_conversation_id IS NOT NULL;
+```
+
+Note **both** zinvites per row. `polis_id` is the phase-2 conversation; `phase6_polis_conversation_id`
+is a separate Polis conversation. The pair is the whole point — the verification compares them.
+
+---
+
+## 2. Cloud VPS — prove the mismatch
+
+On the VPS, open psql in the postgres container. Substituting the zinvites from step 1:
+
+```sql
+SELECT 'phase2' AS phase, v.vote, count(*) FROM votes v WHERE v.zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE2_ZINVITE>') GROUP BY v.vote UNION ALL SELECT 'phase6', v.vote, count(*) FROM votes v WHERE v.zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') GROUP BY v.vote ORDER BY phase, vote;
+```
+
+This does **not** prove direction on its own — both phases legitimately hold a mix. It gives
+you the row counts the repair must match in step 5.
+
+### The decisive check: cast one vote whose intent you know
+
+1. Open the phase 6 round on https://wiki-polis.toolforge.org as yourself.
+2. Deliberately click **Agree** on one card; note the statement.
+3. Re-run, newest first:
+
+```sql
+SELECT v.pid, v.tid, v.vote, to_timestamp(v.created/1000) AS at FROM votes v WHERE v.zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') ORDER BY v.created DESC LIMIT 5;
+```
+
+**Your Agree should be `vote = -1`.** If it is `+1`, the bug is confirmed on production.
+Polis convention is `-1 = agree` — `v2/polis_admin.py:153` counts on it and `:211` states it.
+
+For contrast, cast an Agree in phase 2 of any open consultation and confirm `-1` there.
+Two Agrees, opposite signs, is the finding.
+
+*Reference — the same test on a local stack running `a32d61c` (production code):*
+
+| phase | action | row | stored |
+|---|---|---|---|
+| 2 | Agree | `zid=5, pid=76, tid=10` | **−1** |
+| 6 | Agree, unfixed | `zid=6, pid=31, tid=3` | **+1** |
+| 6 | Agree, fixed | `zid=6, pid=32, tid=4` | **−1** |
+
+---
+
+## 3. Deploy the code fix BEFORE repairing
+
+Repair first and new inverted votes keep arriving into repaired data, with nothing marking
+which rows are which. Deploy `fix/phase6-vote-sign`, confirm with a fresh Agree that new votes
+store `-1`, and only then touch the old ones.
+
+---
+
+## 4. Snapshot before you overwrite
+
+**Test votes are evidence.** They are the only record of what the buggy path actually wrote,
+and they may matter later in ways that are not obvious now — reconstructing whether a result
+shown to someone was affected, validating the repair itself, or as a fixture for a regression
+test against real data rather than mocks. `UPDATE ... SET vote = -vote` destroys that record.
+
+Copy the affected rows first. A plain table in the same database, so it travels with any dump:
+
+```sql
+CREATE TABLE IF NOT EXISTS votes_phase6_presign_backup (LIKE votes INCLUDING ALL);
+```
+
+```sql
+INSERT INTO votes_phase6_presign_backup SELECT * FROM votes WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>');
+```
+
+Confirm the copy matches before going further:
+
+```sql
+SELECT (SELECT count(*) FROM votes_phase6_presign_backup) AS backed_up, (SELECT count(*) FROM votes WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>')) AS live;
+```
+
+The two numbers must be equal. This also gives you a genuine rollback: the pre-repair state is
+recoverable even after `COMMIT`, which the transaction alone does not give you.
+
+---
+
+## 5. Repair — one statement, scoped, counted
+
+⚠️ **Not idempotent.** Running it twice returns the data to broken. Record step 2's counts,
+run once, verify, do not re-run.
+
+```sql
+BEGIN;
+```
+
+```sql
+UPDATE votes SET vote = -vote WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0;
+```
+
+The reported row count **must equal the non-zero total from step 2**. Passes (`vote = 0`) are
+excluded deliberately — negating zero is a no-op that would pad the count and mask a mistake.
+
+Verify before committing; the distribution should mirror, `-1` and `+1` swapped, `0` unchanged:
+
+```sql
+SELECT vote, count(*) FROM votes WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') GROUP BY vote ORDER BY vote;
+```
+
+Then `COMMIT;` — or `ROLLBACK;` if anything is off.
+
+Repeat **one conversation at a time**, verifying each. A wrong row count is recoverable when
+it is the only conversation in the transaction.
+
+---
+
+## 6. Confirm end to end
+
+Re-run the step-2 vote test: a fresh Agree stores `-1`, and previously-cast votes now read the
+direction the participant intended. Spot-check one participant whose intent you know against
+the phase 6 results view.
+
+Keep `votes_phase6_presign_backup`. It is small, and it is the only copy of what the bug wrote.
+
+---
+
+## Why not #285's script
+
+`v2/ops/migrate_phase6_vote_signs.py` (208 lines) does this with discovery, dry-run and a
+run-log. Good work, but its idempotency guard is a **local JSON file** — its own docstring says
+*"Keep that log; do not run on a second machine."* With a handful of phase-6 rows on
+production, a counted `UPDATE` in a transaction is smaller, holds no hidden state, and is
+verified by numbers in front of you rather than by a file that can go missing.
+
+Keep the script for the day a real consultation finishes phase 6 with the bug present. Not today.

--- a/v2/ops/phase6-vote-sign-repair.md
+++ b/v2/ops/phase6-vote-sign-repair.md
@@ -85,6 +85,12 @@ test against real data rather than mocks. `UPDATE ... SET vote = -vote` destroys
 
 ⚠️ **This is the part that makes or breaks the repair.**
 
+> **Rehearsed 2026-08-25** on a local Polis stack, in a transaction rolled back afterwards.
+> Repairing `votes` alone reported `UPDATE 6` and mirrored all six rows — while
+> `votes_latest_unique` came back **byte-for-byte unchanged**. Repairing both, as below,
+> produced identical mirrored data in each. The single-table version fails silently and
+> reports success; this is not a theoretical concern.
+
 - `votes(zid, pid, tid, vote, created)` — append-only history. Has `created`, **no `modified`**.
 - `votes_latest_unique(zid, pid, tid, vote, modified)` — **the authoritative current vote**, and
   **what every phase-6 read path actually queries** (`polis_admin.py:156, 182, 220, 232, 265,

--- a/v2/ops/phase6-vote-sign-repair.md
+++ b/v2/ops/phase6-vote-sign-repair.md
@@ -1,107 +1,108 @@
 # Phase 6 vote-sign: verify, then repair
 
-Two parts. **Verification runs first and proves the bug on your own data** — repair nothing
-until step 2 shows the mismatch.
+Phase 6 informed votes were written to Polis with the **opposite sign** to every other vote — an
+Agree stored as a disagree. This covers verifying that on your own data, then repairing it.
 
-Polis Postgres lives on the **Cloud VPS**. ToolsDB — which knows *which* Polis conversations
-are phase 6 — lives on the **Toolforge bastion**. You need both. All shell access is yours to
-initiate; nothing here should be run by an agent.
+**The frontend comes down for the whole operation.** That is what makes this simple: with nothing
+able to write, every stored phase-6 vote is uniformly inverted, so the repair is one plain
+statement per table with no time boundary to reason about, and no window in which participants
+see a mix of both conventions.
+
+Two databases, two hosts. Polis Postgres lives on the **Cloud VPS**; ToolsDB, which knows *which*
+Polis conversations are phase 6, lives on the **Toolforge bastion**. All shell access is yours to
+initiate.
 
 ---
 
 ## 1. Bastion — which conversations have a phase 6?
 
-Log into the bastion and `become wiki-polis`, then `sql tools`:
+Log in, `become wiki-polis`, then `sql tools`:
 
 ```sql
 USE `s57499__wiki-polis`; SELECT id, slug, polis_id AS phase2_zinvite, phase6_polis_conversation_id AS phase6_zinvite FROM conversations WHERE phase6_polis_conversation_id IS NOT NULL;
 ```
 
 Note **both** zinvites per row. `polis_id` is the phase-2 conversation; `phase6_polis_conversation_id`
-is a separate Polis conversation. The pair is the whole point — the verification compares them.
+is a separate Polis conversation. Every phase-6 zinvite in this list needs repairing.
 
 ---
 
-## 2. Cloud VPS — prove the mismatch
+## 2. Cloud VPS — prove the bug on your own data
 
-⚠️ **Pin the container name.** Production and staging Polis run side by side on that host —
-`particiapp-docker_postgres_1` (port 5432, production) and `wiki-polis-staging_postgres_1`
-(port 5442). A grepped name matches both and will silently pick one, or fail confusingly by
-passing the second name as a command. Confirm which you are on before any write: query
-`zinvites` for the phase-6 zinvite in the container you intend to use — a `zid` back means
-production, empty means staging.
-
-On the VPS, open psql in that pinned container. Substituting the zinvites from step 1:
-
-```sql
-SELECT 'phase2' AS phase, v.vote, count(*) FROM votes v WHERE v.zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE2_ZINVITE>') GROUP BY v.vote UNION ALL SELECT 'phase6', v.vote, count(*) FROM votes v WHERE v.zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') GROUP BY v.vote ORDER BY phase, vote;
-```
-
-This does **not** prove direction on its own — both phases legitimately hold a mix. It gives
-you the row counts the repair must match in step 5.
+⚠️ **Pin the container name.** Production and staging Polis run side by side on that host:
+`particiapp-docker_postgres_1` (port 5432, **production**) and `wiki-polis-staging_postgres_1`
+(port 5442). A grepped name matches both. Confirm which you are on before any write — query
+`zinvites` for your phase-6 zinvite; a `zid` back means production, empty means staging.
 
 ### The decisive check: cast one vote whose intent you know
 
-1. Open the phase 6 round on https://wiki-polis.toolforge.org as yourself.
-2. Deliberately click **Agree** on one card; note the statement.
-3. Re-run, newest first:
+1. Open the phase 6 round as yourself and deliberately click **Agree** on one card.
+2. Read it back, newest first:
 
 ```sql
-SELECT v.pid, v.tid, v.vote, to_timestamp(v.created/1000) AS at FROM votes v WHERE v.zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') ORDER BY v.created DESC LIMIT 5;
+SELECT pid, tid, vote, to_timestamp(created/1000) AS at FROM votes WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') ORDER BY created DESC LIMIT 5;
 ```
 
-**Your Agree should be `vote = -1`.** If it is `+1`, the bug is confirmed on production.
-Polis convention is `-1 = agree` — `v2/polis_admin.py:153` counts on it and `:211` states it.
+**Your Agree should be `vote = -1`.** If it is `+1`, the bug is confirmed. Polis convention is
+`-1 = agree` — `polis_admin.py:153` counts on it and `:211` states it.
 
-For contrast, cast an Agree in phase 2 of any open consultation and confirm `-1` there.
-Two Agrees, opposite signs, is the finding.
+*Reference — the same test on a local stack running production's commit:*
 
-*Reference — the same test on a local stack running `a32d61c` (production code):*
-
-| phase | action | row | stored |
-|---|---|---|---|
-| 2 | Agree | `zid=5, pid=76, tid=10` | **−1** |
-| 6 | Agree, unfixed | `zid=6, pid=31, tid=3` | **+1** |
-| 6 | Agree, fixed | `zid=6, pid=32, tid=4` | **−1** |
+| phase | action | stored |
+|---|---|---|
+| 2 | Agree | **−1** |
+| 6 | Agree, before fix | **+1** |
+| 6 | Agree, after fix | **−1** |
 
 ---
 
-## 3. Deploy the code fix BEFORE repairing
+## 3. Stop the frontend
 
-Repair first and new inverted votes keep arriving into repaired data, with nothing marking
-which rows are which. Deploy `fix/phase6-vote-sign`, confirm with a fresh Agree that new votes
-store `-1`, and only then touch the old ones.
+```bash
+cd ~ && toolforge webservice stop
+```
+
+Confirm it is actually down before going further — a repair that races live voting is the one
+thing this procedure exists to avoid:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' https://wiki-polis.toolforge.org/
+```
+
+Anything other than a normal page (503, connection refused) is what you want. Then confirm no
+votes are still arriving — run this twice, a minute apart, and the count must not move:
+
+```sql
+SELECT count(*) FROM votes WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>');
+```
+
+Everything from here happens with the tool offline.
 
 ---
 
-## 4. Snapshot before you overwrite
+## 4. Snapshot both tables
 
-**Test votes are evidence.** They are the only record of what the buggy path actually wrote,
-and they may matter later in ways that are not obvious now — reconstructing whether a result
-shown to someone was affected, validating the repair itself, or as a fixture for a regression
-test against real data rather than mocks. `UPDATE ... SET vote = -vote` destroys that record.
+**These votes are evidence.** They are the only record of what the buggy path wrote, and may
+matter later — reconstructing whether a result shown to someone was affected, validating the
+repair, or as a fixture for a regression test against real data. Negating them destroys that.
 
 ### Two tables, not one
 
 ⚠️ **This is the part that makes or breaks the repair.**
 
-> **Rehearsed 2026-08-25** on a local Polis stack, in a transaction rolled back afterwards.
-> Repairing `votes` alone reported `UPDATE 6` and mirrored all six rows — while
-> `votes_latest_unique` came back **byte-for-byte unchanged**. Repairing both, as below,
-> produced identical mirrored data in each. The single-table version fails silently and
-> reports success; this is not a theoretical concern.
-
 - `votes(zid, pid, tid, vote, created)` — append-only history. Has `created`, **no `modified`**.
 - `votes_latest_unique(zid, pid, tid, vote, modified)` — **the authoritative current vote**, and
-  **what every phase-6 read path actually queries** (`polis_admin.py:156, 182, 220, 232, 265,
-  305, 327`). Has `modified`, **no `created`**.
+  **what every phase-6 read path queries** (`polis_admin.py:156, 182, 220, 232, 265, 305, 327`).
+  Has `modified`, **no `created`**.
 
 `votes_latest_unique` is maintained by an **INSERT rule** on `votes` (`ref_polis-data-model.md:93`,
-`guide_runbook.md:154-157`). An `UPDATE` fires no INSERT rule, so **updating `votes` alone changes
-nothing that anyone sees** — and leaves the two tables permanently disagreeing with no marker.
-Repairing only `votes` is worse than not repairing at all.
+`guide_runbook.md:154-157`). A row rewrite fires no INSERT rule, so **repairing `votes` alone
+changes nothing that anyone sees.**
 
-Both tables must be snapshotted and both must be updated, in one transaction.
+> **Rehearsed 2026-08-25** on a local Polis stack, in a rolled-back transaction. Repairing
+> `votes` alone reported `UPDATE 6` and mirrored all six rows — while `votes_latest_unique`
+> came back **byte-for-byte unchanged**. Repairing both produced identical mirrored data in
+> each. The single-table version fails silently *and reports success*.
 
 ```sql
 CREATE TABLE IF NOT EXISTS votes_phase6_presign_backup (LIKE votes INCLUDING ALL);
@@ -115,97 +116,98 @@ INSERT INTO votes_phase6_presign_backup SELECT v.* FROM votes v WHERE v.zid = (S
 INSERT INTO vlu_phase6_presign_backup SELECT u.* FROM votes_latest_unique u WHERE u.zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND NOT EXISTS (SELECT 1 FROM vlu_phase6_presign_backup b WHERE b.zid = u.zid);
 ```
 
-Confirm the copies match — **scoped to this conversation on both sides.** The backup tables
-accumulate across conversations by design, so an unscoped count compares A+B against B and
-reports a false failure on the second conversation:
+Confirm both copies — **scoped to this conversation on both sides.** The backup tables accumulate
+across conversations by design, so an unscoped count compares A+B against B and fails falsely on
+the second conversation:
 
 ```sql
 SELECT (SELECT count(*) FROM votes_phase6_presign_backup WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>')) AS votes_backed_up, (SELECT count(*) FROM votes WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>')) AS votes_live, (SELECT count(*) FROM vlu_phase6_presign_backup WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>')) AS vlu_backed_up, (SELECT count(*) FROM votes_latest_unique WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>')) AS vlu_live;
 ```
 
-Each pair must match. This is also your genuine rollback: the pre-repair state survives even
-after `COMMIT`, which the transaction alone does not give you.
+Each pair must match. This is also your real rollback: the pre-repair state survives even after
+`COMMIT`, which the transaction alone does not give you.
 
 ---
 
-## 5. Repair — one statement, scoped, counted
+## 5. Repair — both tables, one transaction, counted
 
-⚠️ **Not idempotent.** Running it twice returns the data to broken. Record step 2's counts,
-run once, verify, do not re-run.
+⚠️ **Not idempotent.** Running it twice returns the data to broken. Run once, verify, do not
+re-run. The `NOT EXISTS` guard protects the *backup*, not this.
+
+Because the frontend is down, every stored phase-6 vote is uniformly inverted — no time bound is
+needed, and none should be added. Count what you expect to touch first; the two numbers will
+normally **differ**, since `votes` keeps every re-vote while `votes_latest_unique` holds one row
+per (pid, tid):
+
+```sql
+SELECT (SELECT count(*) FROM votes WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0) AS votes_expected, (SELECT count(*) FROM votes_latest_unique WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0) AS vlu_expected;
+```
 
 ```sql
 BEGIN;
 ```
 
-⚠️ **The time bound is not optional.** Step 3 deploys the fix first, so every vote cast after
-that moment is *already correct*. An unbounded `UPDATE` would negate those too and make them
-wrong — reintroducing the very bug this repair removes, in rows that were fine. Bound the
-statement to votes written **before the deploy**.
-
-Get the cutoff as epoch milliseconds (`votes.created` is bigint millis). Use the moment the
-webservice restarted onto the fix, not the moment you started reading this:
-
 ```sql
-SELECT extract(epoch FROM TIMESTAMPTZ '2026-08-25 16:40:00+00') * 1000 AS cutoff_millis;
+UPDATE votes SET vote = -vote WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0;
+UPDATE votes_latest_unique SET vote = -vote WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0;
 ```
 
-Then **both** statements, with that number substituted. Note the different time columns —
-`votes` has `created`, `votes_latest_unique` has `modified`; swapping them errors:
+Each must report exactly its own expected number. Passes (`vote = 0`) are excluded deliberately —
+negating zero is a no-op that would pad the counts and mask a mistake.
 
-```sql
-UPDATE votes SET vote = -vote WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0 AND created < <CUTOFF_MILLIS>;
-UPDATE votes_latest_unique SET vote = -vote WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0 AND modified < <CUTOFF_MILLIS>;
-```
-
-Bounding the second on `modified` is also semantically right, not just a column-name
-accommodation: a participant who voted before the deploy and re-voted after it has an inverted
-*history* row in `votes` but an already-correct *current* row in `votes_latest_unique`. The
-`modified` bound leaves that current row alone, which is what you want.
-
-If you are unsure of the exact deploy moment, prefer a cutoff slightly **earlier** than the
-restart. Missing a few genuinely-inverted rows leaves them wrong and correctable later; catching
-correct rows makes them wrong with nothing to distinguish them afterwards.
-
-**Better: pause the consultation for the whole window.** Pause it (admin → Pause) *before* the
-deploy in step 3, repair, then resume. `app.py:6497` rejects phase-6 votes while paused, so no
-votes are cast in between: the cutoff question disappears, and — more importantly — participants
-never see the blended-sign results described in step 3.
-
-Check each `UPDATE`'s row count against its own bounded set. Count both first:
-
-```sql
-SELECT (SELECT count(*) FROM votes WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0 AND created < <CUTOFF_MILLIS>) AS votes_expected, (SELECT count(*) FROM votes_latest_unique WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0 AND modified < <CUTOFF_MILLIS>) AS vlu_expected;
-```
-
-Each `UPDATE` must report exactly its own number. They will normally **differ** — `votes` holds
-every re-vote as a separate row while `votes_latest_unique` holds one per (pid, tid) — so a
-mismatch between the two is expected and is not an error. Passes (`vote = 0`) are excluded
-deliberately: negating zero is a no-op that would pad the counts and mask a mistake.
-
-Verify before committing. Both distributions should mirror — `-1` and `+1` swapped, `0`
-unchanged — and this query reads **both** tables so a divergence is visible *before* you commit:
+Verify before committing. Both distributions should mirror (`-1` and `+1` swapped, `0`
+unchanged), and this reads **both** tables so a divergence is visible *before* you commit:
 
 ```sql
 SELECT 'votes' AS t, vote, count(*) FROM votes WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') GROUP BY vote UNION ALL SELECT 'votes_latest_unique', vote, count(*) FROM votes_latest_unique WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') GROUP BY vote ORDER BY t, vote;
 ```
 
-⚠️ Verifying against `votes` alone is the trap this runbook previously walked into: it would
-show a perfectly mirrored distribution while every participant-facing number stayed inverted.
+⚠️ Verifying against `votes` alone is the trap this runbook previously walked into: it shows a
+perfectly mirrored distribution while every participant-facing number stays inverted.
 
 Then `COMMIT;` — or `ROLLBACK;` if anything is off.
 
-Repeat **one conversation at a time**, verifying each. A wrong row count is recoverable when
-it is the only conversation in the transaction.
+Repeat **one conversation at a time** through steps 4 and 5, verifying each. A wrong row count is
+recoverable when it is the only conversation in the transaction.
 
 ---
 
-## 6. Confirm end to end
+## 6. Deploy the fix, which brings the tool back up
 
-Re-run the step-2 vote test: a fresh Agree stores `-1`, and previously-cast votes now read the
-direction the participant intended. Spot-check one participant whose intent you know against
-the phase 6 results view.
+Only now, with every conversation repaired:
 
-Keep `votes_phase6_presign_backup`. It is small, and it is the only copy of what the bug wrote.
+```bash
+bash ~/wiki-polis/deploy.sh main
+```
+
+`deploy.sh` ends with `toolforge webservice restart`, so this returns the tool to service. It is
+`set -euo pipefail`, so a failed frontend build exits **before** the restart and leaves the tool
+down — which is the safe outcome. Do not start the webservice by hand to "fix" that: repaired
+data plus unfixed code means new votes arrive inverted into corrected rows, and you are back to a
+blend nobody can untangle.
+
+If the deploy fails, leave it down, fix the deploy, and try again.
+
+---
+
+## 7. Confirm end to end
+
+```bash
+curl -s https://wiki-polis.toolforge.org/ | grep -oE '<code>[0-9a-f]{7,40}</code>'
+```
+
+The stamp must be the commit carrying the fix. Then cast one deliberate **Agree** in a phase 6
+round and read it back:
+
+```sql
+SELECT pid, tid, vote, to_timestamp(created/1000) AS at FROM votes WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') ORDER BY created DESC LIMIT 3;
+```
+
+`vote = -1` means new votes are correct. Spot-check one participant whose intent you know against
+the phase 6 results view to confirm the repaired rows read the right way round.
+
+Keep `votes_phase6_presign_backup` and `vlu_phase6_presign_backup`. They are small, and they are
+the only copy of what the bug wrote.
 
 ---
 
@@ -213,8 +215,7 @@ Keep `votes_phase6_presign_backup`. It is small, and it is the only copy of what
 
 `v2/ops/migrate_phase6_vote_signs.py` (208 lines) does this with discovery, dry-run and a
 run-log. Good work, but its idempotency guard is a **local JSON file** — its own docstring says
-*"Keep that log; do not run on a second machine."* With a handful of phase-6 rows on
-production, a counted `UPDATE` in a transaction is smaller, holds no hidden state, and is
-verified by numbers in front of you rather than by a file that can go missing.
-
-Keep the script for the day a real consultation finishes phase 6 with the bug present. Not today.
+*"Keep that log; do not run on a second machine."* It also only ever touched `votes`, so it would
+have hit the same silent-no-op described in step 4. With a handful of phase-6 rows and the tool
+offline, a counted statement pair in a transaction is smaller, holds no hidden state, and is
+verified by numbers in front of you.

--- a/v2/ops/phase6-vote-sign-repair.md
+++ b/v2/ops/phase6-vote-sign-repair.md
@@ -81,24 +81,44 @@ and they may matter later in ways that are not obvious now — reconstructing wh
 shown to someone was affected, validating the repair itself, or as a fixture for a regression
 test against real data rather than mocks. `UPDATE ... SET vote = -vote` destroys that record.
 
-Copy the affected rows first. A plain table in the same database, so it travels with any dump:
+### Two tables, not one
+
+⚠️ **This is the part that makes or breaks the repair.**
+
+- `votes(zid, pid, tid, vote, created)` — append-only history. Has `created`, **no `modified`**.
+- `votes_latest_unique(zid, pid, tid, vote, modified)` — **the authoritative current vote**, and
+  **what every phase-6 read path actually queries** (`polis_admin.py:156, 182, 220, 232, 265,
+  305, 327`). Has `modified`, **no `created`**.
+
+`votes_latest_unique` is maintained by an **INSERT rule** on `votes` (`ref_polis-data-model.md:93`,
+`guide_runbook.md:154-157`). An `UPDATE` fires no INSERT rule, so **updating `votes` alone changes
+nothing that anyone sees** — and leaves the two tables permanently disagreeing with no marker.
+Repairing only `votes` is worse than not repairing at all.
+
+Both tables must be snapshotted and both must be updated, in one transaction.
 
 ```sql
 CREATE TABLE IF NOT EXISTS votes_phase6_presign_backup (LIKE votes INCLUDING ALL);
+CREATE TABLE IF NOT EXISTS vlu_phase6_presign_backup (LIKE votes_latest_unique INCLUDING ALL);
 ```
+
+Copy this conversation's rows, guarded so a re-run cannot double-insert:
 
 ```sql
-INSERT INTO votes_phase6_presign_backup SELECT * FROM votes WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>');
+INSERT INTO votes_phase6_presign_backup SELECT v.* FROM votes v WHERE v.zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND NOT EXISTS (SELECT 1 FROM votes_phase6_presign_backup b WHERE b.zid = v.zid);
+INSERT INTO vlu_phase6_presign_backup SELECT u.* FROM votes_latest_unique u WHERE u.zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND NOT EXISTS (SELECT 1 FROM vlu_phase6_presign_backup b WHERE b.zid = u.zid);
 ```
 
-Confirm the copy matches before going further:
+Confirm the copies match — **scoped to this conversation on both sides.** The backup tables
+accumulate across conversations by design, so an unscoped count compares A+B against B and
+reports a false failure on the second conversation:
 
 ```sql
-SELECT (SELECT count(*) FROM votes_phase6_presign_backup) AS backed_up, (SELECT count(*) FROM votes WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>')) AS live;
+SELECT (SELECT count(*) FROM votes_phase6_presign_backup WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>')) AS votes_backed_up, (SELECT count(*) FROM votes WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>')) AS votes_live, (SELECT count(*) FROM vlu_phase6_presign_backup WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>')) AS vlu_backed_up, (SELECT count(*) FROM votes_latest_unique WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>')) AS vlu_live;
 ```
 
-The two numbers must be equal. This also gives you a genuine rollback: the pre-repair state is
-recoverable even after `COMMIT`, which the transaction alone does not give you.
+Each pair must match. This is also your genuine rollback: the pre-repair state survives even
+after `COMMIT`, which the transaction alone does not give you.
 
 ---
 
@@ -123,34 +143,48 @@ webservice restarted onto the fix, not the moment you started reading this:
 SELECT extract(epoch FROM TIMESTAMPTZ '2026-08-25 16:40:00+00') * 1000 AS cutoff_millis;
 ```
 
-Then, with that number substituted:
+Then **both** statements, with that number substituted. Note the different time columns —
+`votes` has `created`, `votes_latest_unique` has `modified`; swapping them errors:
 
 ```sql
 UPDATE votes SET vote = -vote WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0 AND created < <CUTOFF_MILLIS>;
+UPDATE votes_latest_unique SET vote = -vote WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0 AND modified < <CUTOFF_MILLIS>;
 ```
+
+Bounding the second on `modified` is also semantically right, not just a column-name
+accommodation: a participant who voted before the deploy and re-voted after it has an inverted
+*history* row in `votes` but an already-correct *current* row in `votes_latest_unique`. The
+`modified` bound leaves that current row alone, which is what you want.
 
 If you are unsure of the exact deploy moment, prefer a cutoff slightly **earlier** than the
 restart. Missing a few genuinely-inverted rows leaves them wrong and correctable later; catching
 correct rows makes them wrong with nothing to distinguish them afterwards.
 
-Safest of all: pause the consultation (admin → Pause) for the deploy-and-repair window, so no
-votes are cast in between and the boundary question does not arise.
+**Better: pause the consultation for the whole window.** Pause it (admin → Pause) *before* the
+deploy in step 3, repair, then resume. `app.py:6497` rejects phase-6 votes while paused, so no
+votes are cast in between: the cutoff question disappears, and — more importantly — participants
+never see the blended-sign results described in step 3.
 
-Check the reported row count against the **bounded** set, not step 2's overall total — step 2
-was taken before the cutoff existed. Count what you expect to touch first:
-
-```sql
-SELECT count(*) FROM votes WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0 AND created < <CUTOFF_MILLIS>;
-```
-
-The `UPDATE` must report exactly that number. Passes (`vote = 0`) are
-excluded deliberately — negating zero is a no-op that would pad the count and mask a mistake.
-
-Verify before committing; the distribution should mirror, `-1` and `+1` swapped, `0` unchanged:
+Check each `UPDATE`'s row count against its own bounded set. Count both first:
 
 ```sql
-SELECT vote, count(*) FROM votes WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') GROUP BY vote ORDER BY vote;
+SELECT (SELECT count(*) FROM votes WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0 AND created < <CUTOFF_MILLIS>) AS votes_expected, (SELECT count(*) FROM votes_latest_unique WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0 AND modified < <CUTOFF_MILLIS>) AS vlu_expected;
 ```
+
+Each `UPDATE` must report exactly its own number. They will normally **differ** — `votes` holds
+every re-vote as a separate row while `votes_latest_unique` holds one per (pid, tid) — so a
+mismatch between the two is expected and is not an error. Passes (`vote = 0`) are excluded
+deliberately: negating zero is a no-op that would pad the counts and mask a mistake.
+
+Verify before committing. Both distributions should mirror — `-1` and `+1` swapped, `0`
+unchanged — and this query reads **both** tables so a divergence is visible *before* you commit:
+
+```sql
+SELECT 'votes' AS t, vote, count(*) FROM votes WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') GROUP BY vote UNION ALL SELECT 'votes_latest_unique', vote, count(*) FROM votes_latest_unique WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') GROUP BY vote ORDER BY t, vote;
+```
+
+⚠️ Verifying against `votes` alone is the trap this runbook previously walked into: it would
+show a perfectly mirrored distribution while every participant-facing number stayed inverted.
 
 Then `COMMIT;` — or `ROLLBACK;` if anything is off.
 

--- a/v2/ops/phase6-vote-sign-repair.md
+++ b/v2/ops/phase6-vote-sign-repair.md
@@ -34,7 +34,24 @@ is a separate Polis conversation. Every phase-6 zinvite in this list needs repai
 (port 5442). A grepped name matches both. Confirm which you are on before any write — query
 `zinvites` for your phase-6 zinvite; a `zid` back means production, empty means staging.
 
+Every SQL block below runs inside that container:
+
+```bash
+docker exec -it particiapp-docker_postgres_1 psql -U polis -d polis   # production
+docker exec -it wiki-polis-staging_postgres_1 psql -U polis -d polis  # staging
+```
+
 ### The decisive check: cast one vote whose intent you know
+
+> ⚠️ **The round must not be paused, and the consultation must be active.** Both write
+> paths refuse otherwise — the API returns `409 Informed voting is not open.`, the legacy
+> route `403` — and a paused round is the state this runbook otherwise wants the tool in.
+> Record `active` and `paused` in step 1, unpause for this check and for step 7, and
+> restore the recorded state afterwards.
+>
+> This deliberately writes one genuinely inverted row, so do it **before** the repair,
+> never after. A vote cast between the repair and the deploy breaks step 5's uniformity
+> premise and leaves both conventions in one table.
 
 1. Open the phase 6 round as yourself and deliberately click **Agree** on one card.
 2. Read it back, newest first:
@@ -131,6 +148,11 @@ Each pair must match. This is also your real rollback: the pre-repair state surv
 
 ## 5. Repair — both tables, one transaction, counted
 
+> **Production was repaired on 2026-09-02.** Running this again on the same conversation
+> re-inverts it. The negation is an involution over this predicate — odd runs leave the
+> data repaired, even runs leave it broken — so if you are unsure whether it has already
+> run, do **not** re-run "to be safe". Check first with the known-intent vote from step 2.
+
 ⚠️ **Not idempotent.** Running it twice returns the data to broken. Run once, verify, do not
 re-run. The `NOT EXISTS` guard protects the *backup*, not this.
 
@@ -140,7 +162,7 @@ normally **differ**, since `votes` keeps every re-vote while `votes_latest_uniqu
 per (pid, tid):
 
 ```sql
-SELECT (SELECT count(*) FROM votes WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0) AS votes_expected, (SELECT count(*) FROM votes_latest_unique WHERE zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0) AS vlu_expected;
+SELECT (SELECT count(*) FROM votes v WHERE v.zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND v.vote <> 0 AND NOT EXISTS (SELECT 1 FROM comments c WHERE c.zid = v.zid AND c.tid = v.tid AND c.pid = v.pid)) AS votes_expected, (SELECT count(*) FROM votes_latest_unique v WHERE v.zid=(SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND v.vote <> 0 AND NOT EXISTS (SELECT 1 FROM comments c WHERE c.zid = v.zid AND c.tid = v.tid AND c.pid = v.pid)) AS vlu_expected;
 ```
 
 ```sql
@@ -148,12 +170,20 @@ BEGIN;
 ```
 
 ```sql
-UPDATE votes SET vote = -vote WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0;
-UPDATE votes_latest_unique SET vote = -vote WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0;
+UPDATE votes v SET vote = -v.vote WHERE v.zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND v.vote <> 0 AND NOT EXISTS (SELECT 1 FROM comments c WHERE c.zid = v.zid AND c.tid = v.tid AND c.pid = v.pid);
+UPDATE votes_latest_unique v SET vote = -v.vote WHERE v.zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND v.vote <> 0 AND NOT EXISTS (SELECT 1 FROM comments c WHERE c.zid = v.zid AND c.tid = v.tid AND c.pid = v.pid);
 ```
 
 Each must report exactly its own expected number. Passes (`vote = 0`) are excluded deliberately —
 negating zero is a no-op that would pad the counts and mask a mistake.
+
+**Author rows are excluded by identity, not by value.** Polis writes one vote from the
+statement's own author, and *that* row was never inverted — the app never sent it. On
+production it happens to be a `0` (the moderator seed path sends an explicit zero), so
+`vote <> 0` would exclude it by luck. It is `-1` when a round was seeded through the
+participant endpoint — which is what the local simulator does, i.e. exactly the stack this
+runbook tells you to rehearse on. The `NOT EXISTS` join against `comments` is what actually
+excludes them; keep `vote <> 0` only as the pass optimisation it claims to be.
 
 Verify before committing. Both distributions should mirror (`-1` and `+1` swapped, `0`
 unchanged), and this reads **both** tables so a divergence is visible *before* you commit:
@@ -167,6 +197,35 @@ perfectly mirrored distribution while every participant-facing number stays inve
 
 Then `COMMIT;` — or `ROLLBACK;` if anything is off.
 
+### 5b. Recompute the clusters — the repair is not finished without this
+
+The vote tables are now right and **every rendered opinion group is still wrong.** Polis
+serves clustering from `math_main`, computed from the old signs. A plain row rewrite adds
+no row, fires no rule and moves no timestamp, so nothing tells the math worker that
+anything changed. Step 7's tallies come straight from Postgres and will look correct while
+the groups beside them stay backwards — the one silent mis-display this repair does not fix
+by itself.
+
+Queue a recompute through the mechanism the app already uses (`queue_math_recompute` in
+`polis_admin.py`) — one row in `worker_tasks` of type `update_math`, carrying
+`{"zid": <zid>}`, bucketed on the zid, with `math_env` `'prod'`.
+
+**Then verify it was consumed. Do not assume it.** Record `math_tick` before, and read it
+back after:
+
+```sql
+SELECT zid, math_tick, to_timestamp(last_vote_timestamp/1000) AS last_vote FROM math_main WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>');
+```
+
+`math_tick` must advance. **No movement is a failure, not a pass.** Two known reasons:
+
+- `math_env` is hardcoded `'prod'`, so on a staging or local stack the task is never claimed.
+- The worker may not be draining the queue at all. On 2026-09-02 a task queued on production
+  sat at `attempts = 0` beside one from 2026-08-05, with `math_tick` frozen at 1356 —
+  polismath was running but had computed nothing for a month. If that is the state, the
+  clusters cannot be refreshed here; that is its own incident, and the repair should be
+  reported as vote-data-only rather than complete.
+
 Repeat **one conversation at a time** through steps 4 and 5, verifying each. A wrong row count is
 recoverable when it is the only conversation in the transaction.
 
@@ -177,8 +236,12 @@ recoverable when it is the only conversation in the transaction.
 Only now, with every conversation repaired:
 
 ```bash
-bash ~/wiki-polis/deploy.sh main
+bash ~/wiki-polis/deploy.sh main --expect <sha of the merge commit that carries the fix>
 ```
+
+`--expect` fails closed before installing or restarting. Without it a moved ref puts
+unfixed code in front of freshly repaired data, and the commit-stamp check below catches
+it only once the tool is already serving.
 
 `deploy.sh` ends with `toolforge webservice restart`, so this returns the tool to service. It is
 `set -euo pipefail`, so a failed frontend build exits **before** the restart and leaves the tool
@@ -213,7 +276,7 @@ the only copy of what the bug wrote.
 
 ## Why not #285's script
 
-`v2/ops/migrate_phase6_vote_signs.py` (208 lines) does this with discovery, dry-run and a
+#285's migration script (`migrate_phase6_vote_signs.py`, on that PR's branch — it is not in this tree) does this with discovery, dry-run and a
 run-log. Good work, but its idempotency guard is a **local JSON file** — its own docstring says
 *"Keep that log; do not run on a second machine."* It also only ever touched `votes`, so it would
 have hit the same silent-no-op described in step 4. With a handful of phase-6 rows and the tool

--- a/v2/ops/phase6-vote-sign-repair.md
+++ b/v2/ops/phase6-vote-sign-repair.md
@@ -24,7 +24,14 @@ is a separate Polis conversation. The pair is the whole point — the verificati
 
 ## 2. Cloud VPS — prove the mismatch
 
-On the VPS, open psql in the postgres container. Substituting the zinvites from step 1:
+⚠️ **Pin the container name.** Production and staging Polis run side by side on that host —
+`particiapp-docker_postgres_1` (port 5432, production) and `wiki-polis-staging_postgres_1`
+(port 5442). A grepped name matches both and will silently pick one, or fail confusingly by
+passing the second name as a command. Confirm which you are on before any write: query
+`zinvites` for the phase-6 zinvite in the container you intend to use — a `zid` back means
+production, empty means staging.
+
+On the VPS, open psql in that pinned container. Substituting the zinvites from step 1:
 
 ```sql
 SELECT 'phase2' AS phase, v.vote, count(*) FROM votes v WHERE v.zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE2_ZINVITE>') GROUP BY v.vote UNION ALL SELECT 'phase6', v.vote, count(*) FROM votes v WHERE v.zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') GROUP BY v.vote ORDER BY phase, vote;

--- a/v2/ops/phase6-vote-sign-repair.md
+++ b/v2/ops/phase6-vote-sign-repair.md
@@ -111,11 +111,39 @@ run once, verify, do not re-run.
 BEGIN;
 ```
 
+⚠️ **The time bound is not optional.** Step 3 deploys the fix first, so every vote cast after
+that moment is *already correct*. An unbounded `UPDATE` would negate those too and make them
+wrong — reintroducing the very bug this repair removes, in rows that were fine. Bound the
+statement to votes written **before the deploy**.
+
+Get the cutoff as epoch milliseconds (`votes.created` is bigint millis). Use the moment the
+webservice restarted onto the fix, not the moment you started reading this:
+
 ```sql
-UPDATE votes SET vote = -vote WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0;
+SELECT extract(epoch FROM TIMESTAMPTZ '2026-08-25 16:40:00+00') * 1000 AS cutoff_millis;
 ```
 
-The reported row count **must equal the non-zero total from step 2**. Passes (`vote = 0`) are
+Then, with that number substituted:
+
+```sql
+UPDATE votes SET vote = -vote WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0 AND created < <CUTOFF_MILLIS>;
+```
+
+If you are unsure of the exact deploy moment, prefer a cutoff slightly **earlier** than the
+restart. Missing a few genuinely-inverted rows leaves them wrong and correctable later; catching
+correct rows makes them wrong with nothing to distinguish them afterwards.
+
+Safest of all: pause the consultation (admin → Pause) for the deploy-and-repair window, so no
+votes are cast in between and the boundary question does not arise.
+
+Check the reported row count against the **bounded** set, not step 2's overall total — step 2
+was taken before the cutoff existed. Count what you expect to touch first:
+
+```sql
+SELECT count(*) FROM votes WHERE zid = (SELECT zid FROM zinvites WHERE zinvite='<PHASE6_ZINVITE>') AND vote <> 0 AND created < <CUTOFF_MILLIS>;
+```
+
+The `UPDATE` must report exactly that number. Passes (`vote = 0`) are
 excluded deliberately — negating zero is a no-op that would pad the count and mask a mistake.
 
 Verify before committing; the distribution should mirror, `-1` and `+1` swapped, `0` unchanged:

--- a/v2/ref_polis-data-model.md
+++ b/v2/ref_polis-data-model.md
@@ -28,9 +28,17 @@ vote SMALLINT   -- -1 = Agree, 1 = Disagree, 0 = Pass/Unsure
 This is **opposite to the intuitive sign**. The CSV export negates every vote so that
 Agree = +1 in exports, but the raw table and the vote API use -1 = Agree.
 
-wiki-polis sends `value: 1` for Agree and `value: -1` for Disagree via Particiapi's
-`PUT /api/conversations/{id}/votes/{tid}`. Particiapi translates these before writing to
-Polis. Verify Particiapi's translation if vote data looks inverted.
+wiki-polis sends the **raw Polis sign** — `value: -1` for Agree, `value: 1` for Disagree,
+`0` for Pass — via Particiapi's `PUT /api/conversations/{id}/votes/{tid}`. **Particiapi does
+not translate it**; the value is written to `votes.vote` unmodified. Both write paths agree:
+`app.py:2212` (Explore) and `app.py:2337` (informed vote), with `services/explore.py` putting
+the value on the wire as given, and the legacy Jinja route at `app.py:6591` forwarding the
+client's raw `data-vote` attribute.
+
+The **only** sign flip anywhere in the system is Polis's own CSV export (see above). If vote
+data looks inverted, that export flip is the explanation to check first — see
+`guide_runbook.md:159-170`. Do not go looking for a translation layer inside Particiapi; there
+isn't one, and assuming there was is what caused the Phase 6 inversion fixed in #328.
 
 ### tid and pid start at 0
 

--- a/v2/simulate_cats_vs_dogs.py
+++ b/v2/simulate_cats_vs_dogs.py
@@ -616,11 +616,11 @@ def _cast_informed_votes(p6_zinvite: str, tids: list[int], phase2_conv_id: str) 
     Writes Polis-native signs directly (-1=agree, +1=disagree, 0=pass): the convention
     every other vote in the system uses, and the one `polis_admin.py` counts as agree.
 
-    The app's own informed-vote route currently writes the OPPOSITE sign — `app.py`
-    maps agree to +1 and nothing negates it downstream. That inversion is the bug
-    PR #328 fixes. Until #328 lands, a round cast here and a round cast by clicking
-    in the app disagree, which makes this a useful oracle rather than a trap: once
-    the fix is in, the two should match.
+    The app's informed-vote route wrote the OPPOSITE sign until #328 — agree as +1,
+    with nothing negating it downstream — so rounds cast here and rounds cast by
+    clicking in the app disagreed. #328 corrected the route and the stored rows on
+    production were repaired 2026-09-02, so the two now match. If they ever diverge
+    again, this function is the reference: it has always written Polis-native.
     """
     cast = 0
     for v in range(INFORMED_VOTERS):
@@ -640,9 +640,9 @@ def _cast_informed_votes(p6_zinvite: str, tids: list[int], phase2_conv_id: str) 
     # Say this on stdout, not only in a docstring the operator never opens: anyone
     # comparing this round against one voted through the app needs to know the two
     # currently disagree, or they will read the difference as a bug here.
-    print("  [signs] written Polis-native (-1=agree). The app's own Phase 6 route "
-          "writes +1 for agree, so a round cast here and one cast by clicking in "
-          "the app have OPPOSITE signs until that is fixed.")
+    print("  [signs] written Polis-native (-1=agree) — the same convention the app's "
+          "Phase 6 route uses since #328, so a round cast here and one cast by "
+          "clicking in the app now agree.")
     print(f"  [counts] `votes` will hold {cast} rows plus one author agree per "
           "statement — Polis adds those itself; see ref_polis-data-model.md.")
 

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -931,13 +931,16 @@
 
           {% if item.phase6_stmt_id is not none %}
           <div class="vote-choice-row p6-vote-row">
-            <button class="vote-choice btn-p6-vote" data-vote="-1">
+            {# aria-pressed carries the recorded choice. Without it the selection is
+               conveyed only by opacity, which no assistive technology reports. The JS
+               below keeps it in step with the .p6-voted class. #}
+            <button class="vote-choice btn-p6-vote" data-vote="-1" aria-pressed="false">
               <span class="vote-dot vote-dot--agree"></span>Agree
             </button>
-            <button class="vote-choice btn-p6-vote" data-vote="0">
+            <button class="vote-choice btn-p6-vote" data-vote="0" aria-pressed="false">
               <span class="vote-dot vote-dot--pass"></span>Pass
             </button>
-            <button class="vote-choice btn-p6-vote" data-vote="1">
+            <button class="vote-choice btn-p6-vote" data-vote="1" aria-pressed="false">
               <span class="vote-dot vote-dot--disagree"></span>Disagree
             </button>
           </div>
@@ -1259,7 +1262,9 @@
               badge.removeAttribute('hidden');
               badge.innerHTML = '<span aria-hidden="true">✓</span> ' + label;
               row.querySelectorAll('.btn-p6-vote').forEach(function (b) {
-                b.classList.toggle('p6-voted', b.dataset.vote === String(vote));
+                var picked = b.dataset.vote === String(vote);
+                b.classList.toggle('p6-voted', picked);
+                b.setAttribute('aria-pressed', picked ? 'true' : 'false');
               });
               card.classList.add('p6-card--voted');
               markTerminal(card);

--- a/v2/templates/conversation.html
+++ b/v2/templates/conversation.html
@@ -931,13 +931,13 @@
 
           {% if item.phase6_stmt_id is not none %}
           <div class="vote-choice-row p6-vote-row">
-            <button class="vote-choice btn-p6-vote" data-vote="1">
+            <button class="vote-choice btn-p6-vote" data-vote="-1">
               <span class="vote-dot vote-dot--agree"></span>Agree
             </button>
             <button class="vote-choice btn-p6-vote" data-vote="0">
               <span class="vote-dot vote-dot--pass"></span>Pass
             </button>
-            <button class="vote-choice btn-p6-vote" data-vote="-1">
+            <button class="vote-choice btn-p6-vote" data-vote="1">
               <span class="vote-dot vote-dot--disagree"></span>Disagree
             </button>
           </div>
@@ -1251,8 +1251,10 @@
             body: JSON.stringify({ fs_id: parseInt(fsId, 10), vote: vote }),
           }).then(function (resp) {
             if (resp.ok) {
-              var label = vote === 1 ? 'Agreed' : vote === -1 ? 'Disagreed' : 'Passed';
-              var cls   = vote === 1 ? 'agree' : vote === -1 ? 'disagree' : 'pass';
+              // Polis convention: -1 = agree, +1 = disagree, 0 = pass — same as the
+              // buttons above and as the phase-2 path. See v2/guide_runbook.md.
+              var label = vote === -1 ? 'Agreed' : vote === 1 ? 'Disagreed' : 'Passed';
+              var cls   = vote === -1 ? 'agree' : vote === 1 ? 'disagree' : 'pass';
               badge.className = 'p6-voted-badge p6-voted-badge--' + cls;
               badge.removeAttribute('hidden');
               badge.innerHTML = '<span aria-hidden="true">✓</span> ' + label;

--- a/v2/tests/test_informed_voting_api.py
+++ b/v2/tests/test_informed_voting_api.py
@@ -3,6 +3,8 @@
 import json
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from db import (Argument, Conversation, ConversationBan, FeaturedStatement,
                 Participation, db)
 from services.informed_voting import build_informed_voting_state
@@ -165,6 +167,35 @@ def test_informed_vote_is_idempotent_put_and_translates_phase6_sign(
     # Verified against a live Polis: an agree in each phase now stores -1 in both.
     assert put.call_args.kwargs['json'] == {'value': -1}
     assert put.call_args.kwargs['cookies'] == {'session': 'phase6-cookie'}
+
+
+@pytest.mark.parametrize('choice, polis_value', [
+    ('agree', -1),
+    ('pass', 0),
+    ('disagree', 1),
+])
+def test_informed_vote_sends_polis_signs_for_every_choice(
+    auth_client, participant, choice, polis_value,
+):
+    """Lock all three mappings, not just agree.
+
+    With only `agree` asserted, mapping `disagree` to -1 as well would pass — the
+    map would be wrong and no test would notice. These are the signs Polis stores
+    and `polis_admin.py` counts, and they must match the Explore path exactly.
+    """
+    conversation, participation, first, _second = _fixture(participant)
+    with auth_client.session_transaction() as browser_session:
+        browser_session['_p6_pa'] = 'phase6-cookie'
+        browser_session['_p6_csrf'] = 'phase6-csrf'
+
+    with patch('app.polis_http.put', return_value=_response({})) as put:
+        response = auth_client.put(
+            f'/api/v1/conversations/informed-api/featured-statements/{first.id}/informed-vote',
+            json={'choice': choice},
+        )
+
+    assert response.status_code == 200
+    assert put.call_args.kwargs['json'] == {'value': polis_value}
     db.session.refresh(participation)
     assert participation.last_engagement is not None
 

--- a/v2/tests/test_informed_voting_api.py
+++ b/v2/tests/test_informed_voting_api.py
@@ -158,7 +158,12 @@ def test_informed_vote_is_idempotent_put_and_translates_phase6_sign(
             'informedVoting': '/api/v1/conversations/informed-api/informed-voting',
         },
     }
-    assert put.call_args.kwargs['json'] == {'value': 1}
+    # Polis convention: -1 = agree, +1 = disagree, 0 = pass. Same as the Explore
+    # path at app.py:2212, and what polis_admin.py:153 counts as agree_count.
+    # This asserted {'value': 1} before, which locked in the inverted sign and is
+    # why every informed vote on production was stored as its own opposite.
+    # Verified against a live Polis: an agree in each phase now stores -1 in both.
+    assert put.call_args.kwargs['json'] == {'value': -1}
     assert put.call_args.kwargs['cookies'] == {'session': 'phase6-cookie'}
     db.session.refresh(participation)
     assert participation.last_engagement is not None

--- a/v2/tests/test_phase6_vote.py
+++ b/v2/tests/test_phase6_vote.py
@@ -101,3 +101,35 @@ def test_phase6_vote_rebootstraps_on_stale_token(auth_client, participant):
     assert r.status_code == 200
     assert post.call_count == 1   # the stale reused token 403s -> exactly one re-bootstrap
     assert put.call_count == 2    # first PUT 403, retry PUT 200
+
+
+def test_both_phase6_surfaces_send_the_polis_agree_sign():
+    """Guard the sign at BOTH phase-6 write sites.
+
+    Polis stores -1 = agree (polis_admin.py:211, guide_runbook.md). The API route
+    maps `choice` server-side; the legacy Jinja route forwards the client's raw
+    data-vote attribute unchanged (app.py:6591), so for that surface the template
+    IS the contract. A divergence writes both signs into one votes table depending
+    only on whether the participant is on the SPA or ?spa_only=0 — worse than the
+    original bug, because the rows become indistinguishable. Nothing else in the
+    suite covers the legacy attribute.
+    """
+    import re
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parent.parent
+
+    template = (root / 'templates' / 'conversation.html').read_text()
+    # Only the phase-6 deck uses btn-p6-vote; phase 2 has its own vote controls.
+    buttons = re.findall(
+        r'btn-p6-vote"\s+data-vote="(-?\d)"\s*>\s*'
+        r'<span class="vote-dot vote-dot--(\w+)"></span>(\w+)',
+        template,
+    )
+    assert len(buttons) == 3, f'expected 3 phase-6 vote buttons, found {len(buttons)}'
+    mapping = {label: int(value) for value, _dot, label in buttons}
+    assert mapping == {'Agree': -1, 'Pass': 0, 'Disagree': 1}, mapping
+
+    app_src = (root / 'app.py').read_text()
+    assert app_src.count("polis_values = {'agree': -1, 'pass': 0, 'disagree': 1}") == 2, \
+        'both the Explore and informed-vote API paths must map agree to -1'

--- a/v2/tests/test_phase6_vote.py
+++ b/v2/tests/test_phase6_vote.py
@@ -54,6 +54,10 @@ def test_phase6_vote_reuses_session_across_votes(auth_client, participant):
     assert r2.status_code == 200
     assert post.call_count == 1   # session bootstrap happens once, then is reused
     assert put.call_count == 2    # both votes forwarded
+    # The legacy route forwards the client's integer UNCHANGED (app.py, `_put`).
+    # Nothing else asserts that, so a server-side negation added here later — the
+    # most plausible shape of a future "re-fix" — would pass every other test.
+    assert [c.kwargs['json'] for c in put.call_args_list] == [{'value': -1}, {'value': 1}]
 
 
 def test_phase6_bootstrap_shared_across_sessions_same_participant(app, participant):
@@ -122,7 +126,7 @@ def test_both_phase6_surfaces_send_the_polis_agree_sign():
     template = (root / 'templates' / 'conversation.html').read_text()
     # Only the phase-6 deck uses btn-p6-vote; phase 2 has its own vote controls.
     buttons = re.findall(
-        r'btn-p6-vote"\s+data-vote="(-?\d)"\s*>\s*'
+        r'btn-p6-vote"\s+data-vote="(-?\d)"[^>]*>\s*'
         r'<span class="vote-dot vote-dot--(\w+)"></span>(\w+)',
         template,
     )
@@ -130,6 +134,21 @@ def test_both_phase6_surfaces_send_the_polis_agree_sign():
     mapping = {label: int(value) for value, _dot, label in buttons}
     assert mapping == {'Agree': -1, 'Pass': 0, 'Disagree': 1}, mapping
 
-    app_src = (root / 'app.py').read_text()
-    assert app_src.count("polis_values = {'agree': -1, 'pass': 0, 'disagree': 1}") == 2, \
-        'both the Explore and informed-vote API paths must map agree to -1'
+    # The badge the participant reads after voting is built from the same integer,
+    # in inline JS no test touched. Flip those two lines and every legacy voter is
+    # told the opposite of what was stored, with the suite still green. Derive both
+    # sides and compare, so formatting drift cannot silently disable this.
+    labels = re.search(
+        r"var label = vote === (-?\d) \? 'Agreed' : vote === (-?\d) \? 'Disagreed'",
+        template,
+    )
+    assert labels, 'could not find the phase-6 badge label map in conversation.html'
+    assert int(labels.group(1)) == mapping['Agree'], (
+        'the badge says "Agreed" for a different integer than the Agree button sends')
+    assert int(labels.group(2)) == mapping['Disagree'], (
+        'the badge says "Disagreed" for a different integer than the Disagree button sends')
+
+    # The API path's mapping is asserted behaviourally, per choice, in
+    # test_informed_voting_api.py::test_informed_vote_sends_polis_signs_for_every_choice.
+    # A source-string count was tried here and removed: it passed if both maps moved
+    # into dead code, and failed on a reformat.


### PR DESCRIPTION
Phase 6 informed votes were written to Polis with the **opposite sign** to every other vote in the system. An Agree was stored as a disagree.

Fixes the sign half of #285, which is superseded by this PR. Refs #324.

## Confirmed three independent ways

**1. Static.** On `main`, the two vote paths disagree for the same backend and the same `gateway.vote()` transport:

```python
app.py:2212  # Explore
polis_values = {'agree': -1, 'pass': 0, 'disagree': 1}
app.py:2337  # Phase 6 informed vote
polis_values = {'agree': 1, 'pass': 0, 'disagree': -1}
```

`polis_admin.py:153-154` counts `vote = -1` as `agree_count`, and `:211` states the convention outright. `guide_runbook.md:151-168` says the same and warns against "correcting" it. So Explore is right and Phase 6 was inverted.

**2. Controlled local experiment**, against a stack whose version stamp was verified as `a32d61c` — production's exact commit. One participant, one stack, seconds apart:

| phase | action | Polis row | stored |
|---|---|---|---|
| 2 | Agree | `zid=5, pid=76, tid=10` | **−1** |
| 6 | Agree, before fix | `zid=6, pid=31, tid=3` | **+1** |
| 6 | Agree, after fix | `zid=6, pid=32, tid=4` | **−1** |

**3. Production raw rows.** Eleven deliberate Disagree votes on `cats-v-dogs`, read straight from the production Polis Postgres:

```
 tid | vote |           at
-----+------+------------------------
  10 |   -1 | 2026-08-25 16:22:57+00
   9 |   -1 | 2026-08-25 16:22:55+00
   ...  (11 distinct tids, all -1, within 15 seconds)
```

Every Disagree stored as `-1`, which the reader counts as agree.

## Why it was invisible

Nothing in the UI reads the sign. `build_informed_voting_state` derives `voted` from the list of statement ids in the participant payload, never the value — so the round looks entirely normal while every recorded position is backwards. It surfaces only in aggregates: phase-6 results, the preliminary results surface, and any clustering or report built on that conversation.

On production right now, `agreementShift` is wrong for every statement, and some shifts likely have the wrong sign rather than merely the wrong magnitude.

## Two write paths, not one

The first commit fixed only the API site. An adversarial review of it traced every phase-6 write path and found a second: the legacy Jinja route (`app.py:6483` → `:6591`) forwards the client's raw `data-vote` attribute unchanged, and `conversation.html:934` sent `data-vote="1"` for Agree. That deck is still reachable via the `spa_only=0` fallback.

Fixing one alone would be **worse than fixing neither** — before, both paths agreed and were uniformly correctable; after, the same conversation would receive both signs depending only on which surface the participant was using, with nothing distinguishing the rows afterwards. Both are fixed here.

## Changes

| commit | |
|---|---|
| `0d503c0` | API write site; corrects the test that had locked the bug in |
| `a86e291` | legacy template + badge label mapping + SPA constant; cross-surface guard test; repair runbook |
| `431012e` | runbook: pin the postgres container name |

`test_informed_vote_is_idempotent_put_and_translates_phase6_sign` asserted `{'value': 1}` for an agree — it encoded the bug as expected behaviour, and its name shows the sign was reasoned about and got the wrong direction.

The new guard covers **both** surfaces, because nothing in the suite did: `test_phase6_vote` asserts call counts, not signs, and no test touched the `data-vote` attribute. For the legacy route the template *is* the contract, since the server forwards whatever it is given.

**789 tests pass.** Each fix verified to fail when reverted, in both directions.

## Existing data

Production's phase-6 votes are stored inverted and this PR does not migrate them. `v2/ops/phase6-vote-sign-repair.md` covers verify-then-repair: it snapshots affected rows into a backup table **before** negating, because those votes are the only record of what the buggy path wrote and may be needed later to establish whether a displayed result was affected. Deploy the code fix first — repairing first means new correct votes arrive into repaired data with nothing marking which rows are which.

## Not in scope

Split out of #285 so they are not lost: **#326** (bind phase 2 and phase 6 to one Polis identity) and **#327** (show the participant's actual prior choice on resume). #285's `migrate_phase6_vote_signs.py` is not carried over — its idempotency guard is a local JSON file, and a counted `UPDATE` in a transaction is smaller and has no hidden state at this data volume.

*Prepared by Claude on behalf of @lgelauff.*
