### PR TITLE
Build the SPA in dev.sh, and correct three sign-convention notes

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -140,5 +140,22 @@ export PARTICIAPI_BASE_URL="http://127.0.0.1:$PARTICIAPI_PORT"
 export POLIS_SERVER_URL="http://127.0.0.1:$POLIS_PORT"
 export POLIS_DATABASE_URL="postgresql://polis:polis@127.0.0.1:$POSTGRES_PORT/polis"
 
+# The app serves `/` and every `/c/<slug>` from static/spa/index.html, so a checkout
+# without a built frontend answers 404 on almost everything while /health stays green.
+# That reads like a database or routing problem and is neither, so build it here.
+if [ ! -f "$FLASK_DIR/static/spa/index.html" ]; then
+  if command -v npm >/dev/null 2>&1; then
+    echo "→ static/spa is empty — building the frontend"
+    (
+      cd "$FLASK_DIR/frontend"
+      [ -d node_modules ] || npm ci
+      npm run build
+    )
+  else
+    echo "!! static/spa/index.html is missing and npm was not found."
+    echo "!! Flask will 404 on / and every /c/<slug>; /health will still say ok."
+  fi
+fi
+
 uv run flask --app app init-db
 exec uv run flask --app app run --host 127.0.0.1 --port "$FLASK_PORT"

--- a/v2/guide_local-dev.md
+++ b/v2/guide_local-dev.md
@@ -194,6 +194,17 @@ If you changed the Particiapi port:
 uv run python simulate_cats_vs_dogs.py --particiapi-url http://127.0.0.1:8012
 ```
 
+**Pass `--particiapi-url` whenever `v2/.env` sets `PARTICIAPI_BASE_URL`.** The simulator
+calls `load_dotenv` at import, so a value there wins over the built-in default and the
+run fails with *"cannot reach Particiapi"* naming a port you did not choose. `dev.sh`
+exports the port it actually bound; give the simulator the same one.
+
+**Do not reuse a conversation generated before the phase-2 vote-sign fix.** Those runs
+wrote every agree as a disagree (the `VOTES` table was authored the intuitive way round),
+so an old cats-vs-dogs conversation holds inverted phase-2 votes that cannot be repaired
+in place — its phase 6 round, if it has one, was written correctly, so the database mixes
+both conventions. Generate a fresh conversation instead.
+
 The script also reads `PARTICIAPI_BASE_URL` from `v2/.env`.
 
 ### Derivative statements

--- a/v2/ref_polis-data-model.md
+++ b/v2/ref_polis-data-model.md
@@ -63,9 +63,10 @@ Submitting a statement through the participant endpoint
 **agree (`-1`)** on their own `tid`, from the author's own `pid`. No client asks for it,
 and nothing in wiki-polis casts it — Polis records it as part of accepting the statement.
 
-The **moderator seed path** (`add_seed_return_id` → `/api/v3/comments`, used by
-`_init_phase6`) also writes an author row, but a **pass (`0`)** rather than an agree —
-its explicit `'vote': 0` takes effect. So the two paths differ:
+The **moderator seed path** also writes an author row, but a **pass (`0`)** rather than
+an agree — its explicit `'vote': 0` takes effect. Both of its entry points behave this
+way: `add_seed` for an ordinary seeded statement and `add_seed_return_id` for a derived
+one, since both go through `_post_seed`. So the two paths differ:
 
 | path | author row |
 |------|------------|
@@ -89,10 +90,11 @@ The moderator half was confirmed on production the same day: the one Phase 6 rou
 carried exactly 11 author rows, one per seeded statement, every one `pid=0, vote=0`.
 
 **This is a live divergence between the simulator and production.**
-`simulate_cats_vs_dogs.py --phase6` seeds Phase 6 through the *participant* endpoint
-(it has no Polis admin credentials), so local Phase 6 statements carry `-1` author rows
-where production carries `0`. Anything counting or clustering over a simulated Phase 6
-round sees agrees that production would not have.
+`simulate_cats_vs_dogs.py` seeds **both** rounds through the *participant* endpoint — it
+has no Polis admin credentials — so every locally seeded statement, Phase 2 as well as
+Phase 6, carries a `-1` author row where production carries `0`. Anything counting or
+clustering over a simulated round sees agrees that production would not have, and the
+count is one per statement in each round, not just the featured five.
 
 ### zinvite vs zid
 

--- a/v2/synthetic_traffic.py
+++ b/v2/synthetic_traffic.py
@@ -85,7 +85,7 @@ load_dotenv(Path(__file__).with_name(".env"))
 
 DEFAULT_BASE = os.environ.get("WIKI_POLIS_FLASK_URL", "http://127.0.0.1:5001").rstrip("/")
 DEV_USERS = ["dev-user-1", "dev-user-2", "dev-user-3"]  # /dev/login/<username> (DEV_FAKE_LOGIN=1)
-VOTE_VALUES = [-1, 0, 1]                                 # disagree / pass / agree
+VOTE_VALUES = [-1, 0, 1]                                 # agree / pass / disagree (Polis-native)
 PSEUDONYM_RE = re.compile(r"^[a-z]+-[a-z]+$")            # matches the app's _PSEUDONYM_RE shape
 CONV_ID_RE = re.compile(r'data-conversation-id="([^"]+)"')
 CSRF_RE = re.compile(r'name="csrf_token"[^>]*value="([^"]+)"')


### PR DESCRIPTION
## The dev.sh half

`dev.sh` never built the frontend, and the app serves `/` and every `/c/<slug>` from `static/spa/index.html`. A fresh checkout therefore answers **404 on almost every page while `/health` reports `ok`** — which looks like a database or routing fault and is neither.

This cost most of an hour during an end-to-end run tonight: the 404s were first blamed on the wrong database, then on host validation, before the missing build turned out to be the cause. It now builds when `index.html` is absent, and when `npm` is unavailable it says exactly what will break instead of leaving that to be rediscovered.

## Three corrected notes

All three surfaced in review of #329.

**`ref_polis-data-model.md` — wrong function attributed.** The moderator seed path was credited to `add_seed_return_id` alone. Ordinary seeding uses `add_seed` (`admin_statements.py:227`); only a *derived* statement uses `add_seed_return_id` (`:238`). Both reach `_post_seed`, which is where the explicit `'vote': 0` lives (`polis_admin.py:649`) — so the documented behaviour was right and the attribution was not.

**`ref_polis-data-model.md` — divergence understated.** It said the simulator seeds *Phase 6* through the participant endpoint. It seeds **both rounds** that way, so every locally seeded statement carries a `-1` author row that production does not — one per statement per round, not just the featured five.

**`synthetic_traffic.py:88` — inverted comment.** `VOTE_VALUES` was labelled `disagree / pass / agree`, the last surviving claim in the simulation toolkit that `+1` means agree. The values are correct and `random.choice` covers all three, so nothing behaved wrongly; only the comment was the old convention.

## Two gotchas recorded in guide_local-dev.md

- **Pass `--particiapi-url` when `v2/.env` sets `PARTICIAPI_BASE_URL`.** The simulator calls `load_dotenv` at import, so that value beats the built-in default and the run fails with *"cannot reach Particiapi"* naming a port you never chose.
- **Don't reuse a conversation generated before the phase-2 sign fix.** Its phase-2 votes are inverted and cannot be repaired in place, while a phase-6 round on the same conversation was written correctly — so the local database mixes both conventions.

## Testing

- 792 pytest passed.
- `bash -n dev.sh` clean; the new guard exercised both ways (missing `index.html` triggers the build, present skips it).
- No behaviour change outside `dev.sh`; the other three files are comments and prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)