### PR TITLE
Release participant contributions under CC0

### DIFF
--- a/v2/pub_privacy.md
+++ b/v2/pub_privacy.md
@@ -17,6 +17,28 @@ we collect, how your participation is kept private, and how long we keep it.
 
 We never see or store your email address.
 
+## What you write, and who may reuse it
+
+Statements and arguments you write are released under
+[CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/), which places them in the
+public domain. You agree to this when you join a consultation.
+
+This is what makes the results shareable: a consultation only has a point if its outcome
+can be published, quoted in a community discussion, and reused by anyone who wants to
+build on it — without having to track down every contributor for permission first.
+
+What this does and does not mean:
+
+- **It covers what you write, not who wrote it.** Contributions are published under your
+  pseudonym. CC0 waives the requirement to credit you, so nobody has to name even that.
+- **Votes are not covered.** A vote is a fact rather than a work, and facts are not
+  copyrightable in the first place.
+- **It cannot be withdrawn.** CC0 is irrevocable. Deleting your account later does not
+  un-license text that has already been published — the same as any wiki edit.
+- **It does not change what is public.** Whether a statement is shown at all is governed
+  by moderation and by the sections above; the licence only governs reuse of what does
+  get published.
+
 ## How your opinions stay private
 
 While a conversation is collecting opinions, no one can see who voted what — not other

--- a/v2/pub_privacy.md
+++ b/v2/pub_privacy.md
@@ -21,7 +21,9 @@ We never see or store your email address.
 
 Statements and arguments you write are released under
 [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/), which places them in the
-public domain. You agree to this when you join a consultation.
+public domain. You agree to this on the join screen for a consultation you take part
+in directly. It does not cover a logged-in user who ends up authoring content by way
+of a demo conversation's frictionless auto-join — see #340 for closing that gap.
 
 This is what makes the results shareable: a consultation only has a point if its outcome
 can be published, quoted in a community discussion, and reused by anyone who wants to

--- a/v2/templates/accept.html
+++ b/v2/templates/accept.html
@@ -136,6 +136,25 @@
       </details>
     </div>
 
