### PR TITLE
Bind participant identity in phase 6, as phase 2 already does

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -2260,12 +2260,20 @@ def _phase6_gateway(conv: Conversation, participant: Participant):
         cookie=session.get('_p6_pa'),
         csrf_token=session.get('_p6_csrf'),
     )
+    # Bind the participant's identity, exactly as _explore_gateway does. The subject is
+    # keyed on conv.id, so Phase 2 and Phase 6 resolve to the SAME Polis uid for one
+    # person — which is what _conversation_subject was written for and says it does.
+    # Leaving this as None minted a throwaway anonymous uid per Phase 6 session, so the
+    # two rounds could not be joined per participant and no before/after comparison was
+    # possible. Confirmed on staging 2026-09-03: of 8 Phase 6 voters, 0 had a bound
+    # subject, against 3 of 14 in the same conversation's Phase 2 round.
+    subject_secret = current_app.config.get('PARTICIAPI_SUB_SECRET')
     gateway = ExploreGateway(
         base_url=current_app.config['PARTICIAPI_BASE'],
         transport=polis_http,
         state=state,
-        subject=None,
-        subject_secret=None,
+        subject=_conversation_subject(participant.xid, conv) if subject_secret else None,
+        subject_secret=subject_secret,
     )
     if not (state.cookie and state.csrf_token):
         with _p6_bootstrap_lock(key):
