### PR TITLE
fix(sim): phase 2 was storing every agree as a disagree

### DIFF
--- a/v2/simulate_cats_vs_dogs.py
+++ b/v2/simulate_cats_vs_dogs.py
@@ -88,35 +88,38 @@ FOLLOWUP_STATEMENTS = [
 
 # ── Voting patterns ────────────────────────────────────────────────────────────
 # One tuple per statement: (cat_group, dog_group, neutral_group)
-# 1=agree, -1=disagree, 0=pass
+# Polis-native signs: -1=agree, 1=disagree, 0=pass. These go to Particiapi verbatim
+# (cast_vote does not translate, and neither does Particiapi), so they must be written
+# in the convention Polis stores — the same one _cast_informed_votes uses. Authoring
+# them the intuitive way round is how phase 2 came to store every agree as a disagree.
 VOTES = [
     # Seed statements
-    ( 1, -1,  0),  #  0  cats better companions
-    (-1,  1,  0),  #  1  dogs more loyal
-    ( 1, -1,  1),  #  2  cats easier to care for
-    (-1,  1,  1),  #  3  dogs better for families
-    ( 1, -1,  1),  #  4  cats cleaner
-    (-1,  1,  0),  #  5  dogs better emotional support
-    ( 1, -1,  1),  #  6  cats more independent
-    (-1,  1,  1),  #  7  dogs motivate exercise
-    ( 1, -1,  1),  #  8  cats for apartments
-    (-1,  1,  0),  #  9  dogs more affectionate
+    (-1,  1,  0),  #  0  cats better companions
+    ( 1, -1,  0),  #  1  dogs more loyal
+    (-1,  1, -1),  #  2  cats easier to care for
+    ( 1, -1, -1),  #  3  dogs better for families
+    (-1,  1, -1),  #  4  cats cleaner
+    ( 1, -1,  0),  #  5  dogs better emotional support
+    (-1,  1, -1),  #  6  cats more independent
+    ( 1, -1, -1),  #  7  dogs motivate exercise
+    (-1,  1, -1),  #  8  cats for apartments
+    ( 1, -1,  0),  #  9  dogs more affectionate
     # Follow-up statements
-    ( 1,  1,  1),  # 10  both can be loving (consensus)
-    ( 1, -1,  0),  # 11  dogs require too much time
-    ( 1, -1,  0),  # 12  cats more intelligent
-    ( 1, -1,  1),  # 13  dogs need garden
-    ( 1, -1,  0),  # 14  dogs smell/mess
-    (-1,  1,  1),  # 15  dogs better trained
-    ( 1,  0,  1),  # 16  cats healthier/longer
-    (-1,  1,  1),  # 17  dogs make you social
-    ( 1,  0,  1),  # 18  cats less expensive
-    (-1,  1,  1),  # 19  dogs for security
-    ( 1, -1,  1),  # 20  cats for long work hours
-    (-1,  1,  0),  # 21  dogs for mental health
-    ( 1,  0,  1),  # 22  cats entertaining
-    (-1,  1,  0),  # 23  dogs show empathy
-    ( 1,  1,  1),  # 24  pet type matters less (consensus)
+    (-1, -1, -1),  # 10  both can be loving (consensus)
+    (-1,  1,  0),  # 11  dogs require too much time
+    (-1,  1,  0),  # 12  cats more intelligent
+    (-1,  1, -1),  # 13  dogs need garden
+    (-1,  1,  0),  # 14  dogs smell/mess
+    ( 1, -1, -1),  # 15  dogs better trained
+    (-1,  0, -1),  # 16  cats healthier/longer
+    ( 1, -1, -1),  # 17  dogs make you social
+    (-1,  0, -1),  # 18  cats less expensive
+    ( 1, -1, -1),  # 19  dogs for security
+    (-1,  1, -1),  # 20  cats for long work hours
+    ( 1, -1,  0),  # 21  dogs for mental health
+    (-1,  0, -1),  # 22  cats entertaining
+    ( 1, -1,  0),  # 23  dogs show empathy
+    (-1, -1, -1),  # 24  pet type matters less (consensus)
 ]
 
 GROUP_SIZES = [35, 30, 10]   # cat people, dog people, neutral


### PR DESCRIPTION
## The bug

The simulator's two rounds use opposite sign conventions, so every simulated participant appears to completely reverse their opinion between phase 2 and phase 6.

`VOTES` was authored the intuitive way round — its comment said `1=agree`. Those values go through `add_noise` (which only flips as *noise*; it converts nothing) into `cast_vote`, which sends them to Particiapi verbatim. Particiapi does not translate either — [confirmed by measurement](https://github.com/lgelauff/wiki-polis/pull/302): sending `+1`/`0`/`-1` stores `1`/`0`/`-1`. Polis stores `-1` for agree, so **every phase 2 agree has been landing as a disagree**.

Meanwhile `_cast_informed_votes` (added in #302) writes Polis-native signs correctly.

This poisons precisely the before/after comparison `--phase6` exists to enable — the cross-round analysis behind identity binding and change-of-opinion work. It survived because a uniform sign flip preserves PCA cluster separation; only the labels come out backwards.

## The fix

`VOTES` is now written in Polis-native signs, so one convention holds throughout the file and nothing negates anything — `cast_vote` stays the dumb pass-through it always was, which is also what Particiapi is.

The rewrite is an **exact element-wise negation of all 25 rows**, verified by reparsing the module with `ast` and comparing every tuple against the original.

It also makes `_cast_informed_votes`' docstring true: it claimed to use "the convention every other vote in the system uses", which was accurate about the app but not about the file it sat in.

## Scope

Dev-only. `simulate_cats_vs_dogs.py` has no route, is imported by no test, and never runs on Toolforge. **No production impact** — phase 2 data on production is written by the app, which has always used the correct sign on that path (`app.py` `_explore_vote_api_payload`).

Independent of #328, which fixes the *app's* phase 6 sign. This fixes the *simulator's* phase 2 sign. Both can land in either order.

## Testing

- Full suite: **788 passed**.
- Negation proven programmatically (25/25 rows, exact).
- **Not re-run against a live stack.** The change is a data-table edit with a mechanical proof, but a `--phase6` run would confirm phase 2 now stores `-1` for agree. Happy to run it if wanted.

## Credit

Found reviewing #328 against merged main, and corroborates a panel finding on #302 that was recorded but not acted on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