+    {# ── What happens to what you write ──
+       Stated before the consent box rather than inside it: the checkbox has to
+       stay short enough to read, and a licence nobody reads is not consent. #}
+    <div class="accept-section" id="accept-licence-note">
+      <h2>What you write</h2>
+      <p>
+        Statements and arguments you write here are released under
+        <a href="https://creativecommons.org/publicdomain/zero/1.0/"
+           target="_blank" rel="noopener">CC0<span class="sr-only"> (opens in a new tab)</span></a>,
+        which places them in the public domain. That is what lets the results be
+        published as a report, quoted in a discussion, and reused by anyone.
+      </p>
+      <p class="muted">
+        This covers what you write, not who wrote it: contributions are published
+        under your pseudonym, and CC0 does not require anyone to credit you.
+        Your votes are not covered — a vote is a fact, not a work.
+      </p>
+    </div>
+
     {# ── Consent ── #}
     <label class="consent-label" id="consent-label" for="consent-check" style="margin-top:1.25rem">
       <input type="checkbox"
@@ -146,7 +165,8 @@
              aria-required="true">
       <span>
         I understand my votes and arguments are recorded with this pseudonym,
-        and ProtoWiki keeps an internal username link while this consultation runs.
+        ProtoWiki keeps an internal username link while this consultation runs,
+        and what I write is released under CC0.
       </span>
     </label>
 

--- a/v2/templates/accept.html
+++ b/v2/templates/accept.html
@@ -40,7 +40,7 @@
         action="{{ url_for('participant.accept_post', slug=conversation.slug) }}"
         id="accept-form"
         aria-labelledby="accept-title"
-        aria-describedby="pseudonym-help accept-privacy-note{% if error %} accept-error{% endif %}">
+        aria-describedby="pseudonym-help accept-privacy-note accept-licence-note{% if error %} accept-error{% endif %}">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
     {# ── Pseudonym card ── #}
@@ -145,13 +145,15 @@
         Statements and arguments you write here are released under
         <a href="https://creativecommons.org/publicdomain/zero/1.0/"
            target="_blank" rel="noopener">CC0<span class="sr-only"> (opens in a new tab)</span></a>,
-        which places them in the public domain. That is what lets the results be
-        published as a report, quoted in a discussion, and reused by anyone.
+        which places them in the public domain, the same as a wiki edit. That is
+        what lets the results be published as a report, quoted in a discussion,
+        and reused by anyone.
       </p>
       <p class="muted">
         This covers what you write, not who wrote it: contributions are published
         under your pseudonym, and CC0 does not require anyone to credit you.
-        Your votes are not covered — a vote is a fact, not a work.
+        Your votes are not covered — a vote is a fact, not a work. CC0 cannot be
+        withdrawn once given, the same as any wiki edit.
       </p>
     </div>
 

--- a/v2/templates/base.html
+++ b/v2/templates/base.html
@@ -86,7 +86,12 @@
 
   <div id="toast-container"></div>
 
-  <footer style="text-align:right;padding:.5rem 1rem;font-size:11px;color:var(--muted)">
+  <footer style="display:flex;justify-content:space-between;gap:1rem;padding:.5rem 1rem;font-size:11px;color:var(--muted)">
+    <span>
+      Statements and arguments are released under
+      <a href="https://creativecommons.org/publicdomain/zero/1.0/" target="_blank" rel="noopener"
+         style="color:inherit">CC0<span class="sr-only"> (opens in a new tab)</span></a>.
+    </span>
     <code>{{ git_version }}</code>
   </footer>
 


### PR DESCRIPTION
## Summary

- Adds a CC0 licence notice for participant-written statements and arguments, so future contributions have something on the record. Does **not** cover `2026-nlwiki-arbcom` round 1 — that content predates this and CC0 cannot be applied retroactively without asking those participants (tracked separately in #334).
- Consent lives on the join page, next to the existing required checkbox, and is echoed in `pub_privacy.md` and a persistent site-wide footer notice (matching the pattern Wikipedia and comparable civic-deliberation tools use — a constant footer line backed by a fuller explanation).
- Scope is deliberately narrow: statements and arguments only. Votes are explicitly excluded (a vote is a fact, not a work), and the notice says plainly that CC0 covers *what* was written, not *who* wrote it — contributions stay pseudonymous.

## Review

Went through `/pr-check`: full test suite (792 passed) plus a three-reviewer panel (senior-engineer, accessibility, usability) with cross-review. Three findings came back, each independently verified against the running code before fixing:

- `accept-licence-note` wasn't wired into the join form's `aria-describedby`, unlike its sibling privacy section — fixed.
- Irrevocability was stated only in `pub_privacy.md`, never on the page carrying the actual enforceable checkbox — fixed.
- The copy claimed "you agree to this when you join a consultation" unconditionally. Traced `_ensure_demo_participation` and confirmed that's false for one path: a logged-in user auto-joining a demo conversation never sees this screen at all, and their content is stored identically to a real conversation's. That bypass predates this branch (`git diff --stat -- app.py` against it is empty), so the copy is scoped to what's actually true rather than fixing demo-mode's join logic here — filed separately as #340. A related pre-existing gap (consent is enforced client-side only) is filed as #341.

Full findings and disposition: `.claude/pr-check/feat-cc0-contribution-licence.md` (local, gitignored).

## Known open item

`pub_privacy.md` still opens with "DRAFT — not for publication. Pending legal/comms review," written before this branch. The CC0 decision itself was made explicitly by the repo owner; that banner covers the whole file including unrelated pending items (retention, etc.) and doesn't distinguish this section as settled. Left as-is — worth a deliberate call on how to split that rather than silently resolving it here.

## Test plan

- [x] Full suite: `cd v2 && DATABASE_URL="sqlite:///:memory:" SECRET_KEY=... uv run pytest -q` — 792 passed
- [x] Targeted re-run after the fix commit (`test_templates_parse.py`, `test_a11y_markup.py`, `test_conversations.py`) — 87 passed
- [x] `aria-describedby` chain verified by reading the rendered template
- [ ] Visual check of the join page and footer on staging — not yet run; template-only change, no `RUNTIME` flag fired, so `/pr-check` didn't require it

🤖 Generated with [Claude Code](https://claude.com/claude-code)