@@ -6551,11 +6559,23 @@ def phase6_vote(slug):
         the Flask session and the process-local share cache. Returns (pa, csrf_token);
         aborts 502 on failure."""
         prior = session.get('_p6_pa')
+        # Bind identity exactly as _phase6_gateway and _explore_gateway do. This route
+        # and the API route share _p6_session_cache, so if only one of them bound, an
+        # anonymous session cached by this path would be handed to the other and the
+        # binding would be silently defeated. The bound call deliberately drops
+        # `create=true` and the prior cookie: the subject, not the cookie, selects the uid.
+        subject_secret = current_app.config.get('PARTICIAPI_SUB_SECRET')
+        binding = bool(subject_secret)
+        headers = {
+            'X-Particiapi-Sub': _conversation_subject(participant.xid, conv),
+            'X-Particiapi-Sub-Secret': subject_secret,
+        } if binding else {}
         try:
             r = polis_http.post(
                 f'{base}/api/session',
-                cookies={'session': prior} if prior else {},
-                params={'create': 'true'},
+                cookies={} if binding else ({'session': prior} if prior else {}),
+                params={} if binding else {'create': 'true'},
+                headers=headers,
                 timeout=5,
             )
         except requests.RequestException:

--- a/v2/tests/test_informed_voting_api.py
+++ b/v2/tests/test_informed_voting_api.py
@@ -1,5 +1,7 @@
 """Informed-voting read and command API contract tests."""
 
+import hashlib
+import hmac
 import json
 from unittest.mock import MagicMock, patch
 
@@ -291,3 +293,33 @@ def test_openapi_documents_informed_voting_contract(client):
     assert read['operationId'] == 'getInformedVoting'
     assert vote['operationId'] == 'putInformedVote'
     assert 'Idempotent' in vote['description']
+
+
+def test_informed_vote_api_binds_the_same_identity_explore_uses(app, auth_client, participant):
+    """The API write path must bind identity too, to the SAME subject Phase 2 uses.
+
+    There are two Phase 6 write paths — this one and the legacy Jinja route — and they
+    share `_p6_session_cache`. If only one bound, an anonymous session cached by the other
+    would be handed straight to it and the binding would be silently defeated, so both
+    need locking. See test_phase6_vote.py for the legacy half.
+    """
+    secret = 'shared-upstream-secret'
+    app.config['PARTICIAPI_SUB_SECRET'] = secret
+    conversation, _participation, first, _second = _fixture(participant)
+    conv_id, xid = conversation.id, participant.xid
+
+    # Deliberately do NOT pre-seed _p6_pa/_p6_csrf: the bootstrap must actually run.
+    session_resp = _response({'csrf_token': 'tok'}, cookies={'session': 'pa-cookie'})
+    with patch('app.polis_http.post', return_value=session_resp) as post, \
+         patch('app.polis_http.put', return_value=_response({})):
+        response = auth_client.put(
+            f'/api/v1/conversations/informed-api/featured-statements/{first.id}/informed-vote',
+            json={'choice': 'agree'},
+        )
+
+    assert response.status_code == 200
+    headers = post.call_args.kwargs['headers']
+    assert headers['X-Particiapi-Sub-Secret'] == secret
+    expected = hmac.new(secret.encode(), f'{xid}:{conv_id}'.encode(), hashlib.sha256).hexdigest()
+    assert headers['X-Particiapi-Sub'] == expected
+    assert headers['X-Particiapi-Sub'] != xid

--- a/v2/tests/test_phase6_vote.py
+++ b/v2/tests/test_phase6_vote.py
@@ -1,5 +1,7 @@
 """Phase 6 vote route: server-side Particiapi session/CSRF reuse across votes (A5)."""
 
+import hashlib
+import hmac
 from unittest.mock import MagicMock, patch
 
 import app as app_module
@@ -152,3 +154,45 @@ def test_both_phase6_surfaces_send_the_polis_agree_sign():
     # test_informed_voting_api.py::test_informed_vote_sends_polis_signs_for_every_choice.
     # A source-string count was tried here and removed: it passed if both maps moved
     # into dead code, and failed on a reformat.
+
+
+def _expected_subject(secret, xid, conv_id):
+    """Re-derive the conversation-scoped subject independently, so a change to the keying
+    scheme in app.py breaks this test instead of silently passing."""
+    return hmac.new(secret.encode(), f'{xid}:{conv_id}'.encode(), hashlib.sha256).hexdigest()
+
+
+def test_phase6_binds_the_same_identity_explore_uses(app, auth_client, participant):
+    """Phase 6 must resolve to the SAME Polis uid as Phase 2 for one person.
+
+    `_conversation_subject` is keyed on `conv.id` precisely so a participant's initial and
+    informed votes share a uid — its own docstring says so. But `_phase6_gateway` passed
+    `subject=None`, minting a throwaway anonymous uid per Phase 6 session, so the two
+    rounds could not be joined per participant and no before/after comparison was possible.
+
+    Measured on staging 2026-09-03, one conversation: of 8 Phase 6 voters, **0** had a
+    bound subject, against 3 of 14 in the same conversation's Phase 2 round.
+
+    Asserting the exact subject rather than merely "a header was sent" is the point — a
+    Phase 6 subject that differs from Phase 2's would still look bound while leaving the
+    rounds just as unjoinable.
+    """
+    secret = 'shared-upstream-secret'
+    app.config['PARTICIAPI_SUB_SECRET'] = secret
+    conv, fs = _p6_conv()
+    conv_id, xid = conv.id, participant.xid
+    db.session.add(Participation(participant_id=participant.id, conversation_id=conv.id,
+                                 pseudonym='p6-lion'))
+    db.session.commit()
+
+    with patch.object(app_module.polis_http, 'post', return_value=_session_resp()) as post, \
+         patch.object(app_module.polis_http, 'put', return_value=_put_resp()):
+        response = auth_client.post('/c/p6-conv/phase6/vote',
+                                    json={'fs_id': fs.id, 'vote': -1})
+
+    assert response.status_code == 200
+    headers = post.call_args.kwargs['headers']
+    assert headers['X-Particiapi-Sub-Secret'] == secret
+    assert headers['X-Particiapi-Sub'] == _expected_subject(secret, xid, conv_id)
+    # The raw xid must never be the asserted subject.
+    assert headers['X-Particiapi-Sub'] != xid


### PR DESCRIPTION
## The defect

`_conversation_subject` is keyed on `conv.id` **specifically so that one person resolves to the same Polis uid across a conversation's Phase 2 and Phase 6 rounds**. Its own docstring says so:

> *"Using `conv.id` (not the Polis zinvite) keeps it stable across the conversation's Phase-2 and Phase-6 rounds, so an individual's initial and informed votes share one uid."*

Neither Phase 6 write path ever called it. Both opened an **unbound** Particiapi session, minting a throwaway anonymous uid per session — so the two rounds could not be joined per participant, and no before/after comparison was possible. That is the surviving piece of #285; everything else in it was superseded by #302/#328/#329.

## Reproduced on staging

One conversation (`dogs-vs-cats`), voters only:

| | voters | trusted-sub bound |
|---|---|---|
| Phase 2 | 14 | **3** |
| Phase 6 | 8 | **0** |

Trusted-sub is demonstrably working on that stack (12 bound subjects exist). Phase 2 binds real participants; Phase 6 binds nobody.

**A first attempt looked like a refutation and wasn't.** Querying `participants` rather than voters showed 3 identities spanning both rounds. Those turned out to be the admin account: submitting a statement creates an author vote, and that account seeds statements into *both* conversations, so it appears as a "voter" in each. None of the three had a subject at all.

## The fix

Both write paths now derive the subject exactly as `_explore_gateway` does.

**Fixing both matters more than it looks.** The API route and the legacy Jinja route share `_p6_session_cache`. Had only one bound, an anonymous session cached by the other would be handed straight to it and the binding would be silently defeated.

The bound call drops `create=true` and the prior cookie, because the subject rather than the cookie selects the uid — matching `ExploreGateway.ensure_session()`.

## Tests

One per write path, each asserting the **exact expected subject** rather than merely that some header was sent — a Phase 6 subject that differed from Phase 2's would look bound while leaving the rounds just as unjoinable. The subject is re-derived independently in the test, so changing the keying scheme breaks the test rather than silently passing.

Both were confirmed to **fail with the change reverted**. Full suite: 794 passed.

## Behaviour note

Existing sessions keep their unbound cookie until it expires, so this takes effect for new sessions rather than retroactively, and votes already cast stay under the old anonymous uid. Forcing an immediate rebind would reset visible progress for anyone mid-round, so it is deliberately not done here — worth a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Verifying on staging

This is the only PR in the current set that changes runtime behaviour, so it is the only one needing a staging check.

**1. Voting must still work.** The bound call deliberately drops `create=true` and the prior cookie, so the failure mode to rule out is Particiapi rejecting it — which would surface as a 502 when voting, not as a subtle wrong value. Cast one Phase 6 vote and confirm it succeeds.

**2. Binding must actually take effect.** Re-run the query that reproduced the defect; `phase6_voters_bound` should now be above zero.

```bash
docker exec wiki-polis-staging_postgres_1 psql -U polis polis -c "WITH p2 AS (SELECT zid FROM zinvites WHERE zinvite='2nmxcahub9'), p6 AS (SELECT zid FROM zinvites WHERE zinvite='6vndm7mimz'), v2 AS (SELECT DISTINCT pt.uid FROM votes v JOIN participants pt ON pt.zid=v.zid AND pt.pid=v.pid WHERE v.zid=(SELECT zid FROM p2)), v6 AS (SELECT DISTINCT pt.uid FROM votes v JOIN participants pt ON pt.zid=v.zid AND pt.pid=v.pid WHERE v.zid=(SELECT zid FROM p6)) SELECT (SELECT count(*) FROM v2 JOIN particiapi_users u ON u.uid=v2.uid) AS phase2_voters_bound, (SELECT count(*) FROM v6 JOIN particiapi_users u ON u.uid=v6.uid) AS phase6_voters_bound;"
```

Note that **an existing browser session will not rebind** — the unbound cookie is reused until it expires. Vote from a fresh session (or a different browser) or the check will read zero for reasons unrelated to this change.
