### PR TITLE
Add a private per-conversation admin notes field

### DIFF
--- a/v2/api/admin_routes.py
+++ b/v2/api/admin_routes.py
@@ -279,6 +279,7 @@ def register_admin_routes(
         expected = {
             'title', 'introHtml', 'outroHtml', 'accessPolicy',
             'eligibilityEventId', 'eligibilityLabel', 'recommendationTier',
+            'adminNotes',
         }
         fields = {}
         if not isinstance(body, dict) or set(body) != expected:
@@ -289,13 +290,15 @@ def register_admin_routes(
         if (not isinstance(body['title'], str) or not body['title'].strip()
                 or len(body['title'].strip()) > 255):
             fields['title'] = ['Write a title up to 255 characters.']
-        for key in ('introHtml', 'outroHtml', 'eligibilityEventId', 'eligibilityLabel'):
+        for key in ('introHtml', 'outroHtml', 'eligibilityEventId', 'eligibilityLabel', 'adminNotes'):
             if not isinstance(body[key], str):
                 fields[key] = ['Use text.']
         if isinstance(body['eligibilityEventId'], str) and len(body['eligibilityEventId']) > 80:
             fields['eligibilityEventId'] = ['Use at most 80 characters.']
         if isinstance(body['eligibilityLabel'], str) and len(body['eligibilityLabel']) > 255:
             fields['eligibilityLabel'] = ['Use at most 255 characters.']
+        if isinstance(body['adminNotes'], str) and len(body['adminNotes']) > 4000:
+            fields['adminNotes'] = ['Use at most 4000 characters.']
         if body['accessPolicy'] not in {'public', 'invite_only', 'demo'}:
             fields['accessPolicy'] = ['Choose public, invite_only, or demo.']
         if body['recommendationTier'] not in {'simple', 'medium', 'complex'}:

--- a/v2/app.py
+++ b/v2/app.py
@@ -3571,7 +3571,8 @@ def _update_admin_settings_api_payload(conv_id: int, body: dict) -> dict:
         outro_html=body['outroHtml'], access_policy=body['accessPolicy'],
         eligibility_event_id=body['eligibilityEventId'],
         eligibility_label=body['eligibilityLabel'],
-        tier=body['recommendationTier'], sanitise=_sanitise_text,
+        tier=body['recommendationTier'], admin_notes=body['adminNotes'],
+        sanitise=_sanitise_text,
         session=db.session, audit=record_audit,
     )
     return {

--- a/v2/db.py
+++ b/v2/db.py
@@ -82,6 +82,12 @@ class Conversation(db.Model):
     phase_route   = db.Column(db.String(32), nullable=False, default='default_7',
                               server_default='default_7')
     recommended_quantities = db.Column(db.JSON, nullable=True, default=dict)
+    # Freeform organizer/global-admin notes about this conversation — e.g. "no CC0
+    # consent obtained; predates the licence notice" for a legacy round. Never shown
+    # to participants or moderators, and must never be added to an analysis export
+    # allowlist (see private/analysis/export_app_bundle.py's CONVERSATION_COLUMNS) —
+    # it exists specifically to hold things that are NOT meant to leave this table.
+    admin_notes  = db.Column(db.Text, nullable=True)
     scheduled_transition_at = db.Column(db.DateTime, nullable=True)
     scheduled_transition_target = db.Column(db.String(32), nullable=True)
     scheduled_transition_frozen = db.Column(db.Boolean, nullable=False, default=False,

--- a/v2/frontend/src/api/schema.ts
+++ b/v2/frontend/src/api/schema.ts
@@ -1384,6 +1384,7 @@ export interface components {
             eligibilityLabel: string;
             /** @enum {string} */
             recommendationTier: "simple" | "medium" | "complex";
+            adminNotes: string;
         };
         AdminSettingsUpdateResponse: {
             data: {
@@ -1414,6 +1415,8 @@ export interface components {
                 phaseRoute: string;
                 phaseRouteLabel: string;
                 polisId: string;
+                /** @description Organizer/global-admin-only free text. null when the viewer cannot organize this conversation; never shown to participants. */
+                adminNotes: string | null;
             };
             recommendations: components["schemas"]["AdminRecommendations"];
             eligibility: {

--- a/v2/frontend/src/features/admin/admin-lifecycle-page.tsx
+++ b/v2/frontend/src/features/admin/admin-lifecycle-page.tsx
@@ -152,7 +152,7 @@ function ConfigurationSection({conversationId, csrfToken, settings, refresh, fai
   const [eligibilityLabel, setEligibilityLabel] = useState(settings.eligibility.label ?? '');
   const [tier, setTier] = useState(settings.recommendations.tier);
   const settingsMutation = useMutation({
-    mutationFn: () => putAdminSettings(conversationId, {title, introHtml, outroHtml, accessPolicy, eligibilityEventId: eventId, eligibilityLabel, recommendationTier: settings.recommendations.tier}, csrfToken),
+    mutationFn: () => putAdminSettings(conversationId, {title, introHtml, outroHtml, accessPolicy, eligibilityEventId: eventId, eligibilityLabel, recommendationTier: settings.recommendations.tier, adminNotes: settings.conversation.adminNotes ?? ''}, csrfToken),
     onSuccess: refresh,
     onError: fail,
   });

--- a/v2/frontend/src/features/admin/admin-settings-page.tsx
+++ b/v2/frontend/src/features/admin/admin-settings-page.tsx
@@ -23,10 +23,11 @@ export function AdminSettingsPage({conversationId, csrfToken}: {
   const [eligibilityEventId, setEligibilityEventId] = useState(data.eligibility.eventId);
   const [eligibilityLabel, setEligibilityLabel] = useState(data.eligibility.label ?? '');
   const [tier, setTier] = useState<Tier>(data.recommendations.tier);
+  const [adminNotes, setAdminNotes] = useState(data.conversation.adminNotes ?? '');
   const mutation = useMutation({
     mutationFn: () => putAdminSettings(conversationId, {
       title, introHtml, outroHtml, accessPolicy, eligibilityEventId,
-      eligibilityLabel, recommendationTier: tier,
+      eligibilityLabel, recommendationTier: tier, adminNotes,
     }, csrfToken),
     onSuccess: (receipt) => queryClient.setQueryData<Settings>(
       options.queryKey, receipt.settings,
@@ -81,6 +82,18 @@ export function AdminSettingsPage({conversationId, csrfToken}: {
             </label>
           ))}</fieldset>
         </section>
+        {data.conversation.adminNotes !== null && <section aria-labelledby="settings-notes">
+          <header><span>04</span><div><h2 id="settings-notes">Notes</h2>
+            <p>Organizer/global-admin only. Never shown to participants or moderators without
+              organizer rights — use it for things like recording that a round predates the
+              CC0 consent notice, so nobody assumes it applies retroactively.</p></div></header>
+          <label>
+            <span className="sr-only">Notes about this conversation</span>
+            <textarea value={adminNotes} maxLength={4000} rows={4}
+              placeholder="Notes about this conversation…"
+              onChange={(event) => setAdminNotes(event.target.value)} />
+          </label>
+        </section>}
         {data.capabilities.edit ? <footer>
           <button type="submit" disabled={mutation.isPending}>{mutation.isPending ? 'Saving…' : 'Save settings'}</button>
           {mutation.data && <p role="status">{mutation.data.changed ? 'Settings saved.' : 'Settings already up to date.'}</p>}

--- a/v2/migrations/versions/b1c2d3e4f5a6_add_conversation_admin_notes.py
+++ b/v2/migrations/versions/b1c2d3e4f5a6_add_conversation_admin_notes.py
@@ -1,0 +1,24 @@
+"""add private admin notes to conversations
+
+Revision ID: b1c2d3e4f5a6
+Revises: a8b9c0d1e2f3
+Create Date: 2026-09-04 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'b1c2d3e4f5a6'
+down_revision = 'a8b9c0d1e2f3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('conversations') as batch_op:
+        batch_op.add_column(sa.Column('admin_notes', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('conversations') as batch_op:
+        batch_op.drop_column('admin_notes')

--- a/v2/openapi.json
+++ b/v2/openapi.json
@@ -1,3002 +1,11399 @@
 {
-  "openapi": "3.1.0",
-  "info": {
-    "title": "ProtoWiki application API",
-    "version": "1.0.0",
-    "description": "Same-origin API contract between the browser application and Flask. Polis and Particiapi remain behind Flask."
-  },
-  "servers": [
-    {"url": "/api/v1"}
-  ],
-  "paths": {
-    "/session": {
-      "get": {
-        "operationId": "getSession",
-        "summary": "Return the current browser session and its site-wide capabilities",
-        "responses": {
-          "200": {
-            "description": "Current session",
-            "headers": {
-              "Cache-Control": {
-                "schema": {"type": "string", "const": "no-store"}
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/SessionResponse"}
-              }
-            }
-          }
-        }
-      }
-    },
-    "/admin": {
-      "get": {"operationId": "getAdminCatalog", "summary": "Return site-wide conversation and administrator operations", "responses": {
-        "200": {"description": "Admin catalog", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminCatalogResponse"}}}},
-        "403": {"description": "Global admin permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations": {
-      "post": {"operationId": "postAdminConversation", "summary": "Create a local conversation and its managed voting conversation", "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminConversationCreateRequest"}}}}, "responses": {
-        "201": {"description": "Conversation creation receipt", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminConversationCreateResponse"}}}},
-        "400": {"description": "Invalid conversation fields", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "403": {"description": "Global admin permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "409": {"description": "Slug conflict or unknown creation outcome", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "502": {"description": "Voting service creation failed", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "503": {"description": "Local save failed", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/global-admin-grants": {
-      "post": {"operationId": "postGlobalAdminGrant", "summary": "Grant site-wide administration by known Wikimedia username", "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/GlobalAdminGrantRequest"}}}}, "responses": {
-        "200": {"description": "Existing grant receipt", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/GlobalAdminGrantResponse"}}}},
-        "201": {"description": "New grant receipt", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/GlobalAdminGrantResponse"}}}},
-        "400": {"description": "Invalid username", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "403": {"description": "Global admin permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "404": {"description": "Participant has not signed in", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/global-admins/{participantId}": {
-      "parameters": [{"name": "participantId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "put": {"operationId": "putGlobalAdmin", "summary": "Set desired site-wide administrator membership", "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/GlobalAdminSetRequest"}}}}, "responses": {
-        "200": {"description": "Membership receipt", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/GlobalAdminGrantResponse"}}}},
-        "400": {"description": "Invalid desired state", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "403": {"description": "Global admin permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "404": {"description": "Participant not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations/{conversationId}/termination": {
-      "parameters": [{"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "get": {"operationId": "getAdminConversationTermination", "summary": "Inspect live empty-conversation deletion eligibility", "responses": {
-        "200": {"description": "Termination state", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminTerminationResponse"}}}},
-        "403": {"description": "Global admin permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "404": {"description": "Conversation not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/conversations": {
-      "get": {
-        "operationId": "getConversationLane",
-        "summary": "Return participant-facing conversation groups for one space",
-        "parameters": [
-          {
-            "name": "space",
-            "in": "query",
-            "schema": {"type": "string", "enum": ["real", "demo"], "default": "real"}
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Conversation lane",
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/ConversationLaneResponse"}
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid space",
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/ErrorResponse"}
-              }
-            }
-          }
-        }
-      }
-    },
-    "/conversations/{slug}/workspace": {
-      "get": {
-        "operationId": "getConversationWorkspace",
-        "summary": "Return the participant workspace composition contract",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "schema": {"type": "string", "minLength": 1}
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Conversation workspace composition",
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/ConversationWorkspaceResponse"}
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required for a real conversation",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "403": {
-            "description": "The current browser cannot access this conversation",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "404": {
-            "description": "Conversation not found",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          }
-        }
-      }
-    },
-    "/conversations/{slug}/about": {
-      "get": {
-        "operationId": "getConversationAbout",
-        "summary": "Return the participant-safe record for one conversation",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "schema": {"type": "string", "minLength": 1}
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Conversation record",
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/ConversationAboutResponse"}
-              }
-            }
-          },
-          "403": {
-            "description": "The current browser cannot access this conversation",
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/ErrorResponse"}
-              }
-            }
-          },
-          "404": {
-            "description": "Conversation not found",
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/ErrorResponse"}
-              }
-            }
-          }
-        }
-      }
-    },
-    "/conversations/{slug}/moderation-log": {
-      "get": {
-        "operationId": "getModerationLog",
-        "summary": "Return the public conversation ban and unban history",
-        "parameters": [
-          {"name": "slug", "in": "path", "required": true, "schema": {"type": "string", "minLength": 1}}
-        ],
-        "responses": {
-          "200": {"description": "Public moderation history", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ModerationLogResponse"}}}},
-          "403": {"description": "Conversation access denied", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "404": {"description": "Conversation not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/conversations/{slug}/outputs/{outputKey}": {
-      "get": {
-        "operationId": "getConversationOutput",
-        "summary": "Return one participant-visible conversation output",
-        "parameters": [
-          {"name": "slug", "in": "path", "required": true, "schema": {"type": "string", "minLength": 1}},
-          {"name": "outputKey", "in": "path", "required": true, "schema": {"type": "string", "enum": ["initial-clustering", "argument-map", "preliminary-results", "report", "dataset"]}}
-        ],
-        "responses": {
-          "200": {"description": "Conversation output context", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ConversationOutputPageResponse"}}}},
-          "401": {"description": "Authentication required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "403": {"description": "Conversation access denied", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "404": {"description": "Conversation or output not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "409": {"description": "Participation required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/conversations/{slug}/identity-reveal": {
-      "parameters": [
-        {
-          "name": "slug",
-          "in": "path",
-          "required": true,
-          "schema": {"type": "string", "minLength": 1}
-        }
-      ],
-      "get": {
-        "operationId": "getIdentityReveal",
-        "summary": "Return the participant's identity-reveal timeline and capability",
-        "responses": {
-          "200": {
-            "description": "Identity-reveal state",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IdentityRevealResponse"}}}
-          },
-          "401": {"description": "Authentication required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "409": {"description": "Conversation is not closed or participant has not joined", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      },
-      "post": {
-        "operationId": "createIdentityReveal",
-        "summary": "Permanently link the participant's Wikimedia username and pseudonym",
-        "description": "Irreversible and idempotent. A replay returns the existing public link with HTTP 200.",
-        "requestBody": {
-          "required": true,
-          "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CreateIdentityRevealRequest"}}}
-        },
-        "responses": {
-          "200": {"description": "Existing reveal returned on replay", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IdentityRevealResponse"}}}},
-          "201": {"description": "Identity permanently linked", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IdentityRevealResponse"}}}},
-          "400": {"description": "Explicit confirmation missing", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "409": {"description": "Reveal window is not open", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/conversations/{slug}/participation-entry": {
-      "get": {
-        "operationId": "getParticipationEntry",
-        "summary": "Resolve the authenticated participant's join-route state",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "schema": {"type": "string", "minLength": 1}
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Join form, redirect, or invite-denied route state",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ParticipationEntryResponse"}}}
-          },
-          "401": {"description": "Authentication required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "404": {"description": "Conversation not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/conversations/{slug}/pseudonym-suggestions": {
-      "get": {
-        "operationId": "getPseudonymSuggestions",
-        "summary": "Return available pseudonym suggestions for a join form",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "schema": {"type": "string", "minLength": 1}
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Fresh pseudonym suggestions",
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/PseudonymSuggestionsResponse"}
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/ErrorResponse"}
-              }
-            }
-          }
-        }
-      }
-    },
-    "/conversations/{slug}/participation": {
-      "post": {
-        "operationId": "createParticipation",
-        "summary": "Join a conversation with a globally unique pseudonym",
-        "description": "Idempotent for an already joined participant; a replay returns the existing participation with HTTP 200.",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "schema": {"type": "string", "minLength": 1}
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {"$ref": "#/components/schemas/CreateParticipationRequest"}
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Existing participation returned for an idempotent replay",
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/ParticipationResponse"}
-              }
-            }
-          },
-          "201": {
-            "description": "Participation created",
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/ParticipationResponse"}
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid command",
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/ErrorResponse"}
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/ErrorResponse"}
-              }
-            }
-          },
-          "403": {
-            "description": "Access or eligibility denied",
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/ErrorResponse"}
-              }
-            }
-          },
-          "409": {
-            "description": "Pseudonym conflict",
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/ErrorResponse"}
-              }
-            }
-          }
-        }
-      }
-    },
-    "/conversations/{slug}/explore": {
-      "get": {
-        "operationId": "getExploreState",
-        "summary": "Return the current participant Explore queue state",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "schema": {"type": "string", "minLength": 1}
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Current Explore state",
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/ExploreStateResponse"}
-              }
-            }
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "403": {
-            "description": "Conversation access denied or participant banned",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "409": {
-            "description": "Participation or Explore phase is not active",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "502": {
-            "description": "Voting service unavailable",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          }
-        }
-      }
-    },
-    "/conversations/{slug}/arguments": {
-      "get": {
-        "operationId": "getArgumentMapping",
-        "summary": "Return the participant's argument-mapping task state",
-        "description": "Contribution status, stable argument ordering, prioritization gates, and capabilities are computed server-side. Aggregate importance counts are withheld during the open phase to avoid anchoring.",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "schema": {"type": "string", "minLength": 1}
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Current argument-mapping state",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ArgumentMappingResponse"}}}
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "403": {
-            "description": "Conversation access is denied or the participant is banned",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "404": {
-            "description": "Conversation not found",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "409": {
-            "description": "Participation is missing or argument mapping is not open",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          }
-        }
-      }
-    },
-    "/conversations/{slug}/informed-voting": {
-      "get": {
-        "operationId": "getInformedVoting",
-        "summary": "Return the participant's informed-voting cards and progress",
-        "parameters": [{"name": "slug", "in": "path", "required": true, "schema": {"type": "string", "minLength": 1}}],
-        "responses": {
-          "200": {"description": "Current informed-voting state", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/InformedVotingResponse"}}}},
-          "401": {"description": "Authentication required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "403": {"description": "Conversation access is denied or participant is banned", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "409": {"description": "Participation or informed-voting phase is not active", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "502": {"description": "Voting service unavailable", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/conversations/{slug}/results": {
-      "get": {
-        "operationId": "getResultsReport",
-        "summary": "Return privacy-safe preliminary or final aggregate results",
-        "description": "Uses the live moderation filter for preliminary results and the publication snapshot for a final report.",
-        "parameters": [{"name": "slug", "in": "path", "required": true, "schema": {"type": "string", "minLength": 1}}],
-        "responses": {
-          "200": {"description": "Aggregate results report", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ResultsReportResponse"}}}},
-          "401": {"description": "Authentication required for personal-only results", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "403": {"description": "Conversation access denied", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "409": {"description": "Results are not published", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/conversations/{slug}/intermediate-results": {
-      "get": {
-        "operationId": "getIntermediateResults",
-        "summary": "Return privacy-safe initial-round consensus and opinion groups",
-        "parameters": [{"name": "slug", "in": "path", "required": true, "schema": {"type": "string", "minLength": 1}}],
-        "responses": {
-          "200": {"description": "Current intermediate-results state", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/IntermediateResultsResponse"}}}},
-          "401": {"description": "Authentication required for personal-only results", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "403": {"description": "Conversation access denied", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "409": {"description": "Intermediate results are not published", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/conversations/{slug}/featured-statements/{featuredStatementId}/informed-vote": {
-      "put": {
-        "operationId": "putInformedVote",
-        "summary": "Set the participant's informed vote for a featured statement",
-        "description": "Idempotent replacement command. Phase 6 Polis identifiers are resolved server-side.",
-        "parameters": [
-          {"name": "slug", "in": "path", "required": true, "schema": {"type": "string", "minLength": 1}},
-          {"name": "featuredStatementId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}
-        ],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/InformedVoteRequest"}}}},
-        "responses": {
-          "200": {"description": "Informed vote stored", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/InformedVoteResponse"}}}},
-          "400": {"description": "Invalid choice", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "404": {"description": "Featured statement is not available in this round", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "409": {"description": "Informed voting is not active", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "502": {"description": "Voting service unavailable", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/conversations/{slug}/featured-statements/{featuredStatementId}/arguments": {
-      "post": {
-        "operationId": "createArgument",
-        "summary": "Submit one argument for a featured-statement side",
-        "description": "Idempotent for an identical replay. One contribution per participant, featured statement, and side is enforced by the database.",
-        "parameters": [
-          {"name": "slug", "in": "path", "required": true, "schema": {"type": "string", "minLength": 1}},
-          {"name": "featuredStatementId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}
-        ],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CreateArgumentRequest"}}}},
-        "responses": {
-          "200": {"description": "Existing identical argument returned", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ArgumentSubmissionResponse"}}}},
-          "201": {"description": "Argument created", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ArgumentSubmissionResponse"}}}},
-          "400": {"description": "Invalid argument", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Authentication required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "403": {"description": "Access denied", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "404": {"description": "Conversation or featured statement not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "409": {"description": "Phase conflict or a different argument already exists", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/conversations/{slug}/featured-statements/{featuredStatementId}/contributions/{side}/skip": {
-      "put": {
-        "operationId": "putArgumentContributionSkip",
-        "summary": "Explicitly skip one argument-contribution side",
-        "description": "Idempotent state replacement; repeated PUT requests keep the side skipped.",
-        "parameters": [
-          {"name": "slug", "in": "path", "required": true, "schema": {"type": "string", "minLength": 1}},
-          {"name": "featuredStatementId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}},
-          {"name": "side", "in": "path", "required": true, "schema": {"type": "string", "enum": ["pro", "con"]}}
-        ],
-        "responses": {
-          "200": {"description": "Contribution side is skipped", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ArgumentSkipResponse"}}}},
-          "400": {"description": "Invalid side", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Authentication required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "403": {"description": "Access denied", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "404": {"description": "Conversation or featured statement not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "409": {"description": "Phase conflict or the side already has an argument", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/conversations/{slug}/arguments/{argumentId}/priority": {
-      "put": {
-        "operationId": "putArgumentPriority",
-        "summary": "Set whether an argument is one of the participant's priorities",
-        "description": "Idempotent state replacement serialized per participant, featured statement, and side.",
-        "parameters": [
-          {"name": "slug", "in": "path", "required": true, "schema": {"type": "string", "minLength": 1}},
-          {"name": "argumentId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}
-        ],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ArgumentPriorityRequest"}}}},
-        "responses": {
-          "200": {"description": "Priority state stored", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ArgumentPriorityResponse"}}}},
-          "400": {"description": "Invalid selection state", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Authentication required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "403": {"description": "Access denied", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "404": {"description": "Conversation or argument not found/available", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "409": {"description": "Contribution gate, volume gate, budget, or phase conflict", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/conversations/{slug}/flags": {
-      "post": {
-        "operationId": "createContentFlag",
-        "summary": "Flag a statement or argument for moderator review",
-        "description": "Idempotent for the same participant, target, and category while a flag remains open. Other requires an explanation.",
-        "parameters": [
-          {"name": "slug", "in": "path", "required": true, "schema": {"type": "string", "minLength": 1}}
-        ],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CreateContentFlagRequest"}}}},
-        "responses": {
-          "200": {"description": "Existing open flag returned", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ContentFlagResponse"}}}},
-          "201": {"description": "Flag created", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ContentFlagResponse"}}}},
-          "400": {"description": "Invalid target, category, or missing Other explanation", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Authentication required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "403": {"description": "Access denied", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "404": {"description": "Conversation or target not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "409": {"description": "Participation missing or flags closed", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "502": {"description": "Statement validation service unavailable", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/conversations/{slug}/statements/{statementId}/vote": {
-      "put": {
-        "operationId": "putExploreVote",
-        "summary": "Set the participant's vote on an Explore statement",
-        "description": "Idempotent: repeated PUT requests replace the vote with the requested choice.",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "schema": {"type": "string", "minLength": 1}
-          },
-          {
-            "name": "statementId",
-            "in": "path",
-            "required": true,
-            "schema": {"type": "integer", "minimum": 0}
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {"$ref": "#/components/schemas/ExploreVoteRequest"}
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Vote stored",
-            "content": {
-              "application/json": {
-                "schema": {"$ref": "#/components/schemas/ExploreVoteResponse"}
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid vote choice",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "403": {
-            "description": "Conversation access denied or participant banned",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "404": {
-            "description": "Conversation or statement not found",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "409": {
-            "description": "Participation or Explore phase is not active",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "502": {
-            "description": "Voting service unavailable",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          }
-        }
-      }
-    },
-    "/conversations/{slug}/statements": {
-      "post": {
-        "operationId": "createStatement",
-        "summary": "Submit a new or derivative statement during Explore",
-        "description": "A durable idempotency receipt prevents duplicate upstream statements. Reusing a completed key with the same body returns HTTP 200; a pending receipt reports an unknown outcome.",
-        "parameters": [
-          {
-            "name": "slug",
-            "in": "path",
-            "required": true,
-            "schema": {"type": "string", "minLength": 1}
-          },
-          {
-            "name": "Idempotency-Key",
-            "in": "header",
-            "required": true,
-            "schema": {"type": "string", "minLength": 8, "maxLength": 128, "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$"}
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {"$ref": "#/components/schemas/CreateStatementRequest"}
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Completed command replay",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/StatementCreationResponse"}}}
-          },
-          "201": {
-            "description": "Statement created",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/StatementCreationResponse"}}}
-          },
-          "400": {
-            "description": "Invalid request, idempotency key, or parent statement",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "401": {
-            "description": "Authentication required",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "403": {
-            "description": "Conversation access denied or participant banned",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "409": {
-            "description": "Quota, derivative similarity, idempotency conflict, or unknown outcome",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "502": {
-            "description": "The upstream command outcome is unknown",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          }
-        }
-      }
-    },
-    "/admin/conversations/{conversationId}/participants": {
-      "parameters": [
-        {
-          "name": "conversationId",
-          "in": "path",
-          "required": true,
-          "schema": {"type": "integer", "minimum": 1}
-        }
-      ],
-      "get": {
-        "operationId": "getAdminConversationParticipants",
-        "summary": "Return the authorized participant engagement roster",
-        "responses": {
-          "200": {
-            "description": "Participant roster",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminParticipantRosterResponse"}}}
-          },
-          "403": {
-            "description": "Conversation moderation permission required",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "404": {
-            "description": "Conversation not found",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          }
-        }
-      }
-    },
-    "/admin/conversations/{conversationId}/participants/{participantId}/access": {
-      "parameters": [
-        {
-          "name": "conversationId",
-          "in": "path",
-          "required": true,
-          "schema": {"type": "integer", "minimum": 1}
-        },
-        {
-          "name": "participantId",
-          "in": "path",
-          "required": true,
-          "schema": {"type": "integer", "minimum": 1}
-        }
-      ],
-      "put": {
-        "operationId": "putAdminParticipantAccess",
-        "summary": "Set whether a participant is banned from one conversation",
-        "requestBody": {
-          "required": true,
-          "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminParticipantAccessRequest"}}}
-        },
-        "responses": {
-          "200": {
-            "description": "Current participant access state",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminParticipantAccessResponse"}}}
-          },
-          "400": {
-            "description": "Invalid desired access state",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "403": {
-            "description": "Conversation moderation permission required",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          },
-          "404": {
-            "description": "Conversation or participant membership not found",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          }
-        }
-      }
-    },
-    "/admin/conversations/{conversationId}/flags": {
-      "parameters": [{
-        "name": "conversationId", "in": "path", "required": true,
-        "schema": {"type": "integer", "minimum": 1}
-      }],
-      "get": {
-        "operationId": "getAdminConversationFlags",
-        "summary": "Return the privacy-safe moderation queue",
-        "responses": {
-          "200": {
-            "description": "Moderation queue",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminFlagQueueResponse"}}}
-          },
-          "403": {
-            "description": "Conversation moderation permission required",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
-          }
-        }
-      }
-    },
-    "/admin/conversations/{conversationId}/flags/{flagId}/resolution": {
-      "parameters": [
-        {"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}},
-        {"name": "flagId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}
-      ],
-      "put": {
-        "operationId": "putAdminFlagResolution",
-        "summary": "Resolve one content flag",
-        "requestBody": {
-          "required": true,
-          "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminFlagResolutionRequest"}}}
-        },
-        "responses": {
-          "200": {
-            "description": "Current resolution state",
-            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminFlagResolutionResponse"}}}
-          },
-          "400": {"description": "Invalid resolution", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "403": {"description": "Conversation moderation permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "404": {"description": "Conversation or flag not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/admin/conversations/{conversationId}/invitations": {
-      "parameters": [{"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "get": {
-        "operationId": "getAdminConversationInvitations", "summary": "Return the invitation roster and access policy",
-        "responses": {
-          "200": {"description": "Invitation roster", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminInvitationRosterResponse"}}}},
-          "403": {"description": "Conversation moderation permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      },
-      "put": {
-        "operationId": "putAdminConversationInvitations", "summary": "Add a batch of invitations idempotently",
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminInvitationBatchRequest"}}}},
-        "responses": {
-          "200": {"description": "Batch outcome and refreshed roster", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminInvitationBatchResponse"}}}},
-          "400": {"description": "Invalid usernames", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "403": {"description": "Conversation moderation permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "503": {"description": "Invitations could not be saved atomically", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/admin/conversations/{conversationId}/invitations/{inviteId}": {
-      "parameters": [
-        {"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}},
-        {"name": "inviteId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}
-      ],
-      "delete": {
-        "operationId": "deleteAdminConversationInvitation", "summary": "Remove one invitation",
-        "responses": {
-          "200": {"description": "Removal receipt and refreshed roster", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminInvitationRemovalResponse"}}}},
-          "403": {"description": "Conversation moderation permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "404": {"description": "Conversation or invitation not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/admin/conversations/{conversationId}/roles": {
-      "parameters": [{"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "get": {
-        "operationId": "getAdminConversationRoles", "summary": "Return scoped role assignments and authorized candidates",
-        "responses": {
-          "200": {"description": "Role roster", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminRoleRosterResponse"}}}},
-          "403": {"description": "Conversation moderation permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/admin/conversations/{conversationId}/roles/{participantId}": {
-      "parameters": [
-        {"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}},
-        {"name": "participantId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}
-      ],
-      "put": {
-        "operationId": "putAdminConversationRoles", "summary": "Replace one participant's scoped role set",
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminRoleSetRequest"}}}},
-        "responses": {
-          "200": {"description": "Role replacement receipt", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminRoleSetResponse"}}}},
-          "400": {"description": "Invalid role set", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "403": {"description": "Global admin permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "404": {"description": "Conversation or participant not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/admin/conversations/{conversationId}": {
-      "parameters": [{"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "get": {
-        "operationId": "getAdminConversationLifecycle", "summary": "Return lifecycle, phase readiness, capabilities, and management links",
-        "responses": {
-          "200": {"description": "Admin lifecycle", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminLifecycleResponse"}}}},
-          "403": {"description": "Conversation moderation permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "404": {"description": "Conversation not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      },
-      "delete": {"operationId": "deleteAdminConversation", "summary": "Delete a verified empty conversation after hiding it upstream", "responses": {
-        "200": {"description": "Deletion receipt", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminDeletionResponse"}}}},
-        "403": {"description": "Global admin permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "404": {"description": "Conversation not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "409": {"description": "Votes block deletion or command outcome is unknown", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "502": {"description": "Voting service hide failed", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "503": {"description": "Vote verification unavailable", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations/{conversationId}/settings": {
-      "parameters": [{"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "get": {"operationId": "getAdminConversationSettings", "summary": "Return editable conversation settings and tool-owned guidance", "responses": {
-        "200": {"description": "Conversation settings", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminSettingsResponse"}}}},
-        "403": {"description": "Conversation moderation permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }},
-      "put": {"operationId": "putAdminConversationSettings", "summary": "Replace editable conversation settings", "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminSettingsRequest"}}}}, "responses": {
-        "200": {"description": "Update receipt and refreshed settings", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminSettingsUpdateResponse"}}}},
-        "400": {"description": "Invalid settings", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "403": {"description": "Organizer permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations/{conversationId}/recommendation-tier": {
-      "parameters": [{"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "put": {"operationId": "putAdminConversationRecommendationTier", "summary": "Set the advisory recommendation tier", "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminRecommendationTierRequest"}}}}, "responses": {
-        "200": {"description": "Update receipt and refreshed recommendations", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminRecommendationTierResponse"}}}},
-        "400": {"description": "Invalid recommendation tier", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "403": {"description": "Organizer permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations/{conversationId}/statements": {
-      "parameters": [{"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "get": {"operationId": "getAdminConversationStatements", "summary": "Return the privacy-safe statement moderation workspace", "responses": {
-        "200": {"description": "Statement workspace", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminStatementWorkspaceResponse"}}}},
-        "403": {"description": "Conversation moderation permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "404": {"description": "Conversation not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }},
-      "post": {"operationId": "postAdminSeedStatement", "summary": "Add one approved seed statement with optional correction provenance", "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminSeedStatementRequest"}}}}, "responses": {
-        "201": {"description": "Seed statement receipt", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminSeedStatementResponse"}}}},
-        "400": {"description": "Invalid or locked seed statement", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "403": {"description": "Conversation moderation permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "404": {"description": "Conversation or corrected statement not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "502": {"description": "Statement service unavailable", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations/{conversationId}/statement-moderation-policy": {
-      "parameters": [{"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "put": {"operationId": "putAdminStatementModerationPolicy", "summary": "Set the default decision for future statements without reinterpreting existing statements", "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminStatementModerationPolicyRequest"}}}}, "responses": {
-        "200": {"description": "Policy receipt and refreshed statement workspace", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminStatementModerationPolicyResponse"}}}},
-        "400": {"description": "Invalid policy", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "403": {"description": "Conversation moderation permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "409": {"description": "Upstream outcome may be unknown", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "502": {"description": "Moderation baseline reconciliation failed", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "503": {"description": "Current state could not be verified or saved", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations/{conversationId}/statements/{statementId}/moderation": {
-      "parameters": [
-        {"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}},
-        {"name": "statementId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 0}}
-      ],
-      "put": {"operationId": "putAdminStatementModeration", "summary": "Replace one statement's moderation state", "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminStatementModerationRequest"}}}}, "responses": {
-        "200": {"description": "Moderation receipt and refreshed workspace", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminStatementModerationResponse"}}}},
-        "400": {"description": "Invalid moderation state", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "403": {"description": "Conversation moderation permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "404": {"description": "Conversation or statement not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "409": {"description": "Last featured statement is protected during argument mapping", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "502": {"description": "Statement service unavailable", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations/{conversationId}/statement-imports": {
-      "parameters": [{"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "post": {"operationId": "postAdminStatementImport", "summary": "Import approved seed statements after validation and deduplication", "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminStatementImportRequest"}}}}, "responses": {
-        "200": {"description": "Import outcome", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminStatementImportResponse"}}}},
-        "400": {"description": "Invalid import", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "403": {"description": "Conversation moderation permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "503": {"description": "Existing statements could not be verified", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "502": {"description": "Statement service unavailable", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations/{conversationId}/featured-statements": {
-      "parameters": [{"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "get": {"operationId": "getAdminFeaturedStatements", "summary": "Return selected statements, transparent candidate metrics, and argument moderation state", "responses": {
-        "200": {"description": "Featured workspace", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminFeaturedWorkspaceResponse"}}}},
-        "403": {"description": "Conversation moderation permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations/{conversationId}/featured-statements/{statementId}": {
-      "parameters": [
-        {"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}},
-        {"name": "statementId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 0}}
-      ],
-      "put": {"operationId": "putAdminFeaturedStatement", "summary": "Idempotently select a verified statement for argument mapping", "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminFeaturedSelectionRequest"}}}}, "responses": {
-        "200": {"description": "Selection receipt", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminFeaturedSelectionResponse"}}}},
-        "400": {"description": "Invalid selection source", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "404": {"description": "Statement not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "409": {"description": "Command outcome unknown", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "502": {"description": "Live round synchronization failed", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "503": {"description": "Statement verification unavailable", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations/{conversationId}/featured-selections/{featuredId}": {
-      "parameters": [
-        {"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}},
-        {"name": "featuredId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}
-      ],
-      "delete": {"operationId": "deleteAdminFeaturedSelection", "summary": "Remove a featured selection and reconcile a live informed-voting round", "responses": {
-        "200": {"description": "Removal receipt", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminFeaturedRemovalResponse"}}}},
-        "404": {"description": "Featured selection not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "409": {"description": "Last selection protected or command outcome unknown", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "502": {"description": "Live round synchronization failed", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations/{conversationId}/featured-arguments/{argumentId}": {
-      "parameters": [
-        {"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}},
-        {"name": "argumentId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}
-      ],
-      "put": {"operationId": "putAdminFeaturedArgument", "summary": "Set whether an argument is hidden", "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminFeaturedArgumentRequest"}}}}, "responses": {
-        "200": {"description": "Argument visibility receipt", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminFeaturedArgumentResponse"}}}},
-        "400": {"description": "Invalid desired visibility", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "404": {"description": "Argument not found in conversation", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }},
-      "delete": {"operationId": "deleteAdminFeaturedArgument", "summary": "Delete an argument and its votes", "responses": {
-        "200": {"description": "Argument deletion receipt", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminFeaturedArgumentDeletionResponse"}}}},
-        "404": {"description": "Argument not found in conversation", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations/{conversationId}/phase": {
-      "parameters": [{"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "put": {
-        "operationId": "putAdminConversationPhase", "summary": "Advance the guided lifecycle after confirming readiness",
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminPhaseAdvanceRequest"}}}},
-        "responses": {
-          "200": {"description": "Transition receipt and refreshed lifecycle", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminPhaseAdvanceResponse"}}}},
-          "400": {"description": "Invalid confirmation payload", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "403": {"description": "Organizer permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "409": {"description": "Readiness, state, concurrency, or unknown-outcome conflict", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "502": {"description": "The next phase could not be prepared upstream", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "503": {"description": "The phase transition could not be saved", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
-      }
-    },
-    "/admin/conversations/{conversationId}/phases": {
-      "parameters": [{"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "put": {"operationId": "putAdminConversationPhases", "summary": "Replace the advanced route-valid phase set", "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminAdvancedPhasesRequest"}}}}, "responses": {
-        "200": {"description": "Phase-set receipt and refreshed lifecycle", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminAdvancedPhasesResponse"}}}},
-        "400": {"description": "Invalid or out-of-route phase key", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "403": {"description": "Global admin permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations/{conversationId}/phase6-initialization": {
-      "parameters": [{"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "post": {"operationId": "createAdminPhase6Initialization", "summary": "Initialize the dedicated informed-voting round", "responses": {
-        "201": {"description": "Initialization receipt and refreshed lifecycle", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminPhase6InitializationResponse"}}}},
-        "403": {"description": "Conversation moderation permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "409": {"description": "State, concurrency, or unknown-outcome conflict", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "502": {"description": "The informed-voting round could not be prepared upstream", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations/{conversationId}/pause": {
-      "parameters": [{"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "put": {"operationId": "putAdminConversationPause", "summary": "Set the desired pause state", "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminPauseRequest"}}}}, "responses": {
-        "200": {"description": "Pause receipt and refreshed lifecycle", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminPauseResponse"}}}},
-        "400": {"description": "Invalid state", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "403": {"description": "Global admin permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "409": {"description": "Conversation closed", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations/{conversationId}/archive": {
-      "parameters": [{"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "put": {"operationId": "putAdminConversationArchive", "summary": "Set reversible archive state without publishing", "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminArchiveRequest"}}}}, "responses": {
-        "200": {"description": "Archive receipt and refreshed lifecycle", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminArchiveResponse"}}}},
-        "400": {"description": "Invalid desired state", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "403": {"description": "Global admin permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "409": {"description": "Published conversations cannot be archived", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations/{conversationId}/schedule": {
-      "parameters": [{"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "put": {"operationId": "putAdminConversationSchedule", "summary": "Replace or cancel the pending phase schedule", "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminScheduleRequest"}}}}, "responses": {
-        "200": {"description": "Schedule receipt and refreshed lifecycle", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminScheduleResponse"}}}},
-        "400": {"description": "Invalid or past date-time", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "403": {"description": "Global admin permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "409": {"description": "The current transition cannot be scheduled", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/admin/conversations/{conversationId}/publication": {
-      "parameters": [{"name": "conversationId", "in": "path", "required": true, "schema": {"type": "integer", "minimum": 1}}],
-      "post": {"operationId": "createAdminConversationPublication", "summary": "Irreversibly publish the frozen final report", "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminPublicationRequest"}}}}, "responses": {
-        "201": {"description": "Published lifecycle", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AdminPublicationResponse"}}}},
-        "400": {"description": "Invalid confirmations", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "403": {"description": "Global admin permission required", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-        "409": {"description": "Publication state or readiness conflict", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-      }}
-    },
-    "/openapi.json": {
-      "get": {
-        "operationId": "getOpenApiDocument",
-        "summary": "Return this OpenAPI document",
-        "responses": {
-          "200": {"description": "OpenAPI 3.1 document"}
-        }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "AdminCatalogResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"$ref": "#/components/schemas/AdminCatalog"}}},
-      "AdminCatalog": {"type": "object", "required": ["conversations", "globalAdmins", "phaseRoutes", "creation", "links"], "additionalProperties": false, "properties": {
-        "conversations": {"type": "array", "items": {"type": "object", "required": ["id", "slug", "title", "accessPolicy", "status", "createdAt", "links"], "additionalProperties": false, "properties": {"id": {"type": "integer", "minimum": 1}, "slug": {"type": "string"}, "title": {"type": "string"}, "accessPolicy": {"type": "string", "enum": ["public", "invite_only", "demo"]}, "status": {"type": "string", "enum": ["active", "paused", "archived", "closed"]}, "createdAt": {"type": ["string", "null"], "format": "date-time"}, "links": {"type": "object", "required": ["participant", "manage"], "additionalProperties": false, "properties": {"participant": {"type": "string"}, "manage": {"type": "string"}}}}}},
-        "globalAdmins": {"type": "array", "items": {"type": "object", "required": ["participantId", "username"], "additionalProperties": false, "properties": {"participantId": {"type": "integer", "minimum": 1}, "username": {"type": "string"}}}},
-        "phaseRoutes": {"type": "array", "items": {"type": "object", "required": ["key", "label", "description"], "additionalProperties": false, "properties": {"key": {"type": "string"}, "label": {"type": "string"}, "description": {"type": "string"}}}},
-        "creation": {"type": "object", "required": ["mode", "defaultModerationPolicy"], "additionalProperties": false, "properties": {"mode": {"type": "string", "enum": ["managed", "manual_polis_id"]}, "defaultModerationPolicy": {"type": "string", "const": "moderate"}}},
-        "links": {"type": "object", "required": ["self"], "additionalProperties": false, "properties": {"self": {"type": "string"}}}
-      }},
-      "AdminConversationCreateRequest": {"type": "object", "required": ["slug", "title", "introHtml", "outroHtml", "accessPolicy", "phaseRoute", "eligibilityEventId", "eligibilityLabel", "polisId"], "additionalProperties": false, "properties": {"slug": {"type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$", "maxLength": 80}, "title": {"type": "string", "minLength": 1, "maxLength": 255}, "introHtml": {"type": "string"}, "outroHtml": {"type": "string"}, "accessPolicy": {"type": "string", "enum": ["public", "invite_only", "demo"]}, "phaseRoute": {"type": "string", "minLength": 1}, "eligibilityEventId": {"type": "string", "maxLength": 80}, "eligibilityLabel": {"type": "string", "maxLength": 255}, "polisId": {"type": ["string", "null"]}}},
-      "AdminConversationCreateResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["conversation", "links"], "additionalProperties": false, "properties": {"conversation": {"type": "object", "required": ["id", "slug", "title"], "additionalProperties": false, "properties": {"id": {"type": "integer", "minimum": 1}, "slug": {"type": "string"}, "title": {"type": "string"}}}, "links": {"type": "object", "required": ["manage", "catalog"], "additionalProperties": false, "properties": {"manage": {"type": "string"}, "catalog": {"type": "string"}}}}}}},
-      "GlobalAdminGrantRequest": {"type": "object", "required": ["username"], "additionalProperties": false, "properties": {"username": {"type": "string", "minLength": 1, "maxLength": 255}}},
-      "GlobalAdminSetRequest": {"type": "object", "required": ["granted"], "additionalProperties": false, "properties": {"granted": {"type": "boolean"}}},
-      "GlobalAdminGrantResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["participantId", "username", "granted", "changed", "catalog"], "additionalProperties": false, "properties": {"participantId": {"type": "integer", "minimum": 1}, "username": {"type": "string"}, "granted": {"type": "boolean"}, "changed": {"type": "boolean"}, "catalog": {"$ref": "#/components/schemas/AdminCatalog"}}}}},
-      "AdminTerminationResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"$ref": "#/components/schemas/AdminTermination"}}},
-      "AdminTermination": {"type": "object", "required": ["conversation", "deletion", "links"], "additionalProperties": false, "properties": {
-        "conversation": {"type": "object", "required": ["id", "slug", "title"], "additionalProperties": false, "properties": {"id": {"type": "integer", "minimum": 1}, "slug": {"type": "string"}, "title": {"type": "string"}}},
-        "deletion": {"type": "object", "required": ["state", "validVoteCount", "reason"], "additionalProperties": false, "properties": {"state": {"type": "string", "enum": ["eligible", "blocked_by_votes", "unavailable"]}, "validVoteCount": {"type": ["integer", "null"], "minimum": 0}, "reason": {"type": "string"}}},
-        "links": {"type": "object", "required": ["self", "lifecycle"], "additionalProperties": false, "properties": {"self": {"type": "string"}, "lifecycle": {"type": "string"}}}
-      }},
-      "AdminDeletionResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["conversationId", "deleted", "links"], "additionalProperties": false, "properties": {"conversationId": {"type": "integer", "minimum": 1}, "deleted": {"type": "boolean", "const": true}, "links": {"type": "object", "required": ["admin"], "additionalProperties": false, "properties": {"admin": {"type": "string"}}}}}}},
-      "AdminStatementWorkspaceResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"$ref": "#/components/schemas/AdminStatementWorkspace"}}},
-      "AdminStatementModerationPolicyRequest": {"type": "object", "required": ["mode"], "additionalProperties": false, "properties": {"mode": {"type": "string", "enum": ["moderate", "auto_approve"]}}},
-      "AdminStatementModerationPolicyResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["mode", "changed", "reconciledStatements", "workspace"], "additionalProperties": false, "properties": {"mode": {"type": "string", "enum": ["moderate", "auto_approve"]}, "changed": {"type": "boolean"}, "reconciledStatements": {"type": "integer", "minimum": 0}, "workspace": {"$ref": "#/components/schemas/AdminStatementWorkspace"}}}}},
-      "AdminStatementModerationRequest": {"type": "object", "required": ["status"], "additionalProperties": false, "properties": {"status": {"type": "string", "enum": ["approved", "pending", "hidden"]}}},
-      "AdminStatementModerationResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["statementId", "status", "links"], "additionalProperties": false, "properties": {"statementId": {"type": "integer", "minimum": 0}, "status": {"type": "string", "enum": ["approved", "pending", "hidden"]}, "links": {"type": "object", "required": ["statements"], "additionalProperties": false, "properties": {"statements": {"type": "string"}}}}}}},
-      "AdminSeedStatementRequest": {"type": "object", "required": ["text", "derivedFromId"], "additionalProperties": false, "properties": {"text": {"type": "string", "minLength": 1, "maxLength": 280}, "derivedFromId": {"type": ["integer", "null"], "minimum": 0}}},
-      "AdminSeedStatementResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["statementId", "derivedFromId", "provenanceRecorded", "links"], "additionalProperties": false, "properties": {"statementId": {"type": ["integer", "null"], "minimum": 0}, "derivedFromId": {"type": ["integer", "null"], "minimum": 0}, "provenanceRecorded": {"type": ["boolean", "null"]}, "links": {"type": "object", "required": ["statements"], "additionalProperties": false, "properties": {"statements": {"type": "string"}}}}}}},
-      "AdminStatementImportRequest": {"type": "object", "required": ["statements"], "additionalProperties": false, "properties": {"statements": {"type": "array", "minItems": 1, "maxItems": 20, "items": {"type": "string", "maxLength": 280}}}},
-      "AdminStatementImportResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["outcome", "links"], "additionalProperties": false, "properties": {
-        "outcome": {"type": "object", "required": ["imported", "skippedExisting", "skippedDuplicateInput", "failedUpstream"], "additionalProperties": false, "properties": {"imported": {"type": "integer", "minimum": 0}, "skippedExisting": {"type": "integer", "minimum": 0}, "skippedDuplicateInput": {"type": "integer", "minimum": 0}, "failedUpstream": {"type": "integer", "minimum": 0}}},
-        "links": {"type": "object", "required": ["statements"], "additionalProperties": false, "properties": {"statements": {"type": "string"}}}
-      }}}},
-      "AdminFeaturedWorkspaceResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"$ref": "#/components/schemas/AdminFeaturedWorkspace"}}},
-      "AdminFeaturedSelectionRequest": {"type": "object", "required": ["source"], "additionalProperties": false, "properties": {"source": {"type": "string", "enum": ["system", "manual"]}}},
-      "AdminFeaturedSelectionResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["featuredId", "statementId", "changed", "links"], "additionalProperties": false, "properties": {"featuredId": {"type": "integer", "minimum": 1}, "statementId": {"type": "integer", "minimum": 0}, "changed": {"type": "boolean"}, "links": {"type": "object", "required": ["featured"], "additionalProperties": false, "properties": {"featured": {"type": "string"}}}}}}},
-      "AdminFeaturedRemovalResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["featuredId", "statementId", "removed", "links"], "additionalProperties": false, "properties": {"featuredId": {"type": "integer", "minimum": 1}, "statementId": {"type": "integer", "minimum": 0}, "removed": {"type": "boolean", "const": true}, "links": {"type": "object", "required": ["featured"], "additionalProperties": false, "properties": {"featured": {"type": "string"}}}}}}},
-      "AdminFeaturedArgumentRequest": {"type": "object", "required": ["hidden"], "additionalProperties": false, "properties": {"hidden": {"type": "boolean"}}},
-      "AdminFeaturedArgumentResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["argumentId", "hidden", "changed", "links"], "additionalProperties": false, "properties": {"argumentId": {"type": "integer", "minimum": 1}, "hidden": {"type": "boolean"}, "changed": {"type": "boolean"}, "links": {"type": "object", "required": ["featured"], "additionalProperties": false, "properties": {"featured": {"type": "string"}}}}}}},
-      "AdminFeaturedArgumentDeletionResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["argumentId", "featuredId", "deleted", "links"], "additionalProperties": false, "properties": {"argumentId": {"type": "integer", "minimum": 1}, "featuredId": {"type": "integer", "minimum": 1}, "deleted": {"type": "boolean", "const": true}, "links": {"type": "object", "required": ["featured"], "additionalProperties": false, "properties": {"featured": {"type": "string"}}}}}}},
-      "AdminFeaturedWorkspace": {"type": "object", "required": ["conversation", "selected", "candidates", "dataAvailability", "phase", "guidance", "capabilities", "links"], "additionalProperties": false, "properties": {
-        "conversation": {"type": "object", "required": ["id", "slug", "title"], "additionalProperties": false, "properties": {"id": {"type": "integer", "minimum": 1}, "slug": {"type": "string"}, "title": {"type": "string"}}},
-        "selected": {"type": "array", "items": {"$ref": "#/components/schemas/AdminFeaturedSelection"}},
-        "candidates": {"type": "array", "items": {"$ref": "#/components/schemas/AdminFeaturedCandidate"}},
-        "dataAvailability": {"type": "object", "required": ["candidates"], "additionalProperties": false, "properties": {"candidates": {"type": "boolean"}}},
-        "phase": {"type": "object", "required": ["argumentMappingActive", "informedVotingLive"], "additionalProperties": false, "properties": {"argumentMappingActive": {"type": "boolean"}, "informedVotingLive": {"type": "boolean"}}},
-        "guidance": {"type": "object", "required": ["recommendedCount", "note"], "additionalProperties": false, "properties": {"recommendedCount": {"type": "integer", "minimum": 1}, "note": {"type": "string"}}},
-        "capabilities": {"type": "object", "required": ["manage"], "additionalProperties": false, "properties": {"manage": {"type": "boolean"}}},
-        "links": {"type": "object", "required": ["self", "lifecycle"], "additionalProperties": false, "properties": {"self": {"type": "string"}, "lifecycle": {"type": "string"}}}
-      }},
-      "AdminFeaturedSelection": {"type": "object", "required": ["featuredId", "statementId", "text", "systemSuggested", "provenance", "arguments"], "additionalProperties": false, "properties": {
-        "featuredId": {"type": "integer", "minimum": 1}, "statementId": {"type": "integer", "minimum": 0}, "text": {"type": ["string", "null"]}, "systemSuggested": {"type": "boolean"}, "provenance": {"oneOf": [{"type": "null"}, {"$ref": "#/components/schemas/AdminStatementProvenance"}]},
-        "arguments": {"type": "array", "items": {"type": "object", "required": ["id", "side", "body", "proposerPseudonym", "hidden", "createdAt"], "additionalProperties": false, "properties": {"id": {"type": "integer", "minimum": 1}, "side": {"type": "string", "enum": ["pro", "con"]}, "body": {"type": "string"}, "proposerPseudonym": {"type": ["string", "null"]}, "hidden": {"type": "boolean"}, "createdAt": {"type": ["string", "null"], "format": "date-time"}}}}
-      }},
-      "AdminFeaturedCandidate": {"type": "object", "required": ["statementId", "text", "seed", "votes", "provenance"], "additionalProperties": false, "properties": {
-        "statementId": {"type": "integer", "minimum": 0}, "text": {"type": "string"}, "seed": {"type": "boolean"}, "provenance": {"oneOf": [{"type": "null"}, {"$ref": "#/components/schemas/AdminStatementProvenance"}]},
-        "votes": {"type": "object", "required": ["agree", "pass", "disagree", "total", "agreementPercent"], "additionalProperties": false, "properties": {"agree": {"type": "integer", "minimum": 0}, "pass": {"type": "integer", "minimum": 0}, "disagree": {"type": "integer", "minimum": 0}, "total": {"type": "integer", "minimum": 0}, "agreementPercent": {"type": ["number", "null"], "minimum": 0, "maximum": 100}}}
-      }},
-      "AdminStatementProvenance": {"type": "object", "required": ["derivedFromId", "scores"], "additionalProperties": false, "properties": {"derivedFromId": {"type": "integer", "minimum": 0}, "scores": {"type": "array", "items": {"type": "object", "required": ["model", "value"], "additionalProperties": false, "properties": {"model": {"type": "string"}, "value": {"type": "number", "minimum": 0, "maximum": 1}}}}}},
-      "AdminStatementWorkspace": {"type": "object", "required": ["conversation", "statements", "moderationPolicy", "dataAvailability", "seeding", "capabilities", "links"], "additionalProperties": false, "properties": {
-        "conversation": {"type": "object", "required": ["id", "slug", "title"], "additionalProperties": false, "properties": {"id": {"type": "integer", "minimum": 1}, "slug": {"type": "string"}, "title": {"type": "string"}}},
-        "statements": {"type": "object", "required": ["pending", "approved", "hidden"], "additionalProperties": false, "properties": {"pending": {"type": "array", "items": {"$ref": "#/components/schemas/AdminStatement"}}, "approved": {"type": "array", "items": {"$ref": "#/components/schemas/AdminStatement"}}, "hidden": {"type": "array", "items": {"$ref": "#/components/schemas/AdminStatement"}}}},
-        "moderationPolicy": {"type": "object", "required": ["mode", "newStatements", "available"], "additionalProperties": false, "properties": {"mode": {"type": ["string", "null"], "enum": ["moderate", "auto_approve", null]}, "newStatements": {"type": ["string", "null"], "enum": ["pending", "approved", null]}, "available": {"type": "boolean"}}},
-        "dataAvailability": {"type": "object", "required": ["statements"], "additionalProperties": false, "properties": {"statements": {"type": "boolean"}}},
-        "seeding": {"type": "object", "required": ["allowed", "lockReason", "maxStatementsPerImport", "maxCharactersPerStatement"], "additionalProperties": false, "properties": {"allowed": {"type": "boolean"}, "lockReason": {"type": ["string", "null"]}, "maxStatementsPerImport": {"type": "integer", "minimum": 1}, "maxCharactersPerStatement": {"type": "integer", "minimum": 1}}},
-        "capabilities": {"type": "object", "required": ["moderate", "seed"], "additionalProperties": false, "properties": {"moderate": {"type": "boolean"}, "seed": {"type": "boolean"}}},
-        "links": {"type": "object", "required": ["self", "lifecycle"], "additionalProperties": false, "properties": {"self": {"type": "string"}, "lifecycle": {"type": "string"}}}
-      }},
-      "AdminStatement": {"type": "object", "required": ["id", "text", "moderation", "seed", "featured", "votes", "provenance"], "additionalProperties": false, "properties": {
-        "id": {"type": "integer", "minimum": 0}, "text": {"type": "string"}, "moderation": {"type": "string", "enum": ["approved", "pending", "hidden"]}, "seed": {"type": "boolean"}, "featured": {"type": "boolean"},
-        "votes": {"type": "object", "required": ["agree", "pass", "disagree"], "additionalProperties": false, "properties": {"agree": {"type": "integer", "minimum": 0}, "pass": {"type": "integer", "minimum": 0}, "disagree": {"type": "integer", "minimum": 0}}},
-        "provenance": {"oneOf": [{"type": "null"}, {"type": "object", "required": ["derivedFromId", "scores"], "additionalProperties": false, "properties": {"derivedFromId": {"type": "integer", "minimum": 0}, "scores": {"type": "array", "items": {"type": "object", "required": ["model", "value"], "additionalProperties": false, "properties": {"model": {"type": "string"}, "value": {"type": "number", "minimum": 0, "maximum": 1}}}}}}]}
-      }},
-      "AdminSettingsResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"$ref": "#/components/schemas/AdminSettings"}}},
-      "AdminSettingsRequest": {"type": "object", "required": ["title", "introHtml", "outroHtml", "accessPolicy", "eligibilityEventId", "eligibilityLabel", "recommendationTier"], "additionalProperties": false, "properties": {
-        "title": {"type": "string", "minLength": 1, "maxLength": 255}, "introHtml": {"type": "string"}, "outroHtml": {"type": "string"},
-        "accessPolicy": {"type": "string", "enum": ["public", "invite_only", "demo"]}, "eligibilityEventId": {"type": "string", "maxLength": 80}, "eligibilityLabel": {"type": "string", "maxLength": 255}, "recommendationTier": {"type": "string", "enum": ["simple", "medium", "complex"]}
-      }},
-      "AdminSettingsUpdateResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["changed", "changedFields", "settings"], "additionalProperties": false, "properties": {"changed": {"type": "boolean"}, "changedFields": {"type": "array", "items": {"type": "string"}, "uniqueItems": true}, "settings": {"$ref": "#/components/schemas/AdminSettings"}}}}},
-      "AdminRecommendationTierRequest": {"type": "object", "required": ["tier"], "additionalProperties": false, "properties": {"tier": {"type": "string", "enum": ["simple", "medium", "complex"]}}},
-      "AdminRecommendationTierResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["changed", "recommendations"], "additionalProperties": false, "properties": {"changed": {"type": "boolean"}, "recommendations": {"$ref": "#/components/schemas/AdminRecommendations"}}}}},
-      "AdminSettings": {"type": "object", "required": ["conversation", "recommendations", "eligibility", "capabilities", "links"], "additionalProperties": false, "properties": {
-        "conversation": {"type": "object", "required": ["id", "slug", "title", "introHtml", "outroHtml", "accessPolicy", "phaseRoute", "phaseRouteLabel", "polisId"], "additionalProperties": false, "properties": {"id": {"type": "integer", "minimum": 1}, "slug": {"type": "string"}, "title": {"type": "string"}, "introHtml": {"type": "string"}, "outroHtml": {"type": "string"}, "accessPolicy": {"type": "string", "enum": ["public", "invite_only", "demo"]}, "phaseRoute": {"type": "string"}, "phaseRouteLabel": {"type": "string"}, "polisId": {"type": "string"}}},
-        "recommendations": {"$ref": "#/components/schemas/AdminRecommendations"},
-        "eligibility": {"type": "object", "required": ["configured", "eventId", "label", "configurationMode", "note"], "additionalProperties": false, "properties": {"configured": {"type": "boolean"}, "eventId": {"type": "string"}, "label": {"type": ["string", "null"]}, "configurationMode": {"type": "string", "const": "editable"}, "note": {"type": "string"}}},
-        "capabilities": {"type": "object", "required": ["edit"], "additionalProperties": false, "properties": {"edit": {"type": "boolean"}}},
-        "links": {"type": "object", "required": ["self", "lifecycle"], "additionalProperties": false, "properties": {"self": {"type": "string"}, "lifecycle": {"type": "string"}}}
-      }},
-      "AdminRecommendations": {"type": "object", "required": ["tier", "tiers"], "additionalProperties": false, "properties": {"tier": {"type": "string", "enum": ["simple", "medium", "complex"]}, "tiers": {"type": "array", "items": {"type": "object", "required": ["key", "label", "quantities"], "additionalProperties": false, "properties": {"key": {"type": "string", "enum": ["simple", "medium", "complex"]}, "label": {"type": "string"}, "quantities": {"type": "object", "additionalProperties": {"type": "integer", "minimum": 1}}}}}}},
-      "AdminLifecycleResponse": {
-        "type": "object", "required": ["data"], "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/AdminLifecycle"}}
-      },
-      "AdminPhaseAdvanceRequest": {
-        "type": "object", "required": ["confirmedPreconditionIds"], "additionalProperties": false,
-        "properties": {"confirmedPreconditionIds": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true}}
-      },
-      "AdminAdvancedPhasesRequest": {"type": "object", "required": ["activeKeys"], "additionalProperties": false, "properties": {"activeKeys": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true}}},
-      "AdminAdvancedPhasesResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["changed", "activeKeys", "visibilitySynced", "lifecycle"], "additionalProperties": false, "properties": {"changed": {"type": "boolean"}, "activeKeys": {"type": "array", "items": {"type": "string"}, "uniqueItems": true}, "visibilitySynced": {"type": "boolean"}, "lifecycle": {"$ref": "#/components/schemas/AdminLifecycle"}}}}},
-      "AdminPhase6InitializationResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["initialized", "lifecycle"], "additionalProperties": false, "properties": {"initialized": {"type": "boolean", "const": true}, "lifecycle": {"$ref": "#/components/schemas/AdminLifecycle"}}}}},
-      "AdminPauseRequest": {"type": "object", "required": ["paused"], "additionalProperties": false, "properties": {"paused": {"type": "boolean"}}},
-      "AdminPauseResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["paused", "changed", "lifecycle"], "additionalProperties": false, "properties": {"paused": {"type": "boolean"}, "changed": {"type": "boolean"}, "lifecycle": {"$ref": "#/components/schemas/AdminLifecycle"}}}}},
-      "AdminArchiveRequest": {"type": "object", "required": ["archived"], "additionalProperties": false, "properties": {"archived": {"type": "boolean"}}},
-      "AdminArchiveResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["archived", "changed", "lifecycle"], "additionalProperties": false, "properties": {"archived": {"type": "boolean"}, "changed": {"type": "boolean"}, "lifecycle": {"$ref": "#/components/schemas/AdminLifecycle"}}}}},
-      "AdminScheduleRequest": {"type": "object", "required": ["scheduledAt", "frozen"], "additionalProperties": false, "properties": {"scheduledAt": {"type": ["string", "null"], "format": "date-time"}, "frozen": {"type": "boolean"}}},
-      "AdminScheduleResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["changed", "lifecycle"], "additionalProperties": false, "properties": {"changed": {"type": "boolean"}, "lifecycle": {"$ref": "#/components/schemas/AdminLifecycle"}}}}},
-      "AdminPublicationRequest": {"type": "object", "required": ["confirmedPreconditionIds"], "additionalProperties": false, "properties": {"confirmedPreconditionIds": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true}}},
-      "AdminPublicationResponse": {"type": "object", "required": ["data"], "additionalProperties": false, "properties": {"data": {"type": "object", "required": ["lifecycle"], "additionalProperties": false, "properties": {"lifecycle": {"$ref": "#/components/schemas/AdminLifecycle"}}}}},
-      "AdminPhaseAdvanceResponse": {
-        "type": "object", "required": ["data"], "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/AdminPhaseAdvanceReceipt"}}
-      },
-      "AdminPhaseAdvanceReceipt": {
-        "type": "object", "required": ["transition", "lifecycle"], "additionalProperties": false,
-        "properties": {
-          "transition": {"type": "object", "required": ["sourceKey", "targetKey", "targetLabel", "phase6Created", "phase6SyncMessage", "visibilitySynced"], "additionalProperties": false, "properties": {
-            "sourceKey": {"type": "string"}, "targetKey": {"type": "string"}, "targetLabel": {"type": "string"}, "phase6Created": {"type": "boolean"}, "phase6SyncMessage": {"type": ["string", "null"]}, "visibilitySynced": {"type": "boolean"}
-          }},
-          "lifecycle": {"$ref": "#/components/schemas/AdminLifecycle"}
-        }
-      },
-      "AdminLifecycle": {
-        "type": "object", "required": ["conversation", "operator", "phase", "schedule", "publicationReadiness", "statistics", "counts", "capabilities", "links"], "additionalProperties": false,
-        "properties": {
-          "conversation": {"$ref": "#/components/schemas/AdminLifecycleConversation"},
-          "operator": {"type": "object", "required": ["roleLabel"], "additionalProperties": false, "properties": {"roleLabel": {"type": "string"}}},
-          "phase": {"type": "object", "required": ["linear", "currentIndex", "activeKeys", "steps", "transition", "phase6Setup", "advancedControls"], "additionalProperties": false, "properties": {
-            "linear": {"type": "boolean"}, "currentIndex": {"type": "integer", "minimum": 0}, "activeKeys": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-            "steps": {"type": "array", "items": {"$ref": "#/components/schemas/AdminLifecycleStep"}},
-            "transition": {"oneOf": [{"$ref": "#/components/schemas/AdminLifecycleTransition"}, {"type": "null"}]},
-            "phase6Setup": {"oneOf": [{"type": "null"}, {"type": "object", "required": ["polisConversationId", "seededStatementCount", "confirmedStatementCount"], "additionalProperties": false, "properties": {"polisConversationId": {"type": ["string", "null"]}, "seededStatementCount": {"type": "integer", "minimum": 0}, "confirmedStatementCount": {"type": "integer", "minimum": 0}}}]},
-            "advancedControls": {"type": "array", "items": {"type": "object", "required": ["key", "label", "effect", "active", "requiresInitialization", "initialized"], "additionalProperties": false, "properties": {"key": {"type": "string"}, "label": {"type": "string"}, "effect": {"type": "string"}, "active": {"type": "boolean"}, "requiresInitialization": {"type": "boolean"}, "initialized": {"type": "boolean"}}}}
-          }},
-          "schedule": {"type": "object", "required": ["canSchedule", "scheduledAt", "targetKey", "targetLabel", "frozen"], "additionalProperties": false, "properties": {
-            "canSchedule": {"type": "boolean"}, "scheduledAt": {"type": ["string", "null"], "format": "date-time"}, "targetKey": {"type": ["string", "null"]}, "targetLabel": {"type": ["string", "null"]}, "frozen": {"type": "boolean"}
-          }},
-          "publicationReadiness": {"type": "object", "required": ["windowOpen", "preconditions"], "additionalProperties": false, "properties": {
-            "windowOpen": {"type": "boolean"},
-            "preconditions": {"type": "array", "items": {"type": "object", "required": ["id", "label", "met", "note"], "additionalProperties": false, "properties": {"id": {"type": "string"}, "label": {"type": "string"}, "met": {"type": ["boolean", "null"]}, "note": {"type": ["string", "null"]}}}}
-          }},
-          "statistics": {"type": "object", "required": ["upstreamUnavailable", "groups", "informedVoting"], "additionalProperties": false, "properties": {
-            "upstreamUnavailable": {"type": "boolean"},
-            "groups": {"type": "array", "items": {"type": "object", "required": ["key", "label", "tiles"], "additionalProperties": false, "properties": {
-              "key": {"type": "string"}, "label": {"type": "string"},
-              "tiles": {"type": "array", "items": {"type": "object", "required": ["value", "label", "unit", "note"], "additionalProperties": false, "properties": {
-                "value": {"oneOf": [{"type": "integer"}, {"type": "number"}, {"type": "string"}]}, "label": {"type": "string"}, "unit": {"type": ["string", "null"]}, "note": {"type": ["string", "null"]}
-              }}}
-            }}},
-            "informedVoting": {"oneOf": [{"type": "null"}, {"type": "object", "required": ["participants", "statementCount", "largestShift", "excludedStatementCount", "excludedParticipantCount"], "additionalProperties": false, "properties": {
-              "participants": {"type": ["integer", "null"], "minimum": 0}, "statementCount": {"type": "integer", "minimum": 0},
-              "largestShift": {"oneOf": [{"type": "null"}, {"type": "object", "required": ["text", "shift"], "additionalProperties": false, "properties": {"text": {"type": "string"}, "shift": {"type": "number"}}}]},
-              "excludedStatementCount": {"type": "integer", "minimum": 0}, "excludedParticipantCount": {"type": "integer", "minimum": 0}
-            }}]}
-          }},
-          "counts": {"type": "object", "required": ["participants", "invitations", "openFlags", "featuredStatements"], "additionalProperties": false, "properties": {
-            "participants": {"type": "integer", "minimum": 0}, "invitations": {"type": "integer", "minimum": 0}, "openFlags": {"type": "integer", "minimum": 0}, "featuredStatements": {"type": "integer", "minimum": 0}
-          }},
-          "capabilities": {"type": "object", "required": ["advancePhase", "pause", "publish", "editSettings", "useAdvancedPhases", "initializePhase6", "archive"], "additionalProperties": false, "properties": {
-            "advancePhase": {"type": "boolean"}, "pause": {"type": "boolean"}, "publish": {"type": "boolean"}, "editSettings": {"type": "boolean"}, "useAdvancedPhases": {"type": "boolean"}, "initializePhase6": {"type": "boolean"}, "archive": {"type": "boolean"}
-          }},
-          "links": {"type": "object", "required": ["self", "participantView", "participants", "moderation", "invitations", "roles", "statements", "featuredStatements", "settings", "termination"], "additionalProperties": false, "properties": {
-            "self": {"type": "string"}, "participantView": {"type": "string"}, "participants": {"type": "string"}, "moderation": {"type": "string"}, "invitations": {"type": "string"}, "roles": {"type": "string"}, "statements": {"type": "string"}, "featuredStatements": {"type": "string"}, "settings": {"type": "string"}, "termination": {"type": "string"}
-          }}
-        }
-      },
-      "AdminLifecycleConversation": {
-        "type": "object", "required": ["id", "slug", "title", "accessPolicy", "status", "publication", "closedAt", "identityReveal"], "additionalProperties": false,
-        "properties": {"id": {"type": "integer", "minimum": 1}, "slug": {"type": "string"}, "title": {"type": "string"}, "accessPolicy": {"type": "string", "enum": ["public", "invite_only", "demo"]}, "status": {"type": "string", "enum": ["active", "paused", "scheduled", "archived", "closed"]}, "publication": {"type": "string", "enum": ["not_applicable", "pending", "published"]}, "closedAt": {"type": ["string", "null"], "format": "date-time"}, "identityReveal": {"oneOf": [{"type": "null"}, {"type": "object", "required": ["state", "opensAt", "closesAt", "daysLeft"], "additionalProperties": false, "properties": {"state": {"type": "string", "enum": ["pending", "open", "expired"]}, "opensAt": {"type": ["string", "null"], "format": "date-time"}, "closesAt": {"type": ["string", "null"], "format": "date-time"}, "daysLeft": {"type": ["integer", "null"]}}}]}}
-      },
-      "AdminLifecycleStep": {
-        "type": "object", "required": ["key", "label", "effect", "state"], "additionalProperties": false,
-        "properties": {"key": {"type": "string"}, "label": {"type": "string"}, "effect": {"type": "string"}, "state": {"type": "string", "enum": ["completed", "current", "upcoming", "available"]}}
-      },
-      "AdminLifecycleTransition": {
-        "type": "object", "required": ["source", "target", "consequence", "preconditions", "requiresPhase6Initialization", "showPauseGuidance"], "additionalProperties": false,
-        "properties": {
-          "source": {"$ref": "#/components/schemas/AdminLifecyclePhaseRef"}, "target": {"$ref": "#/components/schemas/AdminLifecyclePhaseRef"},
-          "consequence": {"type": "object", "required": ["opens", "closes"], "additionalProperties": false, "properties": {"opens": {"type": "string"}, "closes": {"type": ["string", "null"]}}},
-          "preconditions": {"type": "array", "items": {"type": "object", "required": ["id", "label", "met", "note"], "additionalProperties": false, "properties": {"id": {"type": "string"}, "label": {"type": "string"}, "met": {"type": ["boolean", "null"]}, "note": {"type": ["string", "null"]}}}},
-          "requiresPhase6Initialization": {"type": "boolean"},
-          "showPauseGuidance": {"type": "boolean"}
-        }
-      },
-      "AdminLifecyclePhaseRef": {"type": "object", "required": ["key", "label"], "additionalProperties": false, "properties": {"key": {"type": "string"}, "label": {"type": "string"}}},
-      "AdminRoleRosterResponse": {
-        "type": "object", "required": ["data"], "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/AdminRoleRoster"}}
-      },
-      "AdminRoleRoster": {
-        "type": "object", "required": ["conversation", "assignments", "candidates", "availableRoles", "capabilities", "links"], "additionalProperties": false,
-        "properties": {
-          "conversation": {"type": "object", "required": ["id", "slug", "title"], "additionalProperties": false, "properties": {"id": {"type": "integer", "minimum": 1}, "slug": {"type": "string"}, "title": {"type": "string"}}},
-          "assignments": {"type": "array", "items": {"$ref": "#/components/schemas/AdminRoleAssignment"}},
-          "candidates": {"type": "array", "items": {"$ref": "#/components/schemas/AdminRoleCandidate"}},
-          "availableRoles": {"type": "array", "items": {"type": "string", "enum": ["moderator", "organizer"]}, "uniqueItems": true},
-          "capabilities": {"type": "object", "required": ["manageRoles"], "additionalProperties": false, "properties": {"manageRoles": {"type": "boolean"}}},
-          "links": {"type": "object", "required": ["self", "conversation"], "additionalProperties": false, "properties": {"self": {"type": "string"}, "conversation": {"type": "string"}}}
-        }
-      },
-      "AdminRoleAssignment": {
-        "type": "object", "required": ["participantId", "username", "roles", "grantedAt"], "additionalProperties": false,
-        "properties": {
-          "participantId": {"type": "integer", "minimum": 1}, "username": {"type": "string"},
-          "roles": {"type": "array", "items": {"type": "string", "enum": ["moderator", "organizer"]}, "uniqueItems": true},
-          "grantedAt": {"type": "array", "items": {"type": "string", "format": "date-time"}}
-        }
-      },
-      "AdminRoleCandidate": {
-        "type": "object", "required": ["participantId", "username"], "additionalProperties": false,
-        "properties": {"participantId": {"type": "integer", "minimum": 1}, "username": {"type": "string"}}
-      },
-      "AdminRoleSetRequest": {
-        "type": "object", "required": ["roles"], "additionalProperties": false,
-        "properties": {"roles": {"type": "array", "items": {"type": "string", "enum": ["moderator", "organizer"]}, "uniqueItems": true}}
-      },
-      "AdminRoleSetResponse": {
-        "type": "object", "required": ["data"], "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/AdminRoleSetReceipt"}}
-      },
-      "AdminRoleSetReceipt": {
-        "type": "object", "required": ["participantId", "username", "roles", "changed", "added", "removed", "links"], "additionalProperties": false,
-        "properties": {
-          "participantId": {"type": "integer", "minimum": 1}, "username": {"type": "string"},
-          "roles": {"type": "array", "items": {"type": "string", "enum": ["moderator", "organizer"]}, "uniqueItems": true},
-          "changed": {"type": "boolean"},
-          "added": {"type": "array", "items": {"type": "string", "enum": ["moderator", "organizer"]}, "uniqueItems": true},
-          "removed": {"type": "array", "items": {"type": "string", "enum": ["moderator", "organizer"]}, "uniqueItems": true},
-          "links": {"type": "object", "required": ["roles"], "additionalProperties": false, "properties": {"roles": {"type": "string"}}}
-        }
-      },
-      "AdminInvitationRosterResponse": {
-        "type": "object", "required": ["data"], "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/AdminInvitationRoster"}}
-      },
-      "AdminInvitationRoster": {
-        "type": "object", "required": ["conversation", "invitations", "capabilities", "links"], "additionalProperties": false,
-        "properties": {
-          "conversation": {
-            "type": "object", "required": ["id", "slug", "title", "accessPolicy"], "additionalProperties": false,
-            "properties": {
-              "id": {"type": "integer", "minimum": 1}, "slug": {"type": "string"}, "title": {"type": "string"},
-              "accessPolicy": {"type": "string", "enum": ["public", "invite_only", "demo"]}
-            }
-          },
-          "invitations": {"type": "array", "items": {"$ref": "#/components/schemas/AdminInvitation"}},
-          "capabilities": {"type": "object", "required": ["manageInvitations"], "additionalProperties": false, "properties": {"manageInvitations": {"type": "boolean"}}},
-          "links": {"type": "object", "required": ["self", "conversation"], "additionalProperties": false, "properties": {"self": {"type": "string"}, "conversation": {"type": "string"}}}
-        }
-      },
-      "AdminInvitation": {
-        "type": "object", "required": ["id", "username", "createdAt"], "additionalProperties": false,
-        "properties": {"id": {"type": "integer", "minimum": 1}, "username": {"type": "string"}, "createdAt": {"type": "string", "format": "date-time"}}
-      },
-      "AdminInvitationBatchRequest": {
-        "type": "object", "required": ["usernames"], "additionalProperties": false,
-        "properties": {"usernames": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1, "maxLength": 255}}}
-      },
-      "AdminInvitationBatchResponse": {
-        "type": "object", "required": ["data"], "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/AdminInvitationBatchReceipt"}}
-      },
-      "AdminInvitationBatchReceipt": {
-        "type": "object", "required": ["outcome", "invitations", "links"], "additionalProperties": false,
-        "properties": {
-          "outcome": {
-            "type": "object", "required": ["added", "alreadyPresent", "concurrentConflicts", "duplicateInputs"], "additionalProperties": false,
-            "properties": {
-              "added": {"type": "integer", "minimum": 0}, "alreadyPresent": {"type": "integer", "minimum": 0},
-              "concurrentConflicts": {"type": "integer", "minimum": 0}, "duplicateInputs": {"type": "integer", "minimum": 0}
-            }
-          },
-          "invitations": {"type": "array", "items": {"$ref": "#/components/schemas/AdminInvitation"}},
-          "links": {"type": "object", "required": ["invitations"], "additionalProperties": false, "properties": {"invitations": {"type": "string"}}}
-        }
-      },
-      "AdminInvitationRemovalResponse": {
-        "type": "object", "required": ["data"], "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/AdminInvitationRemovalReceipt"}}
-      },
-      "AdminInvitationRemovalReceipt": {
-        "type": "object", "required": ["invitationId", "removed", "invitations", "links"], "additionalProperties": false,
-        "properties": {
-          "invitationId": {"type": "integer", "minimum": 1}, "removed": {"type": "boolean", "const": true},
-          "invitations": {"type": "array", "items": {"$ref": "#/components/schemas/AdminInvitation"}},
-          "links": {"type": "object", "required": ["invitations"], "additionalProperties": false, "properties": {"invitations": {"type": "string"}}}
-        }
-      },
-      "AdminFlagQueueResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/AdminFlagQueue"}}
-      },
-      "AdminFlagQueue": {
-        "type": "object",
-        "required": ["conversation", "open", "resolved", "dataAvailability", "capabilities", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "conversation": {
-            "type": "object", "required": ["id", "slug", "title"], "additionalProperties": false,
-            "properties": {"id": {"type": "integer", "minimum": 1}, "slug": {"type": "string"}, "title": {"type": "string"}}
-          },
-          "open": {"type": "array", "items": {"$ref": "#/components/schemas/AdminContentFlag"}},
-          "resolved": {"type": "array", "items": {"$ref": "#/components/schemas/AdminContentFlag"}},
-          "dataAvailability": {
-            "type": "object", "required": ["statementText"], "additionalProperties": false,
-            "properties": {"statementText": {"type": "boolean"}}
-          },
-          "capabilities": {
-            "type": "object", "required": ["resolveFlags"], "additionalProperties": false,
-            "properties": {"resolveFlags": {"type": "boolean"}}
-          },
-          "links": {
-            "type": "object", "required": ["self", "conversation"], "additionalProperties": false,
-            "properties": {"self": {"type": "string"}, "conversation": {"type": "string"}}
-          }
-        }
-      },
-      "AdminContentFlag": {
-        "type": "object",
-        "required": ["id", "status", "category", "categoryLabel", "detail", "flaggedAt", "target", "resolution"],
-        "additionalProperties": false,
-        "properties": {
-          "id": {"type": "integer", "minimum": 1},
-          "status": {"type": "string", "enum": ["open", "resolved"]},
-          "category": {"type": "string", "enum": ["personal_attack", "privacy", "off_topic", "other"]},
-          "categoryLabel": {"type": "string"},
-          "detail": {"type": ["string", "null"]},
-          "flaggedAt": {"type": ["string", "null"], "format": "date-time"},
-          "target": {"$ref": "#/components/schemas/AdminFlagTarget"},
-          "resolution": {"oneOf": [{"$ref": "#/components/schemas/AdminFlagResolution"}, {"type": "null"}]}
-        }
-      },
-      "AdminFlagTarget": {
-        "type": "object", "required": ["type", "id", "label", "text", "reviewHref"], "additionalProperties": false,
-        "properties": {
-          "type": {"type": "string", "enum": ["statement", "argument"]},
-          "id": {"type": "integer", "minimum": 0},
-          "label": {"type": "string"},
-          "text": {"type": "string"},
-          "reviewHref": {"type": "string"}
-        }
-      },
-      "AdminFlagResolution": {
-        "type": "object", "required": ["resolvedAt", "note"], "additionalProperties": false,
-        "properties": {
-          "resolvedAt": {"type": ["string", "null"], "format": "date-time"},
-          "note": {"type": ["string", "null"]}
-        }
-      },
-      "AdminFlagResolutionRequest": {
-        "type": "object", "required": ["resolved"], "additionalProperties": false,
-        "properties": {
-          "resolved": {"type": "boolean", "const": true},
-          "note": {"type": ["string", "null"], "maxLength": 1000}
-        }
-      },
-      "AdminFlagResolutionResponse": {
-        "type": "object", "required": ["data"], "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/AdminFlagResolutionReceipt"}}
-      },
-      "AdminFlagResolutionReceipt": {
-        "type": "object", "required": ["flagId", "status", "changed", "resolution", "links"], "additionalProperties": false,
-        "properties": {
-          "flagId": {"type": "integer", "minimum": 1},
-          "status": {"type": "string", "const": "resolved"},
-          "changed": {"type": "boolean"},
-          "resolution": {"$ref": "#/components/schemas/AdminFlagResolution"},
-          "links": {
-            "type": "object", "required": ["flags"], "additionalProperties": false,
-            "properties": {"flags": {"type": "string"}}
-          }
-        }
-      },
-      "AdminParticipantRosterResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/AdminParticipantRoster"}}
-      },
-      "AdminParticipantRoster": {
-        "type": "object",
-        "required": ["conversation", "participants", "dataAvailability", "capabilities", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "conversation": {
-            "type": "object",
-            "required": ["id", "slug", "title"],
-            "additionalProperties": false,
-            "properties": {
-              "id": {"type": "integer", "minimum": 1},
-              "slug": {"type": "string"},
-              "title": {"type": "string"}
-            }
-          },
-          "participants": {"type": "array", "items": {"$ref": "#/components/schemas/AdminParticipant"}},
-          "dataAvailability": {
-            "type": "object",
-            "required": ["statementProgress"],
-            "additionalProperties": false,
-            "properties": {"statementProgress": {"type": "boolean"}}
-          },
-          "capabilities": {
-            "type": "object",
-            "required": ["setParticipantAccess"],
-            "additionalProperties": false,
-            "properties": {"setParticipantAccess": {"type": "boolean"}}
-          },
-          "links": {
-            "type": "object",
-            "required": ["self", "conversation"],
-            "additionalProperties": false,
-            "properties": {
-              "self": {"type": "string"},
-              "conversation": {"type": "string"}
-            }
-          }
-        }
-      },
-      "AdminParticipant": {
-        "type": "object",
-        "required": ["participantId", "username", "pseudonym", "statementProgress", "arguments", "lastEngagementAt", "access"],
-        "additionalProperties": false,
-        "properties": {
-          "participantId": {"type": "integer", "minimum": 1},
-          "username": {"type": "string"},
-          "pseudonym": {"type": "string"},
-          "statementProgress": {
-            "oneOf": [
-              {"$ref": "#/components/schemas/AdminStatementProgress"},
-              {"type": "null"}
-            ]
-          },
-          "arguments": {
-            "type": "object",
-            "required": ["submitted", "prioritized"],
-            "additionalProperties": false,
-            "properties": {
-              "submitted": {"type": "integer", "minimum": 0},
-              "prioritized": {"type": "integer", "minimum": 0}
-            }
-          },
-          "lastEngagementAt": {"type": ["string", "null"], "format": "date-time"},
-          "access": {"$ref": "#/components/schemas/AdminParticipantAccess"}
-        }
-      },
-      "AdminStatementProgress": {
-        "type": "object",
-        "required": ["total", "voted", "remaining"],
-        "additionalProperties": false,
-        "properties": {
-          "total": {"type": "integer", "minimum": 0},
-          "voted": {"type": "integer", "minimum": 0},
-          "remaining": {"type": "integer", "minimum": 0}
-        }
-      },
-      "AdminParticipantAccess": {
-        "type": "object",
-        "required": ["banned", "changedAt", "summary"],
-        "additionalProperties": false,
-        "properties": {
-          "banned": {"type": "boolean"},
-          "changedAt": {"type": ["string", "null"], "format": "date-time"},
-          "summary": {"type": ["string", "null"]}
-        }
-      },
-      "AdminParticipantAccessRequest": {
-        "type": "object",
-        "required": ["banned"],
-        "additionalProperties": false,
-        "properties": {
-          "banned": {"type": "boolean"},
-          "summary": {"type": ["string", "null"], "maxLength": 1000}
-        }
-      },
-      "AdminParticipantAccessResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/AdminParticipantAccessReceipt"}}
-      },
-      "AdminParticipantAccessReceipt": {
-        "type": "object",
-        "required": ["participantId", "banned", "changed", "changedAt", "summary", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "participantId": {"type": "integer", "minimum": 1},
-          "banned": {"type": "boolean"},
-          "changed": {"type": "boolean"},
-          "changedAt": {"type": ["string", "null"], "format": "date-time"},
-          "summary": {"type": ["string", "null"]},
-          "links": {
-            "type": "object",
-            "required": ["participants"],
-            "additionalProperties": false,
-            "properties": {"participants": {"type": "string"}}
-          }
-        }
-      },
-      "SessionResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {
-          "data": {"$ref": "#/components/schemas/Session"}
-        }
-      },
-      "Session": {
-        "type": "object",
-        "required": ["state", "user", "capabilities", "csrfToken", "developerMode", "developerLogins", "gitVersion", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "state": {"type": "string", "enum": ["anonymous", "authenticated", "demo"]},
-          "user": {
-            "oneOf": [
-              {"$ref": "#/components/schemas/SessionUser"},
-              {"type": "null"}
-            ]
-          },
-          "capabilities": {"$ref": "#/components/schemas/SiteCapabilities"},
-          "csrfToken": {"type": "string", "minLength": 1},
-          "developerMode": {"type": "boolean"},
-          "developerLogins": {
-            "type": "array",
-            "items": {"$ref": "#/components/schemas/DeveloperLogin"}
-          },
-          "gitVersion": {"type": "string", "minLength": 1},
-          "links": {"$ref": "#/components/schemas/SessionLinks"}
-        }
-      },
-      "DeveloperLogin": {
-        "type": "object",
-        "required": ["username", "href"],
-        "additionalProperties": false,
-        "properties": {
-          "username": {"type": "string", "minLength": 1},
-          "href": {"type": "string", "minLength": 1}
-        }
-      },
-      "SessionUser": {
-        "type": "object",
-        "required": ["username", "emailable"],
-        "additionalProperties": false,
-        "properties": {
-          "username": {"type": "string", "minLength": 1},
-          "emailable": {"type": "boolean"}
-        }
-      },
-      "SiteCapabilities": {
-        "type": "object",
-        "required": ["administerSite"],
-        "additionalProperties": false,
-        "properties": {
-          "administerSite": {"type": "boolean"}
-        }
-      },
-      "SessionLinks": {
-        "type": "object",
-        "required": ["login", "logout"],
-        "additionalProperties": false,
-        "properties": {
-          "login": {"type": "string"},
-          "logout": {"type": "string"}
-        }
-      },
-      "ConversationLaneResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {
-          "data": {"$ref": "#/components/schemas/ConversationLane"}
-        }
-      },
-      "ConversationLane": {
-        "type": "object",
-        "required": ["space", "authenticated", "groups"],
-        "additionalProperties": false,
-        "properties": {
-          "space": {"type": "string", "enum": ["real", "demo"]},
-          "authenticated": {"type": "boolean"},
-          "groups": {"$ref": "#/components/schemas/ConversationGroups"}
-        }
-      },
-      "ConversationGroups": {
-        "type": "object",
-        "required": ["needsAttention", "caughtUp", "inactive", "archived", "available", "moderating"],
-        "additionalProperties": false,
-        "properties": {
-          "needsAttention": {"type": "array", "items": {"$ref": "#/components/schemas/ConversationCard"}},
-          "caughtUp": {"type": "array", "items": {"$ref": "#/components/schemas/ConversationCard"}},
-          "inactive": {"type": "array", "items": {"$ref": "#/components/schemas/ConversationCard"}},
-          "archived": {"type": "array", "items": {"$ref": "#/components/schemas/ConversationCard"}},
-          "available": {"type": "array", "items": {"$ref": "#/components/schemas/ConversationCard"}},
-          "moderating": {"type": "array", "items": {"$ref": "#/components/schemas/ConversationCard"}}
-        }
-      },
-      "ConversationCard": {
-        "type": "object",
-        "required": ["slug", "title", "relationship", "participantState", "pseudonym", "status", "closedAt", "phases", "statementsRemaining", "scheduledTransition", "reveal", "outputs", "capabilities", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "slug": {"type": "string", "minLength": 1},
-          "title": {"type": "string", "minLength": 1},
-          "relationship": {"type": "string", "enum": ["joined", "available", "moderating"]},
-          "participantState": {
-            "oneOf": [
-              {"type": "string", "enum": ["needs_attention", "caught_up", "inactive", "archived"]},
-              {"type": "null"}
-            ]
-          },
-          "pseudonym": {"type": ["string", "null"]},
-          "status": {"type": "string", "enum": ["open", "paused", "archived"]},
-          "closedAt": {"type": ["string", "null"], "format": "date-time"},
-          "phases": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-          "statementsRemaining": {"type": ["integer", "null"], "minimum": 0},
-          "scheduledTransition": {
-            "oneOf": [
-              {"$ref": "#/components/schemas/ScheduledTransition"},
-              {"type": "null"}
-            ]
-          },
-          "reveal": {
-            "oneOf": [
-              {"$ref": "#/components/schemas/ConversationRevealSignal"},
-              {"type": "null"}
-            ]
-          },
-          "outputs": {"type": "array", "items": {"$ref": "#/components/schemas/ConversationOutput"}},
-          "capabilities": {"$ref": "#/components/schemas/ConversationCapabilities"},
-          "links": {"$ref": "#/components/schemas/ConversationLinks"}
-        }
-      },
-      "ModerationLogResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/ModerationLog"}}
-      },
-      "ModerationLog": {
-        "type": "object",
-        "required": ["slug", "title", "events", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "slug": {"type": "string", "minLength": 1},
-          "title": {"type": "string", "minLength": 1},
-          "events": {"type": "array", "items": {"$ref": "#/components/schemas/ModerationLogEvent"}},
-          "links": {"$ref": "#/components/schemas/ParticipantPageLinks"}
-        }
-      },
-      "ModerationLogEvent": {
-        "type": "object",
-        "required": ["occurredAt", "action", "pseudonym", "scope", "actor"],
-        "additionalProperties": false,
-        "properties": {
-          "occurredAt": {"type": ["string", "null"], "format": "date-time"},
-          "action": {"type": "string", "enum": ["Banned", "Unbanned"]},
-          "pseudonym": {"type": "string"},
-          "scope": {"type": "string", "enum": ["conversation"]},
-          "actor": {"type": "string"}
-        }
-      },
-      "ConversationOutputPageResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/ConversationOutputPage"}}
-      },
-      "ConversationOutputPage": {
-        "type": "object",
-        "required": ["slug", "title", "output", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "slug": {"type": "string", "minLength": 1},
-          "title": {"type": "string", "minLength": 1},
-          "output": {"$ref": "#/components/schemas/ConversationOutputDetail"},
-          "links": {"$ref": "#/components/schemas/ParticipantPageLinks"}
-        }
-      },
-      "ConversationOutputDetail": {
-        "type": "object",
-        "required": ["key", "label", "phase", "status", "ready", "method", "pending"],
-        "additionalProperties": false,
-        "properties": {
-          "key": {"type": "string", "enum": ["initial-clustering", "argument-map", "preliminary-results", "report", "dataset"]},
-          "label": {"type": "string", "minLength": 1},
-          "phase": {"type": "string", "minLength": 1},
-          "status": {"type": "string", "enum": ["provisional", "final"]},
-          "ready": {"type": "boolean"},
-          "method": {"type": "string", "minLength": 1},
-          "pending": {"type": "string", "minLength": 1}
-        }
-      },
-      "ParticipantPageLinks": {
-        "type": "object",
-        "required": ["self", "conversation", "about"],
-        "additionalProperties": false,
-        "properties": {
-          "self": {"type": "string"},
-          "conversation": {"type": "string"},
-          "about": {"type": "string"}
-        }
-      },
-      "ConversationWorkspaceResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {
-          "data": {"$ref": "#/components/schemas/ConversationWorkspace"}
-        }
-      },
-      "ConversationWorkspace": {
-        "type": "object",
-        "required": ["slug", "title", "space", "status", "descriptionHtml", "outroHtml", "viewer", "spaceWarning", "scheduledTransition", "tabs", "defaultTab", "reveal", "statementContribution", "capabilities", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "slug": {"type": "string", "minLength": 1},
-          "title": {"type": "string", "minLength": 1},
-          "space": {"type": "string", "enum": ["real", "demo"]},
-          "status": {"type": "string", "enum": ["open", "paused", "closed"]},
-          "descriptionHtml": {"type": ["string", "null"]},
-          "outroHtml": {"type": ["string", "null"]},
-          "viewer": {"$ref": "#/components/schemas/ConversationWorkspaceViewer"},
-          "spaceWarning": {"type": ["string", "null"], "enum": ["real", "demo", null]},
-          "scheduledTransition": {
-            "oneOf": [
-              {"$ref": "#/components/schemas/ScheduledTransition"},
-              {"type": "null"}
-            ]
-          },
-          "tabs": {"type": "array", "items": {"$ref": "#/components/schemas/ConversationWorkspaceTab"}},
-          "defaultTab": {
-            "type": ["string", "null"],
-            "enum": ["vote", "results", "arguments", "informed-voting", "p6-results", null]
-          },
-          "reveal": {
-            "oneOf": [
-              {"$ref": "#/components/schemas/ConversationWorkspaceReveal"},
-              {"type": "null"}
-            ]
-          },
-          "statementContribution": {"$ref": "#/components/schemas/ConversationWorkspaceStatementContribution"},
-          "capabilities": {"$ref": "#/components/schemas/ConversationWorkspaceCapabilities"},
-          "links": {"$ref": "#/components/schemas/ConversationWorkspaceLinks"}
-        }
-      },
-      "ConversationWorkspaceViewer": {
-        "type": "object",
-        "required": ["state", "pseudonym"],
-        "additionalProperties": false,
-        "properties": {
-          "state": {"type": "string", "enum": ["participant", "join_required"]},
-          "pseudonym": {"type": ["string", "null"]}
-        }
-      },
-      "ConversationWorkspaceTab": {
-        "type": "object",
-        "required": ["key", "label", "dataHref"],
-        "additionalProperties": false,
-        "properties": {
-          "key": {"type": "string", "enum": ["vote", "results", "arguments", "informed-voting", "p6-results"]},
-          "label": {"type": "string", "minLength": 1},
-          "dataHref": {"type": ["string", "null"]}
-        }
-      },
-      "ConversationWorkspaceReveal": {
-        "type": "object",
-        "required": ["state", "pseudonym", "closedAt", "opensAt", "closesAt", "daysRemaining", "cooldownDays", "windowDays", "countdownTargetAt"],
-        "additionalProperties": false,
-        "properties": {
-          "state": {"type": "string", "enum": ["pending", "open", "revealed", "expired"]},
-          "pseudonym": {"type": ["string", "null"]},
-          "closedAt": {"type": "string", "format": "date-time"},
-          "opensAt": {"type": "string", "format": "date-time"},
-          "closesAt": {"type": "string", "format": "date-time"},
-          "daysRemaining": {"type": "integer", "minimum": 0},
-          "cooldownDays": {"type": "integer", "minimum": 0},
-          "windowDays": {"type": "integer", "minimum": 0},
-          "countdownTargetAt": {"type": ["string", "null"], "format": "date-time"}
-        }
-      },
-      "ConversationWorkspaceStatementContribution": {
-        "type": "object",
-        "required": ["unlockAfter", "quota", "used"],
-        "additionalProperties": false,
-        "properties": {
-          "unlockAfter": {"type": "integer", "minimum": 0},
-          "quota": {"type": "integer", "minimum": 0},
-          "used": {"type": "integer", "minimum": 0}
-        }
-      },
-      "ConversationWorkspaceCapabilities": {
-        "type": "object",
-        "required": ["participate", "moderate"],
-        "additionalProperties": false,
-        "properties": {
-          "participate": {"type": "boolean"},
-          "moderate": {"type": "boolean"}
-        }
-      },
-      "ConversationWorkspaceLinks": {
-        "type": "object",
-        "required": ["self", "conversation", "about", "join"],
-        "additionalProperties": false,
-        "properties": {
-          "self": {"type": "string"},
-          "conversation": {"type": "string"},
-          "about": {"type": "string"},
-          "join": {"type": "string"},
-          "manage": {"type": "string"},
-          "explore": {"type": "string"},
-          "arguments": {"type": "string"},
-          "informedVoting": {"type": "string"},
-          "intermediateResults": {"type": "string"},
-          "results": {"type": "string"}
-        }
-      },
-      "ConversationAboutResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {
-          "data": {"$ref": "#/components/schemas/ConversationAbout"}
-        }
-      },
-      "IdentityRevealResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {
-          "data": {"$ref": "#/components/schemas/IdentityReveal"}
-        }
-      },
-      "CreateIdentityRevealRequest": {
-        "type": "object",
-        "required": ["confirm"],
-        "additionalProperties": false,
-        "properties": {
-          "confirm": {"type": "boolean", "const": true}
-        }
-      },
-      "IdentityReveal": {
-        "type": "object",
-        "required": ["slug", "title", "state", "pseudonym", "wikimediaUsername", "publicUsername", "timeline", "capabilities", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "slug": {"type": "string", "minLength": 1},
-          "title": {"type": "string", "minLength": 1},
-          "state": {"type": "string", "enum": ["pending", "open", "revealed", "expired"]},
-          "pseudonym": {"type": "string", "minLength": 1},
-          "wikimediaUsername": {"type": "string", "minLength": 1},
-          "publicUsername": {"type": ["string", "null"]},
-          "timeline": {"$ref": "#/components/schemas/IdentityRevealTimeline"},
-          "capabilities": {"$ref": "#/components/schemas/IdentityRevealCapabilities"},
-          "links": {"$ref": "#/components/schemas/IdentityRevealLinks"}
-        }
-      },
-      "IdentityRevealTimeline": {
-        "type": "object",
-        "required": ["closedAt", "opensAt", "closesAt", "nextBoundaryAt", "daysRemaining"],
-        "additionalProperties": false,
-        "properties": {
-          "closedAt": {"type": "string", "format": "date-time"},
-          "opensAt": {"type": "string", "format": "date-time"},
-          "closesAt": {"type": "string", "format": "date-time"},
-          "nextBoundaryAt": {"type": ["string", "null"], "format": "date-time"},
-          "daysRemaining": {"type": "integer", "minimum": 0}
-        }
-      },
-      "IdentityRevealCapabilities": {
-        "type": "object",
-        "required": ["revealIdentity"],
-        "additionalProperties": false,
-        "properties": {"revealIdentity": {"type": "boolean"}}
-      },
-      "IdentityRevealLinks": {
-        "type": "object",
-        "required": ["self", "conversation", "about"],
-        "additionalProperties": false,
-        "properties": {
-          "self": {"type": "string"},
-          "conversation": {"type": "string"},
-          "about": {"type": "string"}
-        }
-      },
-      "ParticipationEntryConversation": {
-        "type": "object",
-        "required": ["id", "slug", "title", "descriptionHtml", "eligibilityLabel"],
-        "additionalProperties": false,
-        "properties": {
-          "id": {"type": "integer", "minimum": 1},
-          "slug": {"type": "string", "minLength": 1},
-          "title": {"type": "string", "minLength": 1},
-          "descriptionHtml": {"type": ["string", "null"]},
-          "eligibilityLabel": {"type": ["string", "null"]}
-        }
-      },
-      "JoinParticipationEntry": {
-        "type": "object",
-        "required": ["state", "conversation", "pseudonyms", "emailable", "reveal", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "state": {"type": "string", "enum": ["join"]},
-          "conversation": {"$ref": "#/components/schemas/ParticipationEntryConversation"},
-          "pseudonyms": {
-            "type": "array",
-            "minItems": 1,
-            "items": {"type": "string", "pattern": "^[a-z]{2,20}-[a-z]{2,20}$"}
-          },
-          "emailable": {"type": "boolean"},
-          "reveal": {
-            "type": "object",
-            "required": ["cooldownDays", "windowEndDays"],
-            "additionalProperties": false,
-            "properties": {
-              "cooldownDays": {"type": "integer", "minimum": 0},
-              "windowEndDays": {"type": "integer", "minimum": 0}
-            }
-          },
-          "links": {
-            "type": "object",
-            "required": ["home", "conversation"],
-            "additionalProperties": false,
-            "properties": {"home": {"type": "string"}, "conversation": {"type": "string"}}
-          }
-        }
-      },
-      "RedirectParticipationEntry": {
-        "type": "object",
-        "required": ["state", "reason", "href"],
-        "additionalProperties": false,
-        "properties": {
-          "state": {"type": "string", "enum": ["redirect"]},
-          "reason": {"type": "string", "enum": ["demo", "already_participating"]},
-          "href": {"type": "string"}
-        }
-      },
-      "InviteDeniedParticipationEntry": {
-        "type": "object",
-        "required": ["state", "conversation", "canModerate", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "state": {"type": "string", "enum": ["invite_denied"]},
-          "conversation": {"$ref": "#/components/schemas/ParticipationEntryConversation"},
-          "canModerate": {"type": "boolean"},
-          "links": {
-            "type": "object",
-            "required": ["home", "manageInvites"],
-            "additionalProperties": false,
-            "properties": {
-              "home": {"type": "string"},
-              "manageInvites": {"type": ["string", "null"]}
-            }
-          }
-        }
-      },
-      "ParticipationEntryResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {
-          "data": {
-            "oneOf": [
-              {"$ref": "#/components/schemas/JoinParticipationEntry"},
-              {"$ref": "#/components/schemas/RedirectParticipationEntry"},
-              {"$ref": "#/components/schemas/InviteDeniedParticipationEntry"}
-            ]
-          }
-        }
-      },
-      "PseudonymSuggestionsResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {
-          "data": {
-            "type": "object",
-            "required": ["pseudonyms"],
-            "additionalProperties": false,
-            "properties": {
-              "pseudonyms": {
-                "type": "array",
-                "minItems": 1,
-                "items": {"type": "string", "pattern": "^[a-z]{2,20}-[a-z]{2,20}$"}
-              }
-            }
-          }
-        }
-      },
-      "CreateParticipationRequest": {
-        "type": "object",
-        "required": ["pseudonym"],
-        "additionalProperties": false,
-        "properties": {
-          "pseudonym": {
-            "type": "string",
-            "pattern": "^[a-z]{2,20}-[a-z]{2,20}$"
-          },
-          "notifyEmail": {"type": "boolean", "default": false},
-          "notifyTalkPage": {"type": "boolean", "default": false}
-        }
-      },
-      "ParticipationResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {
-          "data": {"$ref": "#/components/schemas/Participation"}
-        }
-      },
-      "Participation": {
-        "type": "object",
-        "required": ["pseudonym", "notifications", "eligibilityStatus", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "pseudonym": {"type": "string"},
-          "notifications": {
-            "type": "object",
-            "required": ["email", "talkPage"],
-            "additionalProperties": false,
-            "properties": {
-              "email": {"type": "boolean"},
-              "talkPage": {"type": "boolean"}
-            }
-          },
-          "eligibilityStatus": {
-            "type": ["string", "null"],
-            "enum": ["eligible", "not_required", null]
-          },
-          "links": {
-            "type": "object",
-            "required": ["conversation", "about"],
-            "additionalProperties": false,
-            "properties": {
-              "conversation": {"type": "string"},
-              "about": {"type": "string"}
-            }
-          }
-        }
-      },
-      "ExploreStateResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {
-          "data": {"$ref": "#/components/schemas/ExploreState"}
-        }
-      },
-      "ExploreState": {
-        "type": "object",
-        "required": ["slug", "title", "pseudonym", "currentStatement", "progress", "newStatement", "capabilities", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "slug": {"type": "string"},
-          "title": {"type": "string"},
-          "pseudonym": {"type": "string"},
-          "currentStatement": {
-            "oneOf": [
-              {"$ref": "#/components/schemas/ExploreStatement"},
-              {"type": "null"}
-            ]
-          },
-          "progress": {"$ref": "#/components/schemas/ExploreProgress"},
-          "newStatement": {"$ref": "#/components/schemas/NewStatementAvailability"},
-          "capabilities": {"$ref": "#/components/schemas/ExploreCapabilities"},
-          "links": {"$ref": "#/components/schemas/ExploreLinks"}
-        }
-      },
-      "ExploreStatement": {
-        "type": "object",
-        "required": ["id", "text", "isMeta", "isSeed"],
-        "additionalProperties": false,
-        "properties": {
-          "id": {"type": "integer", "minimum": 0},
-          "text": {"type": "string", "minLength": 1},
-          "isMeta": {"type": "boolean"},
-          "isSeed": {"type": "boolean"}
-        }
-      },
-      "ExploreProgress": {
-        "type": "object",
-        "required": ["completed", "total", "remaining", "allDone"],
-        "additionalProperties": false,
-        "properties": {
-          "completed": {"type": "integer", "minimum": 0},
-          "total": {"type": "integer", "minimum": 0},
-          "remaining": {"type": "integer", "minimum": 0},
-          "allDone": {"type": "boolean"}
-        }
-      },
-      "NewStatementAvailability": {
-        "type": "object",
-        "required": ["unlocked", "unlockAfter", "quota", "used", "remaining"],
-        "additionalProperties": false,
-        "properties": {
-          "unlocked": {"type": "boolean"},
-          "unlockAfter": {"type": "integer", "minimum": 0},
-          "quota": {"type": "integer", "minimum": 0},
-          "used": {"type": "integer", "minimum": 0},
-          "remaining": {"type": "integer", "minimum": 0}
-        }
-      },
-      "ExploreCapabilities": {
-        "type": "object",
-        "required": ["vote", "suggestWording", "submitNewStatement"],
-        "additionalProperties": false,
-        "properties": {
-          "vote": {"type": "boolean"},
-          "suggestWording": {"type": "boolean"},
-          "submitNewStatement": {"type": "boolean"}
-        }
-      },
-      "ExploreLinks": {
-        "type": "object",
-        "required": ["self", "about", "conversation"],
-        "additionalProperties": false,
-        "properties": {
-          "self": {"type": "string"},
-          "about": {"type": "string"},
-          "conversation": {"type": "string"},
-          "arguments": {"type": "string"}
-        }
-      },
-      "ExploreVoteRequest": {
-        "type": "object",
-        "required": ["choice"],
-        "additionalProperties": false,
-        "properties": {
-          "choice": {"type": "string", "enum": ["agree", "pass", "disagree"]},
-          "passReason": {
-            "type": "string",
-            "enum": ["unsure", "confusing"],
-            "description": "Optional local reason for a pass vote. Valid only when choice is pass."
-          }
-        }
-      },
-      "ExploreVoteResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {
-          "data": {"$ref": "#/components/schemas/ExploreVoteReceipt"}
-        }
-      },
-      "ExploreVoteReceipt": {
-        "type": "object",
-        "required": ["statementId", "choice", "passReason", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "statementId": {"type": "integer", "minimum": 0},
-          "choice": {"type": "string", "enum": ["agree", "pass", "disagree"]},
-          "passReason": {
-            "type": ["string", "null"],
-            "enum": ["unsure", "confusing", null]
-          },
-          "links": {
-            "type": "object",
-            "required": ["explore"],
-            "additionalProperties": false,
-            "properties": {"explore": {"type": "string"}}
-          }
-        }
-      },
-      "InformedVotingResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/InformedVoting"}}
-      },
-      "InformedVoting": {
-        "type": "object",
-        "required": ["slug", "title", "pseudonym", "cards", "progress", "capabilities", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "slug": {"type": "string"},
-          "title": {"type": "string"},
-          "pseudonym": {"type": "string"},
-          "cards": {"type": "array", "items": {"$ref": "#/components/schemas/InformedVotingCard"}},
-          "progress": {"$ref": "#/components/schemas/ExploreProgress"},
-          "capabilities": {
-            "type": "object",
-            "required": ["vote"],
-            "additionalProperties": false,
-            "properties": {"vote": {"type": "boolean"}}
-          },
-          "links": {"$ref": "#/components/schemas/InformedVotingLinks"}
-        }
-      },
-      "InformedVotingCard": {
-        "type": "object",
-        "required": ["featuredStatementId", "statement", "canVote", "voted", "arguments"],
-        "additionalProperties": false,
-        "properties": {
-          "featuredStatementId": {"type": "integer", "minimum": 1},
-          "statement": {"type": "string", "minLength": 1},
-          "canVote": {"type": "boolean"},
-          "voted": {"type": "boolean"},
-          "arguments": {
-            "type": "object",
-            "required": ["for", "against"],
-            "additionalProperties": false,
-            "properties": {
-              "for": {"type": "array", "items": {"$ref": "#/components/schemas/InformedVotingArgument"}},
-              "against": {"type": "array", "items": {"$ref": "#/components/schemas/InformedVotingArgument"}}
-            }
-          }
-        }
-      },
-      "InformedVotingArgument": {
-        "type": "object",
-        "required": ["id", "body", "helpfulVotes"],
-        "additionalProperties": false,
-        "properties": {
-          "id": {"type": "integer", "minimum": 1},
-          "body": {"type": "string"},
-          "helpfulVotes": {"type": "integer", "minimum": 0}
-        }
-      },
-      "InformedVotingLinks": {
-        "type": "object",
-        "required": ["self", "about", "conversation"],
-        "additionalProperties": false,
-        "properties": {
-          "self": {"type": "string"},
-          "about": {"type": "string"},
-          "conversation": {"type": "string"},
-          "explore": {"type": "string"},
-          "arguments": {"type": "string"},
-          "results": {"type": "string"}
-        }
-      },
-      "InformedVoteRequest": {
-        "type": "object",
-        "required": ["choice"],
-        "additionalProperties": false,
-        "properties": {"choice": {"type": "string", "enum": ["agree", "pass", "disagree"]}}
-      },
-      "InformedVoteResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/InformedVoteReceipt"}}
-      },
-      "InformedVoteReceipt": {
-        "type": "object",
-        "required": ["featuredStatementId", "choice", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "featuredStatementId": {"type": "integer", "minimum": 1},
-          "choice": {"type": "string", "enum": ["agree", "pass", "disagree"]},
-          "links": {
-            "type": "object",
-            "required": ["informedVoting"],
-            "additionalProperties": false,
-            "properties": {"informedVoting": {"type": "string"}}
-          }
-        }
-      },
-      "IntermediateResultsResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/IntermediateResults"}}
-      },
-      "IntermediateResults": {
-        "type": "object",
-        "required": ["slug", "title", "state", "participantCount", "smallSample", "consensus", "groups", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "slug": {"type": "string"},
-          "title": {"type": "string"},
-          "state": {"type": "string", "enum": ["ready", "recomputing", "pending"]},
-          "participantCount": {"type": ["integer", "null"], "minimum": 0},
-          "smallSample": {"type": "boolean"},
-          "consensus": {"type": "array", "items": {"$ref": "#/components/schemas/IntermediateResultPosition"}},
-          "groups": {"type": "array", "items": {"$ref": "#/components/schemas/IntermediateResultGroup"}},
-          "links": {"$ref": "#/components/schemas/IntermediateResultsLinks"}
-        }
-      },
-      "IntermediateResultPosition": {
-        "type": "object",
-        "required": ["choice", "statement", "percentage"],
-        "additionalProperties": false,
-        "properties": {
-          "choice": {"type": "string", "enum": ["agree", "disagree"]},
-          "statement": {"type": "string"},
-          "percentage": {"type": "integer", "minimum": 0, "maximum": 100}
-        }
-      },
-      "IntermediateResultGroup": {
-        "type": "object",
-        "required": ["label", "positions"],
-        "additionalProperties": false,
-        "properties": {
-          "label": {"type": "string"},
-          "positions": {"type": "array", "items": {"$ref": "#/components/schemas/IntermediateResultPosition"}}
-        }
-      },
-      "IntermediateResultsLinks": {
-        "type": "object",
-        "required": ["self", "conversation", "about"],
-        "additionalProperties": false,
-        "properties": {
-          "self": {"type": "string"},
-          "conversation": {"type": "string"},
-          "about": {"type": "string"}
-        }
-      },
-      "ResultsReportResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/ResultsReport"}}
-      },
-      "ResultsReport": {
-        "type": "object",
-        "required": ["slug", "title", "publication", "resultsAvailable", "openedAt", "closedAt", "context", "participation", "dataAvailability", "moderation", "statements", "opinionGroups", "viewer", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "slug": {"type": "string"},
-          "title": {"type": "string"},
-          "publication": {"type": "string", "enum": ["preliminary", "final"]},
-          "resultsAvailable": {"type": "boolean"},
-          "openedAt": {"type": "string", "format": "date-time"},
-          "closedAt": {"type": ["string", "null"], "format": "date-time"},
-          "context": {
-            "type": "object",
-            "required": ["phase", "status", "method"],
-            "additionalProperties": false,
-            "properties": {
-              "phase": {"type": "string"},
-              "status": {"type": "string", "enum": ["provisional", "final"]},
-              "method": {"type": "string"}
-            }
-          },
-          "participation": {
-            "type": "object",
-            "required": ["initialRound", "informedRound", "matchedRounds"],
-            "additionalProperties": false,
-            "properties": {
-              "initialRound": {"type": ["integer", "null"], "minimum": 0},
-              "informedRound": {"type": ["integer", "null"], "minimum": 0},
-              "matchedRounds": {"type": ["integer", "null"], "minimum": 0}
-            }
-          },
-          "dataAvailability": {
-            "type": "object",
-            "required": ["detailedCounts", "opinionGroups"],
-            "additionalProperties": false,
-            "properties": {
-              "detailedCounts": {"type": "boolean"},
-              "opinionGroups": {"type": "boolean"}
-            }
-          },
-          "moderation": {
-            "type": "object",
-            "required": ["excludedStatements", "excludedParticipants"],
-            "additionalProperties": false,
-            "properties": {
-              "excludedStatements": {"type": "integer", "minimum": 0},
-              "excludedParticipants": {"type": "integer", "minimum": 0}
-            }
-          },
-          "statements": {"type": "array", "items": {"$ref": "#/components/schemas/ResultsStatement"}},
-          "opinionGroups": {"type": "array", "items": {"$ref": "#/components/schemas/ResultsOpinionGroup"}},
-          "viewer": {
-            "type": "object",
-            "required": ["participating", "pseudonym", "revealState"],
-            "additionalProperties": false,
-            "properties": {
-              "participating": {"type": "boolean"},
-              "pseudonym": {"type": ["string", "null"]},
-              "revealState": {"type": ["string", "null"], "enum": ["pending", "open", "revealed", "expired", null]}
-            }
-          },
-          "links": {"$ref": "#/components/schemas/ResultsLinks"}
-        }
-      },
-      "ResultsStatement": {
-        "type": "object",
-        "required": ["featuredStatementId", "statement", "initial", "informed", "agreementShift", "viewerChoice"],
-        "additionalProperties": false,
-        "properties": {
-          "featuredStatementId": {"type": "integer", "minimum": 1},
-          "statement": {"type": "string"},
-          "initial": {"oneOf": [{"$ref": "#/components/schemas/VoteTally"}, {"type": "null"}]},
-          "informed": {"oneOf": [{"$ref": "#/components/schemas/VoteTally"}, {"type": "null"}]},
-          "agreementShift": {"type": ["number", "null"]},
-          "viewerChoice": {"type": ["string", "null"], "enum": ["agree", "pass", "disagree", null]}
-        }
-      },
-      "VoteTally": {
-        "type": "object",
-        "required": ["counts", "percentages"],
-        "additionalProperties": false,
-        "properties": {
-          "counts": {
-            "type": "object",
-            "required": ["agree", "pass", "disagree", "voters"],
-            "additionalProperties": false,
-            "properties": {
-              "agree": {"type": "integer", "minimum": 0},
-              "pass": {"type": "integer", "minimum": 0},
-              "disagree": {"type": "integer", "minimum": 0},
-              "voters": {"type": "integer", "minimum": 0}
-            }
-          },
-          "percentages": {
-            "type": "object",
-            "required": ["agree", "pass", "disagree"],
-            "additionalProperties": false,
-            "properties": {
-              "agree": {"type": "number", "minimum": 0, "maximum": 100},
-              "pass": {"type": "number", "minimum": 0, "maximum": 100},
-              "disagree": {"type": "number", "minimum": 0, "maximum": 100}
-            }
-          }
-        }
-      },
-      "ResultsOpinionGroup": {
-        "type": "object",
-        "required": ["label", "memberCount", "positions"],
-        "additionalProperties": false,
-        "properties": {
-          "label": {"type": "string"},
-          "memberCount": {"type": ["integer", "null"], "minimum": 0},
-          "positions": {"type": "array", "items": {"$ref": "#/components/schemas/ResultsGroupPosition"}}
-        }
-      },
-      "ResultsGroupPosition": {
-        "type": "object",
-        "required": ["choice", "statement", "percentage"],
-        "additionalProperties": false,
-        "properties": {
-          "choice": {"type": "string", "enum": ["agree", "disagree"]},
-          "statement": {"type": "string"},
-          "percentage": {"type": ["number", "null"], "minimum": 0, "maximum": 100}
-        }
-      },
-      "ResultsLinks": {
-        "type": "object",
-        "required": ["self", "conversation", "about"],
-        "additionalProperties": false,
-        "properties": {
-          "self": {"type": "string"},
-          "conversation": {"type": "string"},
-          "about": {"type": "string"},
-          "identityReveal": {"type": "string"}
-        }
-      },
-      "ArgumentMappingResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/ArgumentMapping"}}
-      },
-      "ArgumentMapping": {
-        "type": "object",
-        "required": ["conversationId", "slug", "title", "pseudonym", "progress", "featuredStatements", "capabilities", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "conversationId": {"type": "integer", "minimum": 1},
-          "slug": {"type": "string"},
-          "title": {"type": "string"},
-          "pseudonym": {"type": "string"},
-          "progress": {"$ref": "#/components/schemas/ArgumentMappingProgress"},
-          "featuredStatements": {"type": "array", "items": {"$ref": "#/components/schemas/ArgumentFeaturedStatement"}},
-          "capabilities": {"$ref": "#/components/schemas/ArgumentMappingCapabilities"},
-          "links": {"$ref": "#/components/schemas/ArgumentMappingLinks"}
-        }
-      },
-      "ArgumentMappingProgress": {
-        "type": "object",
-        "required": ["completed", "total", "allDone", "currentFeaturedStatementId"],
-        "additionalProperties": false,
-        "properties": {
-          "completed": {"type": "integer", "minimum": 0},
-          "total": {"type": "integer", "minimum": 0},
-          "allDone": {"type": "boolean"},
-          "currentFeaturedStatementId": {"type": ["integer", "null"]}
-        }
-      },
-      "ArgumentFeaturedStatement": {
-        "type": "object",
-        "required": ["id", "statement", "contributionsComplete", "complete", "sides", "capabilities"],
-        "additionalProperties": false,
-        "properties": {
-          "id": {"type": "integer"},
-          "statement": {"$ref": "#/components/schemas/ArgumentStatement"},
-          "contributionsComplete": {"type": "boolean"},
-          "complete": {"type": "boolean"},
-          "sides": {
-            "type": "object",
-            "required": ["pro", "con"],
-            "additionalProperties": false,
-            "properties": {
-              "pro": {"$ref": "#/components/schemas/ArgumentSide"},
-              "con": {"$ref": "#/components/schemas/ArgumentSide"}
-            }
-          },
-          "capabilities": {
-            "type": "object",
-            "required": ["flagStatement"],
-            "additionalProperties": false,
-            "properties": {"flagStatement": {"type": "boolean"}}
-          }
-        }
-      },
-      "ArgumentStatement": {
-        "type": "object",
-        "required": ["id", "text"],
-        "additionalProperties": false,
-        "properties": {"id": {"type": "integer"}, "text": {"type": "string"}}
-      },
-      "ArgumentSide": {
-        "type": "object",
-        "required": ["contribution", "prioritization", "arguments"],
-        "additionalProperties": false,
-        "properties": {
-          "contribution": {"$ref": "#/components/schemas/ArgumentContribution"},
-          "prioritization": {"$ref": "#/components/schemas/ArgumentPrioritization"},
-          "arguments": {"type": "array", "items": {"$ref": "#/components/schemas/ArgumentItem"}}
-        }
-      },
-      "ArgumentContribution": {
-        "type": "object",
-        "required": ["status", "argumentId", "capabilities"],
-        "additionalProperties": false,
-        "properties": {
-          "status": {"type": "string", "enum": ["pending", "submitted", "skipped"]},
-          "argumentId": {"type": ["integer", "null"]},
-          "capabilities": {
-            "type": "object",
-            "required": ["submit", "skip"],
-            "additionalProperties": false,
-            "properties": {"submit": {"type": "boolean"}, "skip": {"type": "boolean"}}
-          }
-        }
-      },
-      "ArgumentPrioritization": {
-        "type": "object",
-        "required": ["available", "requiredArgumentCount", "argumentCount", "selectionBudget", "selectedCount", "complete"],
-        "additionalProperties": false,
-        "properties": {
-          "available": {"type": "boolean"},
-          "requiredArgumentCount": {"type": "integer", "minimum": 1},
-          "argumentCount": {"type": "integer", "minimum": 0},
-          "selectionBudget": {"type": "integer", "minimum": 1},
-          "selectedCount": {"type": "integer", "minimum": 0},
-          "complete": {"type": "boolean"}
-        }
-      },
-      "ArgumentItem": {
-        "type": "object",
-        "required": ["id", "body", "own", "selected", "hidden", "importanceVoteCount", "capabilities"],
-        "additionalProperties": false,
-        "properties": {
-          "id": {"type": "integer"},
-          "body": {"type": "string", "maxLength": 280},
-          "own": {"type": "boolean"},
-          "selected": {"type": "boolean"},
-          "hidden": {"type": "boolean"},
-          "importanceVoteCount": {"type": "integer", "minimum": 0},
-          "capabilities": {
-            "type": "object",
-            "required": ["prioritize", "flag", "moderate"],
-            "additionalProperties": false,
-            "properties": {"prioritize": {"type": "boolean"}, "flag": {"type": "boolean"}, "moderate": {"type": "boolean"}}
-          }
-        }
-      },
-      "ArgumentMappingCapabilities": {
-        "type": "object",
-        "required": ["contribute", "prioritize", "flag", "moderate"],
-        "additionalProperties": false,
-        "properties": {"contribute": {"type": "boolean"}, "prioritize": {"type": "boolean"}, "flag": {"type": "boolean"}, "moderate": {"type": "boolean"}}
-      },
-      "ArgumentMappingLinks": {
-        "type": "object",
-        "required": ["self", "about", "conversation"],
-        "additionalProperties": false,
-        "properties": {
-          "self": {"type": "string"},
-          "about": {"type": "string"},
-          "conversation": {"type": "string"},
-          "explore": {"type": "string"}
-        }
-      },
-      "CreateArgumentRequest": {
-        "type": "object",
-        "required": ["side", "body"],
-        "additionalProperties": false,
-        "properties": {
-          "side": {"type": "string", "enum": ["pro", "con"]},
-          "body": {"type": "string", "minLength": 1, "maxLength": 280}
-        }
-      },
-      "ArgumentCommandLinks": {
-        "type": "object",
-        "required": ["arguments"],
-        "additionalProperties": false,
-        "properties": {"arguments": {"type": "string"}}
-      },
-      "ArgumentSubmissionResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/ArgumentSubmissionReceipt"}}
-      },
-      "ArgumentSubmissionReceipt": {
-        "type": "object",
-        "required": ["featuredStatementId", "side", "status", "argument", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "featuredStatementId": {"type": "integer"},
-          "side": {"type": "string", "enum": ["pro", "con"]},
-          "status": {"type": "string", "const": "submitted"},
-          "argument": {"$ref": "#/components/schemas/ArgumentItem"},
-          "links": {"$ref": "#/components/schemas/ArgumentCommandLinks"}
-        }
-      },
-      "ArgumentSkipResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/ArgumentSkipReceipt"}}
-      },
-      "ArgumentSkipReceipt": {
-        "type": "object",
-        "required": ["featuredStatementId", "side", "status", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "featuredStatementId": {"type": "integer"},
-          "side": {"type": "string", "enum": ["pro", "con"]},
-          "status": {"type": "string", "const": "skipped"},
-          "links": {"$ref": "#/components/schemas/ArgumentCommandLinks"}
-        }
-      },
-      "ArgumentPriorityRequest": {
-        "type": "object",
-        "required": ["selected"],
-        "additionalProperties": false,
-        "properties": {"selected": {"type": "boolean"}}
-      },
-      "ArgumentPriorityResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/ArgumentPriorityReceipt"}}
-      },
-      "ArgumentPriorityReceipt": {
-        "type": "object",
-        "required": ["argumentId", "selected", "selectedCount", "selectionBudget", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "argumentId": {"type": "integer"},
-          "selected": {"type": "boolean"},
-          "selectedCount": {"type": "integer", "minimum": 0},
-          "selectionBudget": {"type": "integer", "minimum": 1},
-          "links": {"$ref": "#/components/schemas/ArgumentCommandLinks"}
-        }
-      },
-      "CreateContentFlagRequest": {
-        "type": "object",
-        "required": ["contentType", "targetId", "category"],
-        "additionalProperties": false,
-        "properties": {
-          "contentType": {"type": "string", "enum": ["statement", "argument"]},
-          "targetId": {"type": "integer", "minimum": 0},
-          "category": {"type": "string", "enum": ["personal_attack", "privacy", "off_topic", "other"]},
-          "detail": {"type": ["string", "null"], "maxLength": 1000}
-        }
-      },
-      "ContentFlagResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {"data": {"$ref": "#/components/schemas/ContentFlagReceipt"}}
-      },
-      "ContentFlagReceipt": {
-        "type": "object",
-        "required": ["contentType", "targetId", "category", "status", "created", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "contentType": {"type": "string", "enum": ["statement", "argument"]},
-          "targetId": {"type": "integer", "minimum": 0},
-          "category": {"type": "string", "enum": ["personal_attack", "privacy", "off_topic", "other"]},
-          "status": {"type": "string", "const": "open"},
-          "created": {"type": "boolean"},
-          "links": {
-            "type": "object",
-            "required": ["conversation"],
-            "additionalProperties": false,
-            "properties": {"conversation": {"type": "string"}}
-          }
-        }
-      },
-      "CreateStatementRequest": {
-        "type": "object",
-        "required": ["text"],
-        "additionalProperties": false,
-        "properties": {
-          "text": {"type": "string", "minLength": 1, "maxLength": 280},
-          "derivedFromStatementId": {"type": ["integer", "null"], "minimum": 0}
-        }
-      },
-      "StatementCreationResponse": {
-        "type": "object",
-        "required": ["data"],
-        "additionalProperties": false,
-        "properties": {
-          "data": {"$ref": "#/components/schemas/StatementCreationReceipt"}
-        }
-      },
-      "StatementCreationReceipt": {
-        "type": "object",
-        "required": ["statementId", "kind", "derivedFromStatementId", "newStatementQuotaRemaining", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "statementId": {"type": "integer", "minimum": 0},
-          "kind": {"type": "string", "enum": ["new", "derivative"]},
-          "derivedFromStatementId": {"type": ["integer", "null"], "minimum": 0},
-          "newStatementQuotaRemaining": {"type": "integer", "minimum": 0},
-          "links": {
-            "type": "object",
-            "required": ["explore"],
-            "additionalProperties": false,
-            "properties": {"explore": {"type": "string"}}
-          }
-        }
-      },
-      "ConversationAbout": {
-        "type": "object",
-        "required": ["slug", "title", "space", "descriptionHtml", "outroHtml", "status", "phases", "scheduledTransition", "pseudonym", "statistics", "personal", "outputs", "moderation", "capabilities", "links"],
-        "additionalProperties": false,
-        "properties": {
-          "slug": {"type": "string", "minLength": 1},
-          "title": {"type": "string", "minLength": 1},
-          "space": {"type": "string", "enum": ["demo", "real"]},
-          "descriptionHtml": {"type": ["string", "null"]},
-          "outroHtml": {"type": ["string", "null"]},
-          "status": {"type": "string", "enum": ["open", "paused", "archived"]},
-          "phases": {"type": "array", "items": {"$ref": "#/components/schemas/ConversationPhase"}},
-          "scheduledTransition": {
-            "oneOf": [
-              {"$ref": "#/components/schemas/ScheduledTransition"},
-              {"type": "null"}
-            ]
-          },
-          "pseudonym": {"type": ["string", "null"]},
-          "statistics": {"$ref": "#/components/schemas/ConversationStatistics"},
-          "personal": {
-            "oneOf": [
-              {"$ref": "#/components/schemas/PersonalContributions"},
-              {"type": "null"}
-            ]
-          },
-          "outputs": {"type": "array", "items": {"$ref": "#/components/schemas/ConversationOutput"}},
-          "moderation": {"$ref": "#/components/schemas/ConversationModeration"},
-          "capabilities": {"$ref": "#/components/schemas/ConversationAboutCapabilities"},
-          "links": {"$ref": "#/components/schemas/ConversationAboutLinks"}
-        }
-      },
-      "ConversationPhase": {
-        "type": "object",
-        "required": ["key", "label"],
-        "additionalProperties": false,
-        "properties": {
-          "key": {"type": "string"},
-          "label": {"type": "string"}
-        }
-      },
-      "ConversationStatistics": {
-        "type": "object",
-        "required": ["participants", "statementVotes", "statements", "arguments", "argumentContributors"],
-        "additionalProperties": false,
-        "properties": {
-          "participants": {"type": ["integer", "null"], "minimum": 0},
-          "statementVotes": {"type": ["integer", "null"], "minimum": 0},
-          "statements": {"type": ["integer", "null"], "minimum": 0},
-          "arguments": {"type": "integer", "minimum": 0},
-          "argumentContributors": {"type": "integer", "minimum": 0}
-        }
-      },
-      "PersonalContributions": {
-        "type": "object",
-        "required": ["statementsSuggested", "statementVotes", "statementVotesAvailable", "argumentsAdded", "argumentsRated"],
-        "additionalProperties": false,
-        "properties": {
-          "statementsSuggested": {"type": "integer", "minimum": 0},
-          "statementVotes": {"type": ["integer", "null"], "minimum": 0},
-          "statementVotesAvailable": {"type": "boolean"},
-          "argumentsAdded": {"type": "integer", "minimum": 0},
-          "argumentsRated": {"type": "integer", "minimum": 0}
-        }
-      },
-      "ConversationModeration": {
-        "type": "object",
-        "required": ["eventCount", "href"],
-        "additionalProperties": false,
-        "properties": {
-          "eventCount": {"type": "integer", "minimum": 0},
-          "href": {"type": "string"}
-        }
-      },
-      "ConversationAboutCapabilities": {
-        "type": "object",
-        "required": ["participate", "moderate"],
-        "additionalProperties": false,
-        "properties": {
-          "participate": {"type": "boolean"},
-          "moderate": {"type": "boolean"}
-        }
-      },
-      "ConversationAboutLinks": {
-        "type": "object",
-        "required": ["self", "conversation"],
-        "additionalProperties": false,
-        "properties": {
-          "self": {"type": "string"},
-          "conversation": {"type": "string"}
-        }
-      },
-      "ScheduledTransition": {
-        "type": "object",
-        "required": ["at", "target", "targetLabel"],
-        "additionalProperties": false,
-        "properties": {
-          "at": {"type": "string", "format": "date-time"},
-          "target": {"type": "string"},
-          "targetLabel": {"type": "string"}
-        }
-      },
-      "ConversationOutput": {
-        "type": "object",
-        "required": ["key", "label", "status", "symbol", "tooltip", "pending", "ready", "href"],
-        "additionalProperties": false,
-        "properties": {
-          "key": {"type": "string"},
-          "label": {"type": "string"},
-          "status": {"type": "string"},
-          "symbol": {"type": "string"},
-          "tooltip": {"type": "string"},
-          "pending": {"type": "string"},
-          "ready": {"type": "boolean"},
-          "href": {"type": ["string", "null"]}
-        }
-      },
-      "ConversationRevealSignal": {
-        "type": "object",
-        "required": ["state", "daysRemaining"],
-        "additionalProperties": false,
-        "properties": {
-          "state": {"type": "string", "enum": ["pending", "open", "revealed", "expired"]},
-          "daysRemaining": {"type": "integer", "minimum": 0}
-        }
-      },
-      "ConversationCapabilities": {
-        "type": "object",
-        "required": ["join", "participate", "moderate"],
-        "additionalProperties": false,
-        "properties": {
-          "join": {"type": "boolean"},
-          "participate": {"type": "boolean"},
-          "moderate": {"type": "boolean"}
-        }
-      },
-      "ConversationLinks": {
-        "type": "object",
-        "required": ["self", "about"],
-        "additionalProperties": false,
-        "properties": {
-          "self": {"type": "string"},
-          "about": {"type": "string"},
-          "explore": {"type": "string"},
-          "arguments": {"type": "string"},
-          "results": {"type": "string"},
-          "informedVoting": {"type": "string"},
-          "identityReveal": {"type": "string"},
-          "admin": {"type": "string"}
-        }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "required": ["error"],
-        "additionalProperties": false,
-        "properties": {
-          "error": {
-            "type": "object",
-            "required": ["code", "message"],
-            "properties": {
-              "code": {"type": "string"},
-              "message": {"type": "string"},
-              "details": {}
-            }
-          }
-        }
-      }
-    }
+ "openapi": "3.1.0",
+ "info": {
+  "title": "ProtoWiki application API",
+  "version": "1.0.0",
+  "description": "Same-origin API contract between the browser application and Flask. Polis and Particiapi remain behind Flask."
+ },
+ "servers": [
+  {
+   "url": "/api/v1"
   }
+ ],
+ "paths": {
+  "/session": {
+   "get": {
+    "operationId": "getSession",
+    "summary": "Return the current browser session and its site-wide capabilities",
+    "responses": {
+     "200": {
+      "description": "Current session",
+      "headers": {
+       "Cache-Control": {
+        "schema": {
+         "type": "string",
+         "const": "no-store"
+        }
+       }
+      },
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/SessionResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin": {
+   "get": {
+    "operationId": "getAdminCatalog",
+    "summary": "Return site-wide conversation and administrator operations",
+    "responses": {
+     "200": {
+      "description": "Admin catalog",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminCatalogResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Global admin permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations": {
+   "post": {
+    "operationId": "postAdminConversation",
+    "summary": "Create a local conversation and its managed voting conversation",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminConversationCreateRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "201": {
+      "description": "Conversation creation receipt",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminConversationCreateResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid conversation fields",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Global admin permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Slug conflict or unknown creation outcome",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "502": {
+      "description": "Voting service creation failed",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "503": {
+      "description": "Local save failed",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/global-admin-grants": {
+   "post": {
+    "operationId": "postGlobalAdminGrant",
+    "summary": "Grant site-wide administration by known Wikimedia username",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/GlobalAdminGrantRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Existing grant receipt",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/GlobalAdminGrantResponse"
+        }
+       }
+      }
+     },
+     "201": {
+      "description": "New grant receipt",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/GlobalAdminGrantResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid username",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Global admin permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Participant has not signed in",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/global-admins/{participantId}": {
+   "parameters": [
+    {
+     "name": "participantId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "put": {
+    "operationId": "putGlobalAdmin",
+    "summary": "Set desired site-wide administrator membership",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/GlobalAdminSetRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Membership receipt",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/GlobalAdminGrantResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid desired state",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Global admin permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Participant not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/termination": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "get": {
+    "operationId": "getAdminConversationTermination",
+    "summary": "Inspect live empty-conversation deletion eligibility",
+    "responses": {
+     "200": {
+      "description": "Termination state",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminTerminationResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Global admin permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations": {
+   "get": {
+    "operationId": "getConversationLane",
+    "summary": "Return participant-facing conversation groups for one space",
+    "parameters": [
+     {
+      "name": "space",
+      "in": "query",
+      "schema": {
+       "type": "string",
+       "enum": [
+        "real",
+        "demo"
+       ],
+       "default": "real"
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Conversation lane",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ConversationLaneResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid space",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/workspace": {
+   "get": {
+    "operationId": "getConversationWorkspace",
+    "summary": "Return the participant workspace composition contract",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Conversation workspace composition",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ConversationWorkspaceResponse"
+        }
+       }
+      }
+     },
+     "401": {
+      "description": "Authentication required for a real conversation",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "The current browser cannot access this conversation",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/about": {
+   "get": {
+    "operationId": "getConversationAbout",
+    "summary": "Return the participant-safe record for one conversation",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Conversation record",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ConversationAboutResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "The current browser cannot access this conversation",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/moderation-log": {
+   "get": {
+    "operationId": "getModerationLog",
+    "summary": "Return the public conversation ban and unban history",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Public moderation history",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ModerationLogResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation access denied",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/outputs/{outputKey}": {
+   "get": {
+    "operationId": "getConversationOutput",
+    "summary": "Return one participant-visible conversation output",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     },
+     {
+      "name": "outputKey",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "enum": [
+        "initial-clustering",
+        "argument-map",
+        "preliminary-results",
+        "report",
+        "dataset"
+       ]
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Conversation output context",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ConversationOutputPageResponse"
+        }
+       }
+      }
+     },
+     "401": {
+      "description": "Authentication required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation access denied",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation or output not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Participation required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/identity-reveal": {
+   "parameters": [
+    {
+     "name": "slug",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "string",
+      "minLength": 1
+     }
+    }
+   ],
+   "get": {
+    "operationId": "getIdentityReveal",
+    "summary": "Return the participant's identity-reveal timeline and capability",
+    "responses": {
+     "200": {
+      "description": "Identity-reveal state",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/IdentityRevealResponse"
+        }
+       }
+      }
+     },
+     "401": {
+      "description": "Authentication required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Conversation is not closed or participant has not joined",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   },
+   "post": {
+    "operationId": "createIdentityReveal",
+    "summary": "Permanently link the participant's Wikimedia username and pseudonym",
+    "description": "Irreversible and idempotent. A replay returns the existing public link with HTTP 200.",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/CreateIdentityRevealRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Existing reveal returned on replay",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/IdentityRevealResponse"
+        }
+       }
+      }
+     },
+     "201": {
+      "description": "Identity permanently linked",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/IdentityRevealResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Explicit confirmation missing",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Reveal window is not open",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/participation-entry": {
+   "get": {
+    "operationId": "getParticipationEntry",
+    "summary": "Resolve the authenticated participant's join-route state",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Join form, redirect, or invite-denied route state",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ParticipationEntryResponse"
+        }
+       }
+      }
+     },
+     "401": {
+      "description": "Authentication required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/pseudonym-suggestions": {
+   "get": {
+    "operationId": "getPseudonymSuggestions",
+    "summary": "Return available pseudonym suggestions for a join form",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Fresh pseudonym suggestions",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/PseudonymSuggestionsResponse"
+        }
+       }
+      }
+     },
+     "401": {
+      "description": "Authentication required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/participation": {
+   "post": {
+    "operationId": "createParticipation",
+    "summary": "Join a conversation with a globally unique pseudonym",
+    "description": "Idempotent for an already joined participant; a replay returns the existing participation with HTTP 200.",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     }
+    ],
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/CreateParticipationRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Existing participation returned for an idempotent replay",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ParticipationResponse"
+        }
+       }
+      }
+     },
+     "201": {
+      "description": "Participation created",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ParticipationResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid command",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "401": {
+      "description": "Authentication required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Access or eligibility denied",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Pseudonym conflict",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/explore": {
+   "get": {
+    "operationId": "getExploreState",
+    "summary": "Return the current participant Explore queue state",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Current Explore state",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ExploreStateResponse"
+        }
+       }
+      }
+     },
+     "401": {
+      "description": "Authentication required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation access denied or participant banned",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Participation or Explore phase is not active",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "502": {
+      "description": "Voting service unavailable",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/arguments": {
+   "get": {
+    "operationId": "getArgumentMapping",
+    "summary": "Return the participant's argument-mapping task state",
+    "description": "Contribution status, stable argument ordering, prioritization gates, and capabilities are computed server-side. Aggregate importance counts are withheld during the open phase to avoid anchoring.",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Current argument-mapping state",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ArgumentMappingResponse"
+        }
+       }
+      }
+     },
+     "401": {
+      "description": "Authentication required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation access is denied or the participant is banned",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Participation is missing or argument mapping is not open",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/informed-voting": {
+   "get": {
+    "operationId": "getInformedVoting",
+    "summary": "Return the participant's informed-voting cards and progress",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Current informed-voting state",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/InformedVotingResponse"
+        }
+       }
+      }
+     },
+     "401": {
+      "description": "Authentication required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation access is denied or participant is banned",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Participation or informed-voting phase is not active",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "502": {
+      "description": "Voting service unavailable",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/results": {
+   "get": {
+    "operationId": "getResultsReport",
+    "summary": "Return privacy-safe preliminary or final aggregate results",
+    "description": "Uses the live moderation filter for preliminary results and the publication snapshot for a final report.",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Aggregate results report",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ResultsReportResponse"
+        }
+       }
+      }
+     },
+     "401": {
+      "description": "Authentication required for personal-only results",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation access denied",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Results are not published",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/intermediate-results": {
+   "get": {
+    "operationId": "getIntermediateResults",
+    "summary": "Return privacy-safe initial-round consensus and opinion groups",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Current intermediate-results state",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/IntermediateResultsResponse"
+        }
+       }
+      }
+     },
+     "401": {
+      "description": "Authentication required for personal-only results",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation access denied",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Intermediate results are not published",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/featured-statements/{featuredStatementId}/informed-vote": {
+   "put": {
+    "operationId": "putInformedVote",
+    "summary": "Set the participant's informed vote for a featured statement",
+    "description": "Idempotent replacement command. Phase 6 Polis identifiers are resolved server-side.",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     },
+     {
+      "name": "featuredStatementId",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "integer",
+       "minimum": 1
+      }
+     }
+    ],
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/InformedVoteRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Informed vote stored",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/InformedVoteResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid choice",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Featured statement is not available in this round",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Informed voting is not active",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "502": {
+      "description": "Voting service unavailable",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/featured-statements/{featuredStatementId}/arguments": {
+   "post": {
+    "operationId": "createArgument",
+    "summary": "Submit one argument for a featured-statement side",
+    "description": "Idempotent for an identical replay. One contribution per participant, featured statement, and side is enforced by the database.",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     },
+     {
+      "name": "featuredStatementId",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "integer",
+       "minimum": 1
+      }
+     }
+    ],
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/CreateArgumentRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Existing identical argument returned",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ArgumentSubmissionResponse"
+        }
+       }
+      }
+     },
+     "201": {
+      "description": "Argument created",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ArgumentSubmissionResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid argument",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "401": {
+      "description": "Authentication required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Access denied",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation or featured statement not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Phase conflict or a different argument already exists",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/featured-statements/{featuredStatementId}/contributions/{side}/skip": {
+   "put": {
+    "operationId": "putArgumentContributionSkip",
+    "summary": "Explicitly skip one argument-contribution side",
+    "description": "Idempotent state replacement; repeated PUT requests keep the side skipped.",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     },
+     {
+      "name": "featuredStatementId",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "integer",
+       "minimum": 1
+      }
+     },
+     {
+      "name": "side",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "enum": [
+        "pro",
+        "con"
+       ]
+      }
+     }
+    ],
+    "responses": {
+     "200": {
+      "description": "Contribution side is skipped",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ArgumentSkipResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid side",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "401": {
+      "description": "Authentication required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Access denied",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation or featured statement not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Phase conflict or the side already has an argument",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/arguments/{argumentId}/priority": {
+   "put": {
+    "operationId": "putArgumentPriority",
+    "summary": "Set whether an argument is one of the participant's priorities",
+    "description": "Idempotent state replacement serialized per participant, featured statement, and side.",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     },
+     {
+      "name": "argumentId",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "integer",
+       "minimum": 1
+      }
+     }
+    ],
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/ArgumentPriorityRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Priority state stored",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ArgumentPriorityResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid selection state",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "401": {
+      "description": "Authentication required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Access denied",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation or argument not found/available",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Contribution gate, volume gate, budget, or phase conflict",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/flags": {
+   "post": {
+    "operationId": "createContentFlag",
+    "summary": "Flag a statement or argument for moderator review",
+    "description": "Idempotent for the same participant, target, and category while a flag remains open. Other requires an explanation.",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     }
+    ],
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/CreateContentFlagRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Existing open flag returned",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ContentFlagResponse"
+        }
+       }
+      }
+     },
+     "201": {
+      "description": "Flag created",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ContentFlagResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid target, category, or missing Other explanation",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "401": {
+      "description": "Authentication required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Access denied",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation or target not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Participation missing or flags closed",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "502": {
+      "description": "Statement validation service unavailable",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/statements/{statementId}/vote": {
+   "put": {
+    "operationId": "putExploreVote",
+    "summary": "Set the participant's vote on an Explore statement",
+    "description": "Idempotent: repeated PUT requests replace the vote with the requested choice.",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     },
+     {
+      "name": "statementId",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "integer",
+       "minimum": 0
+      }
+     }
+    ],
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/ExploreVoteRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Vote stored",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ExploreVoteResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid vote choice",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation access denied or participant banned",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation or statement not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Participation or Explore phase is not active",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "502": {
+      "description": "Voting service unavailable",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/conversations/{slug}/statements": {
+   "post": {
+    "operationId": "createStatement",
+    "summary": "Submit a new or derivative statement during Explore",
+    "description": "A durable idempotency receipt prevents duplicate upstream statements. Reusing a completed key with the same body returns HTTP 200; a pending receipt reports an unknown outcome.",
+    "parameters": [
+     {
+      "name": "slug",
+      "in": "path",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 1
+      }
+     },
+     {
+      "name": "Idempotency-Key",
+      "in": "header",
+      "required": true,
+      "schema": {
+       "type": "string",
+       "minLength": 8,
+       "maxLength": 128,
+       "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{7,127}$"
+      }
+     }
+    ],
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/CreateStatementRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Completed command replay",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/StatementCreationResponse"
+        }
+       }
+      }
+     },
+     "201": {
+      "description": "Statement created",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/StatementCreationResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid request, idempotency key, or parent statement",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "401": {
+      "description": "Authentication required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation access denied or participant banned",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Quota, derivative similarity, idempotency conflict, or unknown outcome",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "502": {
+      "description": "The upstream command outcome is unknown",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/participants": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "get": {
+    "operationId": "getAdminConversationParticipants",
+    "summary": "Return the authorized participant engagement roster",
+    "responses": {
+     "200": {
+      "description": "Participant roster",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminParticipantRosterResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation moderation permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/participants/{participantId}/access": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    },
+    {
+     "name": "participantId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "put": {
+    "operationId": "putAdminParticipantAccess",
+    "summary": "Set whether a participant is banned from one conversation",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminParticipantAccessRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Current participant access state",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminParticipantAccessResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid desired access state",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation moderation permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation or participant membership not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/flags": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "get": {
+    "operationId": "getAdminConversationFlags",
+    "summary": "Return the privacy-safe moderation queue",
+    "responses": {
+     "200": {
+      "description": "Moderation queue",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminFlagQueueResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation moderation permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/flags/{flagId}/resolution": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    },
+    {
+     "name": "flagId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "put": {
+    "operationId": "putAdminFlagResolution",
+    "summary": "Resolve one content flag",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminFlagResolutionRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Current resolution state",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminFlagResolutionResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid resolution",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation moderation permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation or flag not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/invitations": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "get": {
+    "operationId": "getAdminConversationInvitations",
+    "summary": "Return the invitation roster and access policy",
+    "responses": {
+     "200": {
+      "description": "Invitation roster",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminInvitationRosterResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation moderation permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   },
+   "put": {
+    "operationId": "putAdminConversationInvitations",
+    "summary": "Add a batch of invitations idempotently",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminInvitationBatchRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Batch outcome and refreshed roster",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminInvitationBatchResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid usernames",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation moderation permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "503": {
+      "description": "Invitations could not be saved atomically",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/invitations/{inviteId}": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    },
+    {
+     "name": "inviteId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "delete": {
+    "operationId": "deleteAdminConversationInvitation",
+    "summary": "Remove one invitation",
+    "responses": {
+     "200": {
+      "description": "Removal receipt and refreshed roster",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminInvitationRemovalResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation moderation permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation or invitation not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/roles": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "get": {
+    "operationId": "getAdminConversationRoles",
+    "summary": "Return scoped role assignments and authorized candidates",
+    "responses": {
+     "200": {
+      "description": "Role roster",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminRoleRosterResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation moderation permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/roles/{participantId}": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    },
+    {
+     "name": "participantId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "put": {
+    "operationId": "putAdminConversationRoles",
+    "summary": "Replace one participant's scoped role set",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminRoleSetRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Role replacement receipt",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminRoleSetResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid role set",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Global admin permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation or participant not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "get": {
+    "operationId": "getAdminConversationLifecycle",
+    "summary": "Return lifecycle, phase readiness, capabilities, and management links",
+    "responses": {
+     "200": {
+      "description": "Admin lifecycle",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminLifecycleResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation moderation permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   },
+   "delete": {
+    "operationId": "deleteAdminConversation",
+    "summary": "Delete a verified empty conversation after hiding it upstream",
+    "responses": {
+     "200": {
+      "description": "Deletion receipt",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminDeletionResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Global admin permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Votes block deletion or command outcome is unknown",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "502": {
+      "description": "Voting service hide failed",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "503": {
+      "description": "Vote verification unavailable",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/settings": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "get": {
+    "operationId": "getAdminConversationSettings",
+    "summary": "Return editable conversation settings and tool-owned guidance",
+    "responses": {
+     "200": {
+      "description": "Conversation settings",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminSettingsResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation moderation permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   },
+   "put": {
+    "operationId": "putAdminConversationSettings",
+    "summary": "Replace editable conversation settings",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminSettingsRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Update receipt and refreshed settings",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminSettingsUpdateResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid settings",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Organizer permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/recommendation-tier": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "put": {
+    "operationId": "putAdminConversationRecommendationTier",
+    "summary": "Set the advisory recommendation tier",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminRecommendationTierRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Update receipt and refreshed recommendations",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminRecommendationTierResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid recommendation tier",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Organizer permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/statements": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "get": {
+    "operationId": "getAdminConversationStatements",
+    "summary": "Return the privacy-safe statement moderation workspace",
+    "responses": {
+     "200": {
+      "description": "Statement workspace",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminStatementWorkspaceResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation moderation permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   },
+   "post": {
+    "operationId": "postAdminSeedStatement",
+    "summary": "Add one approved seed statement with optional correction provenance",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminSeedStatementRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "201": {
+      "description": "Seed statement receipt",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminSeedStatementResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid or locked seed statement",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation moderation permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation or corrected statement not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "502": {
+      "description": "Statement service unavailable",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/statement-moderation-policy": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "put": {
+    "operationId": "putAdminStatementModerationPolicy",
+    "summary": "Set the default decision for future statements without reinterpreting existing statements",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminStatementModerationPolicyRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Policy receipt and refreshed statement workspace",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminStatementModerationPolicyResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid policy",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation moderation permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Upstream outcome may be unknown",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "502": {
+      "description": "Moderation baseline reconciliation failed",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "503": {
+      "description": "Current state could not be verified or saved",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/statements/{statementId}/moderation": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    },
+    {
+     "name": "statementId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 0
+     }
+    }
+   ],
+   "put": {
+    "operationId": "putAdminStatementModeration",
+    "summary": "Replace one statement's moderation state",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminStatementModerationRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Moderation receipt and refreshed workspace",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminStatementModerationResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid moderation state",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation moderation permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Conversation or statement not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Last featured statement is protected during argument mapping",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "502": {
+      "description": "Statement service unavailable",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/statement-imports": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "post": {
+    "operationId": "postAdminStatementImport",
+    "summary": "Import approved seed statements after validation and deduplication",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminStatementImportRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Import outcome",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminStatementImportResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid import",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation moderation permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "503": {
+      "description": "Existing statements could not be verified",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "502": {
+      "description": "Statement service unavailable",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/featured-statements": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "get": {
+    "operationId": "getAdminFeaturedStatements",
+    "summary": "Return selected statements, transparent candidate metrics, and argument moderation state",
+    "responses": {
+     "200": {
+      "description": "Featured workspace",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminFeaturedWorkspaceResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation moderation permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/featured-statements/{statementId}": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    },
+    {
+     "name": "statementId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 0
+     }
+    }
+   ],
+   "put": {
+    "operationId": "putAdminFeaturedStatement",
+    "summary": "Idempotently select a verified statement for argument mapping",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminFeaturedSelectionRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Selection receipt",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminFeaturedSelectionResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid selection source",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Statement not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Command outcome unknown",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "502": {
+      "description": "Live round synchronization failed",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "503": {
+      "description": "Statement verification unavailable",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/featured-selections/{featuredId}": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    },
+    {
+     "name": "featuredId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "delete": {
+    "operationId": "deleteAdminFeaturedSelection",
+    "summary": "Remove a featured selection and reconcile a live informed-voting round",
+    "responses": {
+     "200": {
+      "description": "Removal receipt",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminFeaturedRemovalResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Featured selection not found",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Last selection protected or command outcome unknown",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "502": {
+      "description": "Live round synchronization failed",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/featured-arguments/{argumentId}": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    },
+    {
+     "name": "argumentId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "put": {
+    "operationId": "putAdminFeaturedArgument",
+    "summary": "Set whether an argument is hidden",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminFeaturedArgumentRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Argument visibility receipt",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminFeaturedArgumentResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid desired visibility",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Argument not found in conversation",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   },
+   "delete": {
+    "operationId": "deleteAdminFeaturedArgument",
+    "summary": "Delete an argument and its votes",
+    "responses": {
+     "200": {
+      "description": "Argument deletion receipt",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminFeaturedArgumentDeletionResponse"
+        }
+       }
+      }
+     },
+     "404": {
+      "description": "Argument not found in conversation",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/phase": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "put": {
+    "operationId": "putAdminConversationPhase",
+    "summary": "Advance the guided lifecycle after confirming readiness",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminPhaseAdvanceRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Transition receipt and refreshed lifecycle",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminPhaseAdvanceResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid confirmation payload",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Organizer permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Readiness, state, concurrency, or unknown-outcome conflict",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "502": {
+      "description": "The next phase could not be prepared upstream",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "503": {
+      "description": "The phase transition could not be saved",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/phases": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "put": {
+    "operationId": "putAdminConversationPhases",
+    "summary": "Replace the advanced route-valid phase set",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminAdvancedPhasesRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Phase-set receipt and refreshed lifecycle",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminAdvancedPhasesResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid or out-of-route phase key",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Global admin permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/phase6-initialization": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "post": {
+    "operationId": "createAdminPhase6Initialization",
+    "summary": "Initialize the dedicated informed-voting round",
+    "responses": {
+     "201": {
+      "description": "Initialization receipt and refreshed lifecycle",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminPhase6InitializationResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Conversation moderation permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "State, concurrency, or unknown-outcome conflict",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "502": {
+      "description": "The informed-voting round could not be prepared upstream",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/pause": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "put": {
+    "operationId": "putAdminConversationPause",
+    "summary": "Set the desired pause state",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminPauseRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Pause receipt and refreshed lifecycle",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminPauseResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid state",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Global admin permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Conversation closed",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/archive": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "put": {
+    "operationId": "putAdminConversationArchive",
+    "summary": "Set reversible archive state without publishing",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminArchiveRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Archive receipt and refreshed lifecycle",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminArchiveResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid desired state",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Global admin permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Published conversations cannot be archived",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/schedule": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "put": {
+    "operationId": "putAdminConversationSchedule",
+    "summary": "Replace or cancel the pending phase schedule",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminScheduleRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "200": {
+      "description": "Schedule receipt and refreshed lifecycle",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminScheduleResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid or past date-time",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Global admin permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "The current transition cannot be scheduled",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/admin/conversations/{conversationId}/publication": {
+   "parameters": [
+    {
+     "name": "conversationId",
+     "in": "path",
+     "required": true,
+     "schema": {
+      "type": "integer",
+      "minimum": 1
+     }
+    }
+   ],
+   "post": {
+    "operationId": "createAdminConversationPublication",
+    "summary": "Irreversibly publish the frozen final report",
+    "requestBody": {
+     "required": true,
+     "content": {
+      "application/json": {
+       "schema": {
+        "$ref": "#/components/schemas/AdminPublicationRequest"
+       }
+      }
+     }
+    },
+    "responses": {
+     "201": {
+      "description": "Published lifecycle",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/AdminPublicationResponse"
+        }
+       }
+      }
+     },
+     "400": {
+      "description": "Invalid confirmations",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "403": {
+      "description": "Global admin permission required",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     },
+     "409": {
+      "description": "Publication state or readiness conflict",
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/ErrorResponse"
+        }
+       }
+      }
+     }
+    }
+   }
+  },
+  "/openapi.json": {
+   "get": {
+    "operationId": "getOpenApiDocument",
+    "summary": "Return this OpenAPI document",
+    "responses": {
+     "200": {
+      "description": "OpenAPI 3.1 document"
+     }
+    }
+   }
+  }
+ },
+ "components": {
+  "schemas": {
+   "AdminCatalogResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/AdminCatalog"
+     }
+    }
+   },
+   "AdminCatalog": {
+    "type": "object",
+    "required": [
+     "conversations",
+     "globalAdmins",
+     "phaseRoutes",
+     "creation",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "conversations": {
+      "type": "array",
+      "items": {
+       "type": "object",
+       "required": [
+        "id",
+        "slug",
+        "title",
+        "accessPolicy",
+        "status",
+        "createdAt",
+        "links"
+       ],
+       "additionalProperties": false,
+       "properties": {
+        "id": {
+         "type": "integer",
+         "minimum": 1
+        },
+        "slug": {
+         "type": "string"
+        },
+        "title": {
+         "type": "string"
+        },
+        "accessPolicy": {
+         "type": "string",
+         "enum": [
+          "public",
+          "invite_only",
+          "demo"
+         ]
+        },
+        "status": {
+         "type": "string",
+         "enum": [
+          "active",
+          "paused",
+          "archived",
+          "closed"
+         ]
+        },
+        "createdAt": {
+         "type": [
+          "string",
+          "null"
+         ],
+         "format": "date-time"
+        },
+        "links": {
+         "type": "object",
+         "required": [
+          "participant",
+          "manage"
+         ],
+         "additionalProperties": false,
+         "properties": {
+          "participant": {
+           "type": "string"
+          },
+          "manage": {
+           "type": "string"
+          }
+         }
+        }
+       }
+      }
+     },
+     "globalAdmins": {
+      "type": "array",
+      "items": {
+       "type": "object",
+       "required": [
+        "participantId",
+        "username"
+       ],
+       "additionalProperties": false,
+       "properties": {
+        "participantId": {
+         "type": "integer",
+         "minimum": 1
+        },
+        "username": {
+         "type": "string"
+        }
+       }
+      }
+     },
+     "phaseRoutes": {
+      "type": "array",
+      "items": {
+       "type": "object",
+       "required": [
+        "key",
+        "label",
+        "description"
+       ],
+       "additionalProperties": false,
+       "properties": {
+        "key": {
+         "type": "string"
+        },
+        "label": {
+         "type": "string"
+        },
+        "description": {
+         "type": "string"
+        }
+       }
+      }
+     },
+     "creation": {
+      "type": "object",
+      "required": [
+       "mode",
+       "defaultModerationPolicy"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "mode": {
+        "type": "string",
+        "enum": [
+         "managed",
+         "manual_polis_id"
+        ]
+       },
+       "defaultModerationPolicy": {
+        "type": "string",
+        "const": "moderate"
+       }
+      }
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "self"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "self": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "AdminConversationCreateRequest": {
+    "type": "object",
+    "required": [
+     "slug",
+     "title",
+     "introHtml",
+     "outroHtml",
+     "accessPolicy",
+     "phaseRoute",
+     "eligibilityEventId",
+     "eligibilityLabel",
+     "polisId"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "slug": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "maxLength": 80
+     },
+     "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+     },
+     "introHtml": {
+      "type": "string"
+     },
+     "outroHtml": {
+      "type": "string"
+     },
+     "accessPolicy": {
+      "type": "string",
+      "enum": [
+       "public",
+       "invite_only",
+       "demo"
+      ]
+     },
+     "phaseRoute": {
+      "type": "string",
+      "minLength": 1
+     },
+     "eligibilityEventId": {
+      "type": "string",
+      "maxLength": 80
+     },
+     "eligibilityLabel": {
+      "type": "string",
+      "maxLength": 255
+     },
+     "polisId": {
+      "type": [
+       "string",
+       "null"
+      ]
+     }
+    }
+   },
+   "AdminConversationCreateResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "conversation",
+       "links"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "conversation": {
+        "type": "object",
+        "required": [
+         "id",
+         "slug",
+         "title"
+        ],
+        "additionalProperties": false,
+        "properties": {
+         "id": {
+          "type": "integer",
+          "minimum": 1
+         },
+         "slug": {
+          "type": "string"
+         },
+         "title": {
+          "type": "string"
+         }
+        }
+       },
+       "links": {
+        "type": "object",
+        "required": [
+         "manage",
+         "catalog"
+        ],
+        "additionalProperties": false,
+        "properties": {
+         "manage": {
+          "type": "string"
+         },
+         "catalog": {
+          "type": "string"
+         }
+        }
+       }
+      }
+     }
+    }
+   },
+   "GlobalAdminGrantRequest": {
+    "type": "object",
+    "required": [
+     "username"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "username": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+     }
+    }
+   },
+   "GlobalAdminSetRequest": {
+    "type": "object",
+    "required": [
+     "granted"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "granted": {
+      "type": "boolean"
+     }
+    }
+   },
+   "GlobalAdminGrantResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "participantId",
+       "username",
+       "granted",
+       "changed",
+       "catalog"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "participantId": {
+        "type": "integer",
+        "minimum": 1
+       },
+       "username": {
+        "type": "string"
+       },
+       "granted": {
+        "type": "boolean"
+       },
+       "changed": {
+        "type": "boolean"
+       },
+       "catalog": {
+        "$ref": "#/components/schemas/AdminCatalog"
+       }
+      }
+     }
+    }
+   },
+   "AdminTerminationResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/AdminTermination"
+     }
+    }
+   },
+   "AdminTermination": {
+    "type": "object",
+    "required": [
+     "conversation",
+     "deletion",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "conversation": {
+      "type": "object",
+      "required": [
+       "id",
+       "slug",
+       "title"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "id": {
+        "type": "integer",
+        "minimum": 1
+       },
+       "slug": {
+        "type": "string"
+       },
+       "title": {
+        "type": "string"
+       }
+      }
+     },
+     "deletion": {
+      "type": "object",
+      "required": [
+       "state",
+       "validVoteCount",
+       "reason"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "state": {
+        "type": "string",
+        "enum": [
+         "eligible",
+         "blocked_by_votes",
+         "unavailable"
+        ]
+       },
+       "validVoteCount": {
+        "type": [
+         "integer",
+         "null"
+        ],
+        "minimum": 0
+       },
+       "reason": {
+        "type": "string"
+       }
+      }
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "self",
+       "lifecycle"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "self": {
+        "type": "string"
+       },
+       "lifecycle": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "AdminDeletionResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "conversationId",
+       "deleted",
+       "links"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "conversationId": {
+        "type": "integer",
+        "minimum": 1
+       },
+       "deleted": {
+        "type": "boolean",
+        "const": true
+       },
+       "links": {
+        "type": "object",
+        "required": [
+         "admin"
+        ],
+        "additionalProperties": false,
+        "properties": {
+         "admin": {
+          "type": "string"
+         }
+        }
+       }
+      }
+     }
+    }
+   },
+   "AdminStatementWorkspaceResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/AdminStatementWorkspace"
+     }
+    }
+   },
+   "AdminStatementModerationPolicyRequest": {
+    "type": "object",
+    "required": [
+     "mode"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "mode": {
+      "type": "string",
+      "enum": [
+       "moderate",
+       "auto_approve"
+      ]
+     }
+    }
+   },
+   "AdminStatementModerationPolicyResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "mode",
+       "changed",
+       "reconciledStatements",
+       "workspace"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "mode": {
+        "type": "string",
+        "enum": [
+         "moderate",
+         "auto_approve"
+        ]
+       },
+       "changed": {
+        "type": "boolean"
+       },
+       "reconciledStatements": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "workspace": {
+        "$ref": "#/components/schemas/AdminStatementWorkspace"
+       }
+      }
+     }
+    }
+   },
+   "AdminStatementModerationRequest": {
+    "type": "object",
+    "required": [
+     "status"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "status": {
+      "type": "string",
+      "enum": [
+       "approved",
+       "pending",
+       "hidden"
+      ]
+     }
+    }
+   },
+   "AdminStatementModerationResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "statementId",
+       "status",
+       "links"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "statementId": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "status": {
+        "type": "string",
+        "enum": [
+         "approved",
+         "pending",
+         "hidden"
+        ]
+       },
+       "links": {
+        "type": "object",
+        "required": [
+         "statements"
+        ],
+        "additionalProperties": false,
+        "properties": {
+         "statements": {
+          "type": "string"
+         }
+        }
+       }
+      }
+     }
+    }
+   },
+   "AdminSeedStatementRequest": {
+    "type": "object",
+    "required": [
+     "text",
+     "derivedFromId"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "text": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 280
+     },
+     "derivedFromId": {
+      "type": [
+       "integer",
+       "null"
+      ],
+      "minimum": 0
+     }
+    }
+   },
+   "AdminSeedStatementResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "statementId",
+       "derivedFromId",
+       "provenanceRecorded",
+       "links"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "statementId": {
+        "type": [
+         "integer",
+         "null"
+        ],
+        "minimum": 0
+       },
+       "derivedFromId": {
+        "type": [
+         "integer",
+         "null"
+        ],
+        "minimum": 0
+       },
+       "provenanceRecorded": {
+        "type": [
+         "boolean",
+         "null"
+        ]
+       },
+       "links": {
+        "type": "object",
+        "required": [
+         "statements"
+        ],
+        "additionalProperties": false,
+        "properties": {
+         "statements": {
+          "type": "string"
+         }
+        }
+       }
+      }
+     }
+    }
+   },
+   "AdminStatementImportRequest": {
+    "type": "object",
+    "required": [
+     "statements"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "statements": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 20,
+      "items": {
+       "type": "string",
+       "maxLength": 280
+      }
+     }
+    }
+   },
+   "AdminStatementImportResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "outcome",
+       "links"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "outcome": {
+        "type": "object",
+        "required": [
+         "imported",
+         "skippedExisting",
+         "skippedDuplicateInput",
+         "failedUpstream"
+        ],
+        "additionalProperties": false,
+        "properties": {
+         "imported": {
+          "type": "integer",
+          "minimum": 0
+         },
+         "skippedExisting": {
+          "type": "integer",
+          "minimum": 0
+         },
+         "skippedDuplicateInput": {
+          "type": "integer",
+          "minimum": 0
+         },
+         "failedUpstream": {
+          "type": "integer",
+          "minimum": 0
+         }
+        }
+       },
+       "links": {
+        "type": "object",
+        "required": [
+         "statements"
+        ],
+        "additionalProperties": false,
+        "properties": {
+         "statements": {
+          "type": "string"
+         }
+        }
+       }
+      }
+     }
+    }
+   },
+   "AdminFeaturedWorkspaceResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/AdminFeaturedWorkspace"
+     }
+    }
+   },
+   "AdminFeaturedSelectionRequest": {
+    "type": "object",
+    "required": [
+     "source"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "source": {
+      "type": "string",
+      "enum": [
+       "system",
+       "manual"
+      ]
+     }
+    }
+   },
+   "AdminFeaturedSelectionResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "featuredId",
+       "statementId",
+       "changed",
+       "links"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "featuredId": {
+        "type": "integer",
+        "minimum": 1
+       },
+       "statementId": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "changed": {
+        "type": "boolean"
+       },
+       "links": {
+        "type": "object",
+        "required": [
+         "featured"
+        ],
+        "additionalProperties": false,
+        "properties": {
+         "featured": {
+          "type": "string"
+         }
+        }
+       }
+      }
+     }
+    }
+   },
+   "AdminFeaturedRemovalResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "featuredId",
+       "statementId",
+       "removed",
+       "links"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "featuredId": {
+        "type": "integer",
+        "minimum": 1
+       },
+       "statementId": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "removed": {
+        "type": "boolean",
+        "const": true
+       },
+       "links": {
+        "type": "object",
+        "required": [
+         "featured"
+        ],
+        "additionalProperties": false,
+        "properties": {
+         "featured": {
+          "type": "string"
+         }
+        }
+       }
+      }
+     }
+    }
+   },
+   "AdminFeaturedArgumentRequest": {
+    "type": "object",
+    "required": [
+     "hidden"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "hidden": {
+      "type": "boolean"
+     }
+    }
+   },
+   "AdminFeaturedArgumentResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "argumentId",
+       "hidden",
+       "changed",
+       "links"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "argumentId": {
+        "type": "integer",
+        "minimum": 1
+       },
+       "hidden": {
+        "type": "boolean"
+       },
+       "changed": {
+        "type": "boolean"
+       },
+       "links": {
+        "type": "object",
+        "required": [
+         "featured"
+        ],
+        "additionalProperties": false,
+        "properties": {
+         "featured": {
+          "type": "string"
+         }
+        }
+       }
+      }
+     }
+    }
+   },
+   "AdminFeaturedArgumentDeletionResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "argumentId",
+       "featuredId",
+       "deleted",
+       "links"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "argumentId": {
+        "type": "integer",
+        "minimum": 1
+       },
+       "featuredId": {
+        "type": "integer",
+        "minimum": 1
+       },
+       "deleted": {
+        "type": "boolean",
+        "const": true
+       },
+       "links": {
+        "type": "object",
+        "required": [
+         "featured"
+        ],
+        "additionalProperties": false,
+        "properties": {
+         "featured": {
+          "type": "string"
+         }
+        }
+       }
+      }
+     }
+    }
+   },
+   "AdminFeaturedWorkspace": {
+    "type": "object",
+    "required": [
+     "conversation",
+     "selected",
+     "candidates",
+     "dataAvailability",
+     "phase",
+     "guidance",
+     "capabilities",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "conversation": {
+      "type": "object",
+      "required": [
+       "id",
+       "slug",
+       "title"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "id": {
+        "type": "integer",
+        "minimum": 1
+       },
+       "slug": {
+        "type": "string"
+       },
+       "title": {
+        "type": "string"
+       }
+      }
+     },
+     "selected": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/AdminFeaturedSelection"
+      }
+     },
+     "candidates": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/AdminFeaturedCandidate"
+      }
+     },
+     "dataAvailability": {
+      "type": "object",
+      "required": [
+       "candidates"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "candidates": {
+        "type": "boolean"
+       }
+      }
+     },
+     "phase": {
+      "type": "object",
+      "required": [
+       "argumentMappingActive",
+       "informedVotingLive"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "argumentMappingActive": {
+        "type": "boolean"
+       },
+       "informedVotingLive": {
+        "type": "boolean"
+       }
+      }
+     },
+     "guidance": {
+      "type": "object",
+      "required": [
+       "recommendedCount",
+       "note"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "recommendedCount": {
+        "type": "integer",
+        "minimum": 1
+       },
+       "note": {
+        "type": "string"
+       }
+      }
+     },
+     "capabilities": {
+      "type": "object",
+      "required": [
+       "manage"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "manage": {
+        "type": "boolean"
+       }
+      }
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "self",
+       "lifecycle"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "self": {
+        "type": "string"
+       },
+       "lifecycle": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "AdminFeaturedSelection": {
+    "type": "object",
+    "required": [
+     "featuredId",
+     "statementId",
+     "text",
+     "systemSuggested",
+     "provenance",
+     "arguments"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "featuredId": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "statementId": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "text": {
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "systemSuggested": {
+      "type": "boolean"
+     },
+     "provenance": {
+      "oneOf": [
+       {
+        "type": "null"
+       },
+       {
+        "$ref": "#/components/schemas/AdminStatementProvenance"
+       }
+      ]
+     },
+     "arguments": {
+      "type": "array",
+      "items": {
+       "type": "object",
+       "required": [
+        "id",
+        "side",
+        "body",
+        "proposerPseudonym",
+        "hidden",
+        "createdAt"
+       ],
+       "additionalProperties": false,
+       "properties": {
+        "id": {
+         "type": "integer",
+         "minimum": 1
+        },
+        "side": {
+         "type": "string",
+         "enum": [
+          "pro",
+          "con"
+         ]
+        },
+        "body": {
+         "type": "string"
+        },
+        "proposerPseudonym": {
+         "type": [
+          "string",
+          "null"
+         ]
+        },
+        "hidden": {
+         "type": "boolean"
+        },
+        "createdAt": {
+         "type": [
+          "string",
+          "null"
+         ],
+         "format": "date-time"
+        }
+       }
+      }
+     }
+    }
+   },
+   "AdminFeaturedCandidate": {
+    "type": "object",
+    "required": [
+     "statementId",
+     "text",
+     "seed",
+     "votes",
+     "provenance"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "statementId": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "text": {
+      "type": "string"
+     },
+     "seed": {
+      "type": "boolean"
+     },
+     "provenance": {
+      "oneOf": [
+       {
+        "type": "null"
+       },
+       {
+        "$ref": "#/components/schemas/AdminStatementProvenance"
+       }
+      ]
+     },
+     "votes": {
+      "type": "object",
+      "required": [
+       "agree",
+       "pass",
+       "disagree",
+       "total",
+       "agreementPercent"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "agree": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "pass": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "disagree": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "total": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "agreementPercent": {
+        "type": [
+         "number",
+         "null"
+        ],
+        "minimum": 0,
+        "maximum": 100
+       }
+      }
+     }
+    }
+   },
+   "AdminStatementProvenance": {
+    "type": "object",
+    "required": [
+     "derivedFromId",
+     "scores"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "derivedFromId": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "scores": {
+      "type": "array",
+      "items": {
+       "type": "object",
+       "required": [
+        "model",
+        "value"
+       ],
+       "additionalProperties": false,
+       "properties": {
+        "model": {
+         "type": "string"
+        },
+        "value": {
+         "type": "number",
+         "minimum": 0,
+         "maximum": 1
+        }
+       }
+      }
+     }
+    }
+   },
+   "AdminStatementWorkspace": {
+    "type": "object",
+    "required": [
+     "conversation",
+     "statements",
+     "moderationPolicy",
+     "dataAvailability",
+     "seeding",
+     "capabilities",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "conversation": {
+      "type": "object",
+      "required": [
+       "id",
+       "slug",
+       "title"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "id": {
+        "type": "integer",
+        "minimum": 1
+       },
+       "slug": {
+        "type": "string"
+       },
+       "title": {
+        "type": "string"
+       }
+      }
+     },
+     "statements": {
+      "type": "object",
+      "required": [
+       "pending",
+       "approved",
+       "hidden"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "pending": {
+        "type": "array",
+        "items": {
+         "$ref": "#/components/schemas/AdminStatement"
+        }
+       },
+       "approved": {
+        "type": "array",
+        "items": {
+         "$ref": "#/components/schemas/AdminStatement"
+        }
+       },
+       "hidden": {
+        "type": "array",
+        "items": {
+         "$ref": "#/components/schemas/AdminStatement"
+        }
+       }
+      }
+     },
+     "moderationPolicy": {
+      "type": "object",
+      "required": [
+       "mode",
+       "newStatements",
+       "available"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "mode": {
+        "type": [
+         "string",
+         "null"
+        ],
+        "enum": [
+         "moderate",
+         "auto_approve",
+         null
+        ]
+       },
+       "newStatements": {
+        "type": [
+         "string",
+         "null"
+        ],
+        "enum": [
+         "pending",
+         "approved",
+         null
+        ]
+       },
+       "available": {
+        "type": "boolean"
+       }
+      }
+     },
+     "dataAvailability": {
+      "type": "object",
+      "required": [
+       "statements"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "statements": {
+        "type": "boolean"
+       }
+      }
+     },
+     "seeding": {
+      "type": "object",
+      "required": [
+       "allowed",
+       "lockReason",
+       "maxStatementsPerImport",
+       "maxCharactersPerStatement"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "allowed": {
+        "type": "boolean"
+       },
+       "lockReason": {
+        "type": [
+         "string",
+         "null"
+        ]
+       },
+       "maxStatementsPerImport": {
+        "type": "integer",
+        "minimum": 1
+       },
+       "maxCharactersPerStatement": {
+        "type": "integer",
+        "minimum": 1
+       }
+      }
+     },
+     "capabilities": {
+      "type": "object",
+      "required": [
+       "moderate",
+       "seed"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "moderate": {
+        "type": "boolean"
+       },
+       "seed": {
+        "type": "boolean"
+       }
+      }
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "self",
+       "lifecycle"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "self": {
+        "type": "string"
+       },
+       "lifecycle": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "AdminStatement": {
+    "type": "object",
+    "required": [
+     "id",
+     "text",
+     "moderation",
+     "seed",
+     "featured",
+     "votes",
+     "provenance"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "id": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "text": {
+      "type": "string"
+     },
+     "moderation": {
+      "type": "string",
+      "enum": [
+       "approved",
+       "pending",
+       "hidden"
+      ]
+     },
+     "seed": {
+      "type": "boolean"
+     },
+     "featured": {
+      "type": "boolean"
+     },
+     "votes": {
+      "type": "object",
+      "required": [
+       "agree",
+       "pass",
+       "disagree"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "agree": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "pass": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "disagree": {
+        "type": "integer",
+        "minimum": 0
+       }
+      }
+     },
+     "provenance": {
+      "oneOf": [
+       {
+        "type": "null"
+       },
+       {
+        "type": "object",
+        "required": [
+         "derivedFromId",
+         "scores"
+        ],
+        "additionalProperties": false,
+        "properties": {
+         "derivedFromId": {
+          "type": "integer",
+          "minimum": 0
+         },
+         "scores": {
+          "type": "array",
+          "items": {
+           "type": "object",
+           "required": [
+            "model",
+            "value"
+           ],
+           "additionalProperties": false,
+           "properties": {
+            "model": {
+             "type": "string"
+            },
+            "value": {
+             "type": "number",
+             "minimum": 0,
+             "maximum": 1
+            }
+           }
+          }
+         }
+        }
+       }
+      ]
+     }
+    }
+   },
+   "AdminSettingsResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/AdminSettings"
+     }
+    }
+   },
+   "AdminSettingsRequest": {
+    "type": "object",
+    "required": [
+     "title",
+     "introHtml",
+     "outroHtml",
+     "accessPolicy",
+     "eligibilityEventId",
+     "eligibilityLabel",
+     "recommendationTier",
+     "adminNotes"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "title": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
+     },
+     "introHtml": {
+      "type": "string"
+     },
+     "outroHtml": {
+      "type": "string"
+     },
+     "accessPolicy": {
+      "type": "string",
+      "enum": [
+       "public",
+       "invite_only",
+       "demo"
+      ]
+     },
+     "eligibilityEventId": {
+      "type": "string",
+      "maxLength": 80
+     },
+     "eligibilityLabel": {
+      "type": "string",
+      "maxLength": 255
+     },
+     "recommendationTier": {
+      "type": "string",
+      "enum": [
+       "simple",
+       "medium",
+       "complex"
+      ]
+     },
+     "adminNotes": {
+      "type": "string",
+      "maxLength": 4000
+     }
+    }
+   },
+   "AdminSettingsUpdateResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "changed",
+       "changedFields",
+       "settings"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "changed": {
+        "type": "boolean"
+       },
+       "changedFields": {
+        "type": "array",
+        "items": {
+         "type": "string"
+        },
+        "uniqueItems": true
+       },
+       "settings": {
+        "$ref": "#/components/schemas/AdminSettings"
+       }
+      }
+     }
+    }
+   },
+   "AdminRecommendationTierRequest": {
+    "type": "object",
+    "required": [
+     "tier"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "tier": {
+      "type": "string",
+      "enum": [
+       "simple",
+       "medium",
+       "complex"
+      ]
+     }
+    }
+   },
+   "AdminRecommendationTierResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "changed",
+       "recommendations"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "changed": {
+        "type": "boolean"
+       },
+       "recommendations": {
+        "$ref": "#/components/schemas/AdminRecommendations"
+       }
+      }
+     }
+    }
+   },
+   "AdminSettings": {
+    "type": "object",
+    "required": [
+     "conversation",
+     "recommendations",
+     "eligibility",
+     "capabilities",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "conversation": {
+      "type": "object",
+      "required": [
+       "id",
+       "slug",
+       "title",
+       "introHtml",
+       "outroHtml",
+       "accessPolicy",
+       "phaseRoute",
+       "phaseRouteLabel",
+       "polisId",
+       "adminNotes"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "id": {
+        "type": "integer",
+        "minimum": 1
+       },
+       "slug": {
+        "type": "string"
+       },
+       "title": {
+        "type": "string"
+       },
+       "introHtml": {
+        "type": "string"
+       },
+       "outroHtml": {
+        "type": "string"
+       },
+       "accessPolicy": {
+        "type": "string",
+        "enum": [
+         "public",
+         "invite_only",
+         "demo"
+        ]
+       },
+       "phaseRoute": {
+        "type": "string"
+       },
+       "phaseRouteLabel": {
+        "type": "string"
+       },
+       "polisId": {
+        "type": "string"
+       },
+       "adminNotes": {
+        "type": [
+         "string",
+         "null"
+        ],
+        "maxLength": 4000,
+        "description": "Organizer/global-admin-only free text. null when the viewer cannot organize this conversation; never shown to participants."
+       }
+      }
+     },
+     "recommendations": {
+      "$ref": "#/components/schemas/AdminRecommendations"
+     },
+     "eligibility": {
+      "type": "object",
+      "required": [
+       "configured",
+       "eventId",
+       "label",
+       "configurationMode",
+       "note"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "configured": {
+        "type": "boolean"
+       },
+       "eventId": {
+        "type": "string"
+       },
+       "label": {
+        "type": [
+         "string",
+         "null"
+        ]
+       },
+       "configurationMode": {
+        "type": "string",
+        "const": "editable"
+       },
+       "note": {
+        "type": "string"
+       }
+      }
+     },
+     "capabilities": {
+      "type": "object",
+      "required": [
+       "edit"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "edit": {
+        "type": "boolean"
+       }
+      }
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "self",
+       "lifecycle"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "self": {
+        "type": "string"
+       },
+       "lifecycle": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "AdminRecommendations": {
+    "type": "object",
+    "required": [
+     "tier",
+     "tiers"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "tier": {
+      "type": "string",
+      "enum": [
+       "simple",
+       "medium",
+       "complex"
+      ]
+     },
+     "tiers": {
+      "type": "array",
+      "items": {
+       "type": "object",
+       "required": [
+        "key",
+        "label",
+        "quantities"
+       ],
+       "additionalProperties": false,
+       "properties": {
+        "key": {
+         "type": "string",
+         "enum": [
+          "simple",
+          "medium",
+          "complex"
+         ]
+        },
+        "label": {
+         "type": "string"
+        },
+        "quantities": {
+         "type": "object",
+         "additionalProperties": {
+          "type": "integer",
+          "minimum": 1
+         }
+        }
+       }
+      }
+     }
+    }
+   },
+   "AdminLifecycleResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/AdminLifecycle"
+     }
+    }
+   },
+   "AdminPhaseAdvanceRequest": {
+    "type": "object",
+    "required": [
+     "confirmedPreconditionIds"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "confirmedPreconditionIds": {
+      "type": "array",
+      "items": {
+       "type": "string",
+       "minLength": 1
+      },
+      "uniqueItems": true
+     }
+    }
+   },
+   "AdminAdvancedPhasesRequest": {
+    "type": "object",
+    "required": [
+     "activeKeys"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "activeKeys": {
+      "type": "array",
+      "items": {
+       "type": "string",
+       "minLength": 1
+      },
+      "uniqueItems": true
+     }
+    }
+   },
+   "AdminAdvancedPhasesResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "changed",
+       "activeKeys",
+       "visibilitySynced",
+       "lifecycle"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "changed": {
+        "type": "boolean"
+       },
+       "activeKeys": {
+        "type": "array",
+        "items": {
+         "type": "string"
+        },
+        "uniqueItems": true
+       },
+       "visibilitySynced": {
+        "type": "boolean"
+       },
+       "lifecycle": {
+        "$ref": "#/components/schemas/AdminLifecycle"
+       }
+      }
+     }
+    }
+   },
+   "AdminPhase6InitializationResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "initialized",
+       "lifecycle"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "initialized": {
+        "type": "boolean",
+        "const": true
+       },
+       "lifecycle": {
+        "$ref": "#/components/schemas/AdminLifecycle"
+       }
+      }
+     }
+    }
+   },
+   "AdminPauseRequest": {
+    "type": "object",
+    "required": [
+     "paused"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "paused": {
+      "type": "boolean"
+     }
+    }
+   },
+   "AdminPauseResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "paused",
+       "changed",
+       "lifecycle"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "paused": {
+        "type": "boolean"
+       },
+       "changed": {
+        "type": "boolean"
+       },
+       "lifecycle": {
+        "$ref": "#/components/schemas/AdminLifecycle"
+       }
+      }
+     }
+    }
+   },
+   "AdminArchiveRequest": {
+    "type": "object",
+    "required": [
+     "archived"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "archived": {
+      "type": "boolean"
+     }
+    }
+   },
+   "AdminArchiveResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "archived",
+       "changed",
+       "lifecycle"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "archived": {
+        "type": "boolean"
+       },
+       "changed": {
+        "type": "boolean"
+       },
+       "lifecycle": {
+        "$ref": "#/components/schemas/AdminLifecycle"
+       }
+      }
+     }
+    }
+   },
+   "AdminScheduleRequest": {
+    "type": "object",
+    "required": [
+     "scheduledAt",
+     "frozen"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "scheduledAt": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "format": "date-time"
+     },
+     "frozen": {
+      "type": "boolean"
+     }
+    }
+   },
+   "AdminScheduleResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "changed",
+       "lifecycle"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "changed": {
+        "type": "boolean"
+       },
+       "lifecycle": {
+        "$ref": "#/components/schemas/AdminLifecycle"
+       }
+      }
+     }
+    }
+   },
+   "AdminPublicationRequest": {
+    "type": "object",
+    "required": [
+     "confirmedPreconditionIds"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "confirmedPreconditionIds": {
+      "type": "array",
+      "items": {
+       "type": "string",
+       "minLength": 1
+      },
+      "uniqueItems": true
+     }
+    }
+   },
+   "AdminPublicationResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "lifecycle"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "lifecycle": {
+        "$ref": "#/components/schemas/AdminLifecycle"
+       }
+      }
+     }
+    }
+   },
+   "AdminPhaseAdvanceResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/AdminPhaseAdvanceReceipt"
+     }
+    }
+   },
+   "AdminPhaseAdvanceReceipt": {
+    "type": "object",
+    "required": [
+     "transition",
+     "lifecycle"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "transition": {
+      "type": "object",
+      "required": [
+       "sourceKey",
+       "targetKey",
+       "targetLabel",
+       "phase6Created",
+       "phase6SyncMessage",
+       "visibilitySynced"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "sourceKey": {
+        "type": "string"
+       },
+       "targetKey": {
+        "type": "string"
+       },
+       "targetLabel": {
+        "type": "string"
+       },
+       "phase6Created": {
+        "type": "boolean"
+       },
+       "phase6SyncMessage": {
+        "type": [
+         "string",
+         "null"
+        ]
+       },
+       "visibilitySynced": {
+        "type": "boolean"
+       }
+      }
+     },
+     "lifecycle": {
+      "$ref": "#/components/schemas/AdminLifecycle"
+     }
+    }
+   },
+   "AdminLifecycle": {
+    "type": "object",
+    "required": [
+     "conversation",
+     "operator",
+     "phase",
+     "schedule",
+     "publicationReadiness",
+     "statistics",
+     "counts",
+     "capabilities",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "conversation": {
+      "$ref": "#/components/schemas/AdminLifecycleConversation"
+     },
+     "operator": {
+      "type": "object",
+      "required": [
+       "roleLabel"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "roleLabel": {
+        "type": "string"
+       }
+      }
+     },
+     "phase": {
+      "type": "object",
+      "required": [
+       "linear",
+       "currentIndex",
+       "activeKeys",
+       "steps",
+       "transition",
+       "phase6Setup",
+       "advancedControls"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "linear": {
+        "type": "boolean"
+       },
+       "currentIndex": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "activeKeys": {
+        "type": "array",
+        "items": {
+         "type": "string"
+        },
+        "uniqueItems": true
+       },
+       "steps": {
+        "type": "array",
+        "items": {
+         "$ref": "#/components/schemas/AdminLifecycleStep"
+        }
+       },
+       "transition": {
+        "oneOf": [
+         {
+          "$ref": "#/components/schemas/AdminLifecycleTransition"
+         },
+         {
+          "type": "null"
+         }
+        ]
+       },
+       "phase6Setup": {
+        "oneOf": [
+         {
+          "type": "null"
+         },
+         {
+          "type": "object",
+          "required": [
+           "polisConversationId",
+           "seededStatementCount",
+           "confirmedStatementCount"
+          ],
+          "additionalProperties": false,
+          "properties": {
+           "polisConversationId": {
+            "type": [
+             "string",
+             "null"
+            ]
+           },
+           "seededStatementCount": {
+            "type": "integer",
+            "minimum": 0
+           },
+           "confirmedStatementCount": {
+            "type": "integer",
+            "minimum": 0
+           }
+          }
+         }
+        ]
+       },
+       "advancedControls": {
+        "type": "array",
+        "items": {
+         "type": "object",
+         "required": [
+          "key",
+          "label",
+          "effect",
+          "active",
+          "requiresInitialization",
+          "initialized"
+         ],
+         "additionalProperties": false,
+         "properties": {
+          "key": {
+           "type": "string"
+          },
+          "label": {
+           "type": "string"
+          },
+          "effect": {
+           "type": "string"
+          },
+          "active": {
+           "type": "boolean"
+          },
+          "requiresInitialization": {
+           "type": "boolean"
+          },
+          "initialized": {
+           "type": "boolean"
+          }
+         }
+        }
+       }
+      }
+     },
+     "schedule": {
+      "type": "object",
+      "required": [
+       "canSchedule",
+       "scheduledAt",
+       "targetKey",
+       "targetLabel",
+       "frozen"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "canSchedule": {
+        "type": "boolean"
+       },
+       "scheduledAt": {
+        "type": [
+         "string",
+         "null"
+        ],
+        "format": "date-time"
+       },
+       "targetKey": {
+        "type": [
+         "string",
+         "null"
+        ]
+       },
+       "targetLabel": {
+        "type": [
+         "string",
+         "null"
+        ]
+       },
+       "frozen": {
+        "type": "boolean"
+       }
+      }
+     },
+     "publicationReadiness": {
+      "type": "object",
+      "required": [
+       "windowOpen",
+       "preconditions"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "windowOpen": {
+        "type": "boolean"
+       },
+       "preconditions": {
+        "type": "array",
+        "items": {
+         "type": "object",
+         "required": [
+          "id",
+          "label",
+          "met",
+          "note"
+         ],
+         "additionalProperties": false,
+         "properties": {
+          "id": {
+           "type": "string"
+          },
+          "label": {
+           "type": "string"
+          },
+          "met": {
+           "type": [
+            "boolean",
+            "null"
+           ]
+          },
+          "note": {
+           "type": [
+            "string",
+            "null"
+           ]
+          }
+         }
+        }
+       }
+      }
+     },
+     "statistics": {
+      "type": "object",
+      "required": [
+       "upstreamUnavailable",
+       "groups",
+       "informedVoting"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "upstreamUnavailable": {
+        "type": "boolean"
+       },
+       "groups": {
+        "type": "array",
+        "items": {
+         "type": "object",
+         "required": [
+          "key",
+          "label",
+          "tiles"
+         ],
+         "additionalProperties": false,
+         "properties": {
+          "key": {
+           "type": "string"
+          },
+          "label": {
+           "type": "string"
+          },
+          "tiles": {
+           "type": "array",
+           "items": {
+            "type": "object",
+            "required": [
+             "value",
+             "label",
+             "unit",
+             "note"
+            ],
+            "additionalProperties": false,
+            "properties": {
+             "value": {
+              "oneOf": [
+               {
+                "type": "integer"
+               },
+               {
+                "type": "number"
+               },
+               {
+                "type": "string"
+               }
+              ]
+             },
+             "label": {
+              "type": "string"
+             },
+             "unit": {
+              "type": [
+               "string",
+               "null"
+              ]
+             },
+             "note": {
+              "type": [
+               "string",
+               "null"
+              ]
+             }
+            }
+           }
+          }
+         }
+        }
+       },
+       "informedVoting": {
+        "oneOf": [
+         {
+          "type": "null"
+         },
+         {
+          "type": "object",
+          "required": [
+           "participants",
+           "statementCount",
+           "largestShift",
+           "excludedStatementCount",
+           "excludedParticipantCount"
+          ],
+          "additionalProperties": false,
+          "properties": {
+           "participants": {
+            "type": [
+             "integer",
+             "null"
+            ],
+            "minimum": 0
+           },
+           "statementCount": {
+            "type": "integer",
+            "minimum": 0
+           },
+           "largestShift": {
+            "oneOf": [
+             {
+              "type": "null"
+             },
+             {
+              "type": "object",
+              "required": [
+               "text",
+               "shift"
+              ],
+              "additionalProperties": false,
+              "properties": {
+               "text": {
+                "type": "string"
+               },
+               "shift": {
+                "type": "number"
+               }
+              }
+             }
+            ]
+           },
+           "excludedStatementCount": {
+            "type": "integer",
+            "minimum": 0
+           },
+           "excludedParticipantCount": {
+            "type": "integer",
+            "minimum": 0
+           }
+          }
+         }
+        ]
+       }
+      }
+     },
+     "counts": {
+      "type": "object",
+      "required": [
+       "participants",
+       "invitations",
+       "openFlags",
+       "featuredStatements"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "participants": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "invitations": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "openFlags": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "featuredStatements": {
+        "type": "integer",
+        "minimum": 0
+       }
+      }
+     },
+     "capabilities": {
+      "type": "object",
+      "required": [
+       "advancePhase",
+       "pause",
+       "publish",
+       "editSettings",
+       "useAdvancedPhases",
+       "initializePhase6",
+       "archive"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "advancePhase": {
+        "type": "boolean"
+       },
+       "pause": {
+        "type": "boolean"
+       },
+       "publish": {
+        "type": "boolean"
+       },
+       "editSettings": {
+        "type": "boolean"
+       },
+       "useAdvancedPhases": {
+        "type": "boolean"
+       },
+       "initializePhase6": {
+        "type": "boolean"
+       },
+       "archive": {
+        "type": "boolean"
+       }
+      }
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "self",
+       "participantView",
+       "participants",
+       "moderation",
+       "invitations",
+       "roles",
+       "statements",
+       "featuredStatements",
+       "settings",
+       "termination"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "self": {
+        "type": "string"
+       },
+       "participantView": {
+        "type": "string"
+       },
+       "participants": {
+        "type": "string"
+       },
+       "moderation": {
+        "type": "string"
+       },
+       "invitations": {
+        "type": "string"
+       },
+       "roles": {
+        "type": "string"
+       },
+       "statements": {
+        "type": "string"
+       },
+       "featuredStatements": {
+        "type": "string"
+       },
+       "settings": {
+        "type": "string"
+       },
+       "termination": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "AdminLifecycleConversation": {
+    "type": "object",
+    "required": [
+     "id",
+     "slug",
+     "title",
+     "accessPolicy",
+     "status",
+     "publication",
+     "closedAt",
+     "identityReveal"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "id": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "slug": {
+      "type": "string"
+     },
+     "title": {
+      "type": "string"
+     },
+     "accessPolicy": {
+      "type": "string",
+      "enum": [
+       "public",
+       "invite_only",
+       "demo"
+      ]
+     },
+     "status": {
+      "type": "string",
+      "enum": [
+       "active",
+       "paused",
+       "scheduled",
+       "archived",
+       "closed"
+      ]
+     },
+     "publication": {
+      "type": "string",
+      "enum": [
+       "not_applicable",
+       "pending",
+       "published"
+      ]
+     },
+     "closedAt": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "format": "date-time"
+     },
+     "identityReveal": {
+      "oneOf": [
+       {
+        "type": "null"
+       },
+       {
+        "type": "object",
+        "required": [
+         "state",
+         "opensAt",
+         "closesAt",
+         "daysLeft"
+        ],
+        "additionalProperties": false,
+        "properties": {
+         "state": {
+          "type": "string",
+          "enum": [
+           "pending",
+           "open",
+           "expired"
+          ]
+         },
+         "opensAt": {
+          "type": [
+           "string",
+           "null"
+          ],
+          "format": "date-time"
+         },
+         "closesAt": {
+          "type": [
+           "string",
+           "null"
+          ],
+          "format": "date-time"
+         },
+         "daysLeft": {
+          "type": [
+           "integer",
+           "null"
+          ]
+         }
+        }
+       }
+      ]
+     }
+    }
+   },
+   "AdminLifecycleStep": {
+    "type": "object",
+    "required": [
+     "key",
+     "label",
+     "effect",
+     "state"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "key": {
+      "type": "string"
+     },
+     "label": {
+      "type": "string"
+     },
+     "effect": {
+      "type": "string"
+     },
+     "state": {
+      "type": "string",
+      "enum": [
+       "completed",
+       "current",
+       "upcoming",
+       "available"
+      ]
+     }
+    }
+   },
+   "AdminLifecycleTransition": {
+    "type": "object",
+    "required": [
+     "source",
+     "target",
+     "consequence",
+     "preconditions",
+     "requiresPhase6Initialization",
+     "showPauseGuidance"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "source": {
+      "$ref": "#/components/schemas/AdminLifecyclePhaseRef"
+     },
+     "target": {
+      "$ref": "#/components/schemas/AdminLifecyclePhaseRef"
+     },
+     "consequence": {
+      "type": "object",
+      "required": [
+       "opens",
+       "closes"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "opens": {
+        "type": "string"
+       },
+       "closes": {
+        "type": [
+         "string",
+         "null"
+        ]
+       }
+      }
+     },
+     "preconditions": {
+      "type": "array",
+      "items": {
+       "type": "object",
+       "required": [
+        "id",
+        "label",
+        "met",
+        "note"
+       ],
+       "additionalProperties": false,
+       "properties": {
+        "id": {
+         "type": "string"
+        },
+        "label": {
+         "type": "string"
+        },
+        "met": {
+         "type": [
+          "boolean",
+          "null"
+         ]
+        },
+        "note": {
+         "type": [
+          "string",
+          "null"
+         ]
+        }
+       }
+      }
+     },
+     "requiresPhase6Initialization": {
+      "type": "boolean"
+     },
+     "showPauseGuidance": {
+      "type": "boolean"
+     }
+    }
+   },
+   "AdminLifecyclePhaseRef": {
+    "type": "object",
+    "required": [
+     "key",
+     "label"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "key": {
+      "type": "string"
+     },
+     "label": {
+      "type": "string"
+     }
+    }
+   },
+   "AdminRoleRosterResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/AdminRoleRoster"
+     }
+    }
+   },
+   "AdminRoleRoster": {
+    "type": "object",
+    "required": [
+     "conversation",
+     "assignments",
+     "candidates",
+     "availableRoles",
+     "capabilities",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "conversation": {
+      "type": "object",
+      "required": [
+       "id",
+       "slug",
+       "title"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "id": {
+        "type": "integer",
+        "minimum": 1
+       },
+       "slug": {
+        "type": "string"
+       },
+       "title": {
+        "type": "string"
+       }
+      }
+     },
+     "assignments": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/AdminRoleAssignment"
+      }
+     },
+     "candidates": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/AdminRoleCandidate"
+      }
+     },
+     "availableRoles": {
+      "type": "array",
+      "items": {
+       "type": "string",
+       "enum": [
+        "moderator",
+        "organizer"
+       ]
+      },
+      "uniqueItems": true
+     },
+     "capabilities": {
+      "type": "object",
+      "required": [
+       "manageRoles"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "manageRoles": {
+        "type": "boolean"
+       }
+      }
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "self",
+       "conversation"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "self": {
+        "type": "string"
+       },
+       "conversation": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "AdminRoleAssignment": {
+    "type": "object",
+    "required": [
+     "participantId",
+     "username",
+     "roles",
+     "grantedAt"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "participantId": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "username": {
+      "type": "string"
+     },
+     "roles": {
+      "type": "array",
+      "items": {
+       "type": "string",
+       "enum": [
+        "moderator",
+        "organizer"
+       ]
+      },
+      "uniqueItems": true
+     },
+     "grantedAt": {
+      "type": "array",
+      "items": {
+       "type": "string",
+       "format": "date-time"
+      }
+     }
+    }
+   },
+   "AdminRoleCandidate": {
+    "type": "object",
+    "required": [
+     "participantId",
+     "username"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "participantId": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "username": {
+      "type": "string"
+     }
+    }
+   },
+   "AdminRoleSetRequest": {
+    "type": "object",
+    "required": [
+     "roles"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "roles": {
+      "type": "array",
+      "items": {
+       "type": "string",
+       "enum": [
+        "moderator",
+        "organizer"
+       ]
+      },
+      "uniqueItems": true
+     }
+    }
+   },
+   "AdminRoleSetResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/AdminRoleSetReceipt"
+     }
+    }
+   },
+   "AdminRoleSetReceipt": {
+    "type": "object",
+    "required": [
+     "participantId",
+     "username",
+     "roles",
+     "changed",
+     "added",
+     "removed",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "participantId": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "username": {
+      "type": "string"
+     },
+     "roles": {
+      "type": "array",
+      "items": {
+       "type": "string",
+       "enum": [
+        "moderator",
+        "organizer"
+       ]
+      },
+      "uniqueItems": true
+     },
+     "changed": {
+      "type": "boolean"
+     },
+     "added": {
+      "type": "array",
+      "items": {
+       "type": "string",
+       "enum": [
+        "moderator",
+        "organizer"
+       ]
+      },
+      "uniqueItems": true
+     },
+     "removed": {
+      "type": "array",
+      "items": {
+       "type": "string",
+       "enum": [
+        "moderator",
+        "organizer"
+       ]
+      },
+      "uniqueItems": true
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "roles"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "roles": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "AdminInvitationRosterResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/AdminInvitationRoster"
+     }
+    }
+   },
+   "AdminInvitationRoster": {
+    "type": "object",
+    "required": [
+     "conversation",
+     "invitations",
+     "capabilities",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "conversation": {
+      "type": "object",
+      "required": [
+       "id",
+       "slug",
+       "title",
+       "accessPolicy"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "id": {
+        "type": "integer",
+        "minimum": 1
+       },
+       "slug": {
+        "type": "string"
+       },
+       "title": {
+        "type": "string"
+       },
+       "accessPolicy": {
+        "type": "string",
+        "enum": [
+         "public",
+         "invite_only",
+         "demo"
+        ]
+       }
+      }
+     },
+     "invitations": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/AdminInvitation"
+      }
+     },
+     "capabilities": {
+      "type": "object",
+      "required": [
+       "manageInvitations"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "manageInvitations": {
+        "type": "boolean"
+       }
+      }
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "self",
+       "conversation"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "self": {
+        "type": "string"
+       },
+       "conversation": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "AdminInvitation": {
+    "type": "object",
+    "required": [
+     "id",
+     "username",
+     "createdAt"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "id": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "username": {
+      "type": "string"
+     },
+     "createdAt": {
+      "type": "string",
+      "format": "date-time"
+     }
+    }
+   },
+   "AdminInvitationBatchRequest": {
+    "type": "object",
+    "required": [
+     "usernames"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "usernames": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+       "type": "string",
+       "minLength": 1,
+       "maxLength": 255
+      }
+     }
+    }
+   },
+   "AdminInvitationBatchResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/AdminInvitationBatchReceipt"
+     }
+    }
+   },
+   "AdminInvitationBatchReceipt": {
+    "type": "object",
+    "required": [
+     "outcome",
+     "invitations",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "outcome": {
+      "type": "object",
+      "required": [
+       "added",
+       "alreadyPresent",
+       "concurrentConflicts",
+       "duplicateInputs"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "added": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "alreadyPresent": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "concurrentConflicts": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "duplicateInputs": {
+        "type": "integer",
+        "minimum": 0
+       }
+      }
+     },
+     "invitations": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/AdminInvitation"
+      }
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "invitations"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "invitations": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "AdminInvitationRemovalResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/AdminInvitationRemovalReceipt"
+     }
+    }
+   },
+   "AdminInvitationRemovalReceipt": {
+    "type": "object",
+    "required": [
+     "invitationId",
+     "removed",
+     "invitations",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "invitationId": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "removed": {
+      "type": "boolean",
+      "const": true
+     },
+     "invitations": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/AdminInvitation"
+      }
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "invitations"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "invitations": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "AdminFlagQueueResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/AdminFlagQueue"
+     }
+    }
+   },
+   "AdminFlagQueue": {
+    "type": "object",
+    "required": [
+     "conversation",
+     "open",
+     "resolved",
+     "dataAvailability",
+     "capabilities",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "conversation": {
+      "type": "object",
+      "required": [
+       "id",
+       "slug",
+       "title"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "id": {
+        "type": "integer",
+        "minimum": 1
+       },
+       "slug": {
+        "type": "string"
+       },
+       "title": {
+        "type": "string"
+       }
+      }
+     },
+     "open": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/AdminContentFlag"
+      }
+     },
+     "resolved": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/AdminContentFlag"
+      }
+     },
+     "dataAvailability": {
+      "type": "object",
+      "required": [
+       "statementText"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "statementText": {
+        "type": "boolean"
+       }
+      }
+     },
+     "capabilities": {
+      "type": "object",
+      "required": [
+       "resolveFlags"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "resolveFlags": {
+        "type": "boolean"
+       }
+      }
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "self",
+       "conversation"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "self": {
+        "type": "string"
+       },
+       "conversation": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "AdminContentFlag": {
+    "type": "object",
+    "required": [
+     "id",
+     "status",
+     "category",
+     "categoryLabel",
+     "detail",
+     "flaggedAt",
+     "target",
+     "resolution"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "id": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "status": {
+      "type": "string",
+      "enum": [
+       "open",
+       "resolved"
+      ]
+     },
+     "category": {
+      "type": "string",
+      "enum": [
+       "personal_attack",
+       "privacy",
+       "off_topic",
+       "other"
+      ]
+     },
+     "categoryLabel": {
+      "type": "string"
+     },
+     "detail": {
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "flaggedAt": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "format": "date-time"
+     },
+     "target": {
+      "$ref": "#/components/schemas/AdminFlagTarget"
+     },
+     "resolution": {
+      "oneOf": [
+       {
+        "$ref": "#/components/schemas/AdminFlagResolution"
+       },
+       {
+        "type": "null"
+       }
+      ]
+     }
+    }
+   },
+   "AdminFlagTarget": {
+    "type": "object",
+    "required": [
+     "type",
+     "id",
+     "label",
+     "text",
+     "reviewHref"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "type": {
+      "type": "string",
+      "enum": [
+       "statement",
+       "argument"
+      ]
+     },
+     "id": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "label": {
+      "type": "string"
+     },
+     "text": {
+      "type": "string"
+     },
+     "reviewHref": {
+      "type": "string"
+     }
+    }
+   },
+   "AdminFlagResolution": {
+    "type": "object",
+    "required": [
+     "resolvedAt",
+     "note"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "resolvedAt": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "format": "date-time"
+     },
+     "note": {
+      "type": [
+       "string",
+       "null"
+      ]
+     }
+    }
+   },
+   "AdminFlagResolutionRequest": {
+    "type": "object",
+    "required": [
+     "resolved"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "resolved": {
+      "type": "boolean",
+      "const": true
+     },
+     "note": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "maxLength": 1000
+     }
+    }
+   },
+   "AdminFlagResolutionResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/AdminFlagResolutionReceipt"
+     }
+    }
+   },
+   "AdminFlagResolutionReceipt": {
+    "type": "object",
+    "required": [
+     "flagId",
+     "status",
+     "changed",
+     "resolution",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "flagId": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "status": {
+      "type": "string",
+      "const": "resolved"
+     },
+     "changed": {
+      "type": "boolean"
+     },
+     "resolution": {
+      "$ref": "#/components/schemas/AdminFlagResolution"
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "flags"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "flags": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "AdminParticipantRosterResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/AdminParticipantRoster"
+     }
+    }
+   },
+   "AdminParticipantRoster": {
+    "type": "object",
+    "required": [
+     "conversation",
+     "participants",
+     "dataAvailability",
+     "capabilities",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "conversation": {
+      "type": "object",
+      "required": [
+       "id",
+       "slug",
+       "title"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "id": {
+        "type": "integer",
+        "minimum": 1
+       },
+       "slug": {
+        "type": "string"
+       },
+       "title": {
+        "type": "string"
+       }
+      }
+     },
+     "participants": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/AdminParticipant"
+      }
+     },
+     "dataAvailability": {
+      "type": "object",
+      "required": [
+       "statementProgress"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "statementProgress": {
+        "type": "boolean"
+       }
+      }
+     },
+     "capabilities": {
+      "type": "object",
+      "required": [
+       "setParticipantAccess"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "setParticipantAccess": {
+        "type": "boolean"
+       }
+      }
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "self",
+       "conversation"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "self": {
+        "type": "string"
+       },
+       "conversation": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "AdminParticipant": {
+    "type": "object",
+    "required": [
+     "participantId",
+     "username",
+     "pseudonym",
+     "statementProgress",
+     "arguments",
+     "lastEngagementAt",
+     "access"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "participantId": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "username": {
+      "type": "string"
+     },
+     "pseudonym": {
+      "type": "string"
+     },
+     "statementProgress": {
+      "oneOf": [
+       {
+        "$ref": "#/components/schemas/AdminStatementProgress"
+       },
+       {
+        "type": "null"
+       }
+      ]
+     },
+     "arguments": {
+      "type": "object",
+      "required": [
+       "submitted",
+       "prioritized"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "submitted": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "prioritized": {
+        "type": "integer",
+        "minimum": 0
+       }
+      }
+     },
+     "lastEngagementAt": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "format": "date-time"
+     },
+     "access": {
+      "$ref": "#/components/schemas/AdminParticipantAccess"
+     }
+    }
+   },
+   "AdminStatementProgress": {
+    "type": "object",
+    "required": [
+     "total",
+     "voted",
+     "remaining"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "total": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "voted": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "remaining": {
+      "type": "integer",
+      "minimum": 0
+     }
+    }
+   },
+   "AdminParticipantAccess": {
+    "type": "object",
+    "required": [
+     "banned",
+     "changedAt",
+     "summary"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "banned": {
+      "type": "boolean"
+     },
+     "changedAt": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "format": "date-time"
+     },
+     "summary": {
+      "type": [
+       "string",
+       "null"
+      ]
+     }
+    }
+   },
+   "AdminParticipantAccessRequest": {
+    "type": "object",
+    "required": [
+     "banned"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "banned": {
+      "type": "boolean"
+     },
+     "summary": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "maxLength": 1000
+     }
+    }
+   },
+   "AdminParticipantAccessResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/AdminParticipantAccessReceipt"
+     }
+    }
+   },
+   "AdminParticipantAccessReceipt": {
+    "type": "object",
+    "required": [
+     "participantId",
+     "banned",
+     "changed",
+     "changedAt",
+     "summary",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "participantId": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "banned": {
+      "type": "boolean"
+     },
+     "changed": {
+      "type": "boolean"
+     },
+     "changedAt": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "format": "date-time"
+     },
+     "summary": {
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "participants"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "participants": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "SessionResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/Session"
+     }
+    }
+   },
+   "Session": {
+    "type": "object",
+    "required": [
+     "state",
+     "user",
+     "capabilities",
+     "csrfToken",
+     "developerMode",
+     "developerLogins",
+     "gitVersion",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "state": {
+      "type": "string",
+      "enum": [
+       "anonymous",
+       "authenticated",
+       "demo"
+      ]
+     },
+     "user": {
+      "oneOf": [
+       {
+        "$ref": "#/components/schemas/SessionUser"
+       },
+       {
+        "type": "null"
+       }
+      ]
+     },
+     "capabilities": {
+      "$ref": "#/components/schemas/SiteCapabilities"
+     },
+     "csrfToken": {
+      "type": "string",
+      "minLength": 1
+     },
+     "developerMode": {
+      "type": "boolean"
+     },
+     "developerLogins": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/DeveloperLogin"
+      }
+     },
+     "gitVersion": {
+      "type": "string",
+      "minLength": 1
+     },
+     "links": {
+      "$ref": "#/components/schemas/SessionLinks"
+     }
+    }
+   },
+   "DeveloperLogin": {
+    "type": "object",
+    "required": [
+     "username",
+     "href"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "username": {
+      "type": "string",
+      "minLength": 1
+     },
+     "href": {
+      "type": "string",
+      "minLength": 1
+     }
+    }
+   },
+   "SessionUser": {
+    "type": "object",
+    "required": [
+     "username",
+     "emailable"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "username": {
+      "type": "string",
+      "minLength": 1
+     },
+     "emailable": {
+      "type": "boolean"
+     }
+    }
+   },
+   "SiteCapabilities": {
+    "type": "object",
+    "required": [
+     "administerSite"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "administerSite": {
+      "type": "boolean"
+     }
+    }
+   },
+   "SessionLinks": {
+    "type": "object",
+    "required": [
+     "login",
+     "logout"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "login": {
+      "type": "string"
+     },
+     "logout": {
+      "type": "string"
+     }
+    }
+   },
+   "ConversationLaneResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/ConversationLane"
+     }
+    }
+   },
+   "ConversationLane": {
+    "type": "object",
+    "required": [
+     "space",
+     "authenticated",
+     "groups"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "space": {
+      "type": "string",
+      "enum": [
+       "real",
+       "demo"
+      ]
+     },
+     "authenticated": {
+      "type": "boolean"
+     },
+     "groups": {
+      "$ref": "#/components/schemas/ConversationGroups"
+     }
+    }
+   },
+   "ConversationGroups": {
+    "type": "object",
+    "required": [
+     "needsAttention",
+     "caughtUp",
+     "inactive",
+     "archived",
+     "available",
+     "moderating"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "needsAttention": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/ConversationCard"
+      }
+     },
+     "caughtUp": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/ConversationCard"
+      }
+     },
+     "inactive": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/ConversationCard"
+      }
+     },
+     "archived": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/ConversationCard"
+      }
+     },
+     "available": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/ConversationCard"
+      }
+     },
+     "moderating": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/ConversationCard"
+      }
+     }
+    }
+   },
+   "ConversationCard": {
+    "type": "object",
+    "required": [
+     "slug",
+     "title",
+     "relationship",
+     "participantState",
+     "pseudonym",
+     "status",
+     "closedAt",
+     "phases",
+     "statementsRemaining",
+     "scheduledTransition",
+     "reveal",
+     "outputs",
+     "capabilities",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "slug": {
+      "type": "string",
+      "minLength": 1
+     },
+     "title": {
+      "type": "string",
+      "minLength": 1
+     },
+     "relationship": {
+      "type": "string",
+      "enum": [
+       "joined",
+       "available",
+       "moderating"
+      ]
+     },
+     "participantState": {
+      "oneOf": [
+       {
+        "type": "string",
+        "enum": [
+         "needs_attention",
+         "caught_up",
+         "inactive",
+         "archived"
+        ]
+       },
+       {
+        "type": "null"
+       }
+      ]
+     },
+     "pseudonym": {
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "status": {
+      "type": "string",
+      "enum": [
+       "open",
+       "paused",
+       "archived"
+      ]
+     },
+     "closedAt": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "format": "date-time"
+     },
+     "phases": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "uniqueItems": true
+     },
+     "statementsRemaining": {
+      "type": [
+       "integer",
+       "null"
+      ],
+      "minimum": 0
+     },
+     "scheduledTransition": {
+      "oneOf": [
+       {
+        "$ref": "#/components/schemas/ScheduledTransition"
+       },
+       {
+        "type": "null"
+       }
+      ]
+     },
+     "reveal": {
+      "oneOf": [
+       {
+        "$ref": "#/components/schemas/ConversationRevealSignal"
+       },
+       {
+        "type": "null"
+       }
+      ]
+     },
+     "outputs": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/ConversationOutput"
+      }
+     },
+     "capabilities": {
+      "$ref": "#/components/schemas/ConversationCapabilities"
+     },
+     "links": {
+      "$ref": "#/components/schemas/ConversationLinks"
+     }
+    }
+   },
+   "ModerationLogResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/ModerationLog"
+     }
+    }
+   },
+   "ModerationLog": {
+    "type": "object",
+    "required": [
+     "slug",
+     "title",
+     "events",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "slug": {
+      "type": "string",
+      "minLength": 1
+     },
+     "title": {
+      "type": "string",
+      "minLength": 1
+     },
+     "events": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/ModerationLogEvent"
+      }
+     },
+     "links": {
+      "$ref": "#/components/schemas/ParticipantPageLinks"
+     }
+    }
+   },
+   "ModerationLogEvent": {
+    "type": "object",
+    "required": [
+     "occurredAt",
+     "action",
+     "pseudonym",
+     "scope",
+     "actor"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "occurredAt": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "format": "date-time"
+     },
+     "action": {
+      "type": "string",
+      "enum": [
+       "Banned",
+       "Unbanned"
+      ]
+     },
+     "pseudonym": {
+      "type": "string"
+     },
+     "scope": {
+      "type": "string",
+      "enum": [
+       "conversation"
+      ]
+     },
+     "actor": {
+      "type": "string"
+     }
+    }
+   },
+   "ConversationOutputPageResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/ConversationOutputPage"
+     }
+    }
+   },
+   "ConversationOutputPage": {
+    "type": "object",
+    "required": [
+     "slug",
+     "title",
+     "output",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "slug": {
+      "type": "string",
+      "minLength": 1
+     },
+     "title": {
+      "type": "string",
+      "minLength": 1
+     },
+     "output": {
+      "$ref": "#/components/schemas/ConversationOutputDetail"
+     },
+     "links": {
+      "$ref": "#/components/schemas/ParticipantPageLinks"
+     }
+    }
+   },
+   "ConversationOutputDetail": {
+    "type": "object",
+    "required": [
+     "key",
+     "label",
+     "phase",
+     "status",
+     "ready",
+     "method",
+     "pending"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "key": {
+      "type": "string",
+      "enum": [
+       "initial-clustering",
+       "argument-map",
+       "preliminary-results",
+       "report",
+       "dataset"
+      ]
+     },
+     "label": {
+      "type": "string",
+      "minLength": 1
+     },
+     "phase": {
+      "type": "string",
+      "minLength": 1
+     },
+     "status": {
+      "type": "string",
+      "enum": [
+       "provisional",
+       "final"
+      ]
+     },
+     "ready": {
+      "type": "boolean"
+     },
+     "method": {
+      "type": "string",
+      "minLength": 1
+     },
+     "pending": {
+      "type": "string",
+      "minLength": 1
+     }
+    }
+   },
+   "ParticipantPageLinks": {
+    "type": "object",
+    "required": [
+     "self",
+     "conversation",
+     "about"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "self": {
+      "type": "string"
+     },
+     "conversation": {
+      "type": "string"
+     },
+     "about": {
+      "type": "string"
+     }
+    }
+   },
+   "ConversationWorkspaceResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/ConversationWorkspace"
+     }
+    }
+   },
+   "ConversationWorkspace": {
+    "type": "object",
+    "required": [
+     "slug",
+     "title",
+     "space",
+     "status",
+     "descriptionHtml",
+     "outroHtml",
+     "viewer",
+     "spaceWarning",
+     "scheduledTransition",
+     "tabs",
+     "defaultTab",
+     "reveal",
+     "statementContribution",
+     "capabilities",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "slug": {
+      "type": "string",
+      "minLength": 1
+     },
+     "title": {
+      "type": "string",
+      "minLength": 1
+     },
+     "space": {
+      "type": "string",
+      "enum": [
+       "real",
+       "demo"
+      ]
+     },
+     "status": {
+      "type": "string",
+      "enum": [
+       "open",
+       "paused",
+       "closed"
+      ]
+     },
+     "descriptionHtml": {
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "outroHtml": {
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "viewer": {
+      "$ref": "#/components/schemas/ConversationWorkspaceViewer"
+     },
+     "spaceWarning": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "enum": [
+       "real",
+       "demo",
+       null
+      ]
+     },
+     "scheduledTransition": {
+      "oneOf": [
+       {
+        "$ref": "#/components/schemas/ScheduledTransition"
+       },
+       {
+        "type": "null"
+       }
+      ]
+     },
+     "tabs": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/ConversationWorkspaceTab"
+      }
+     },
+     "defaultTab": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "enum": [
+       "vote",
+       "results",
+       "arguments",
+       "informed-voting",
+       "p6-results",
+       null
+      ]
+     },
+     "reveal": {
+      "oneOf": [
+       {
+        "$ref": "#/components/schemas/ConversationWorkspaceReveal"
+       },
+       {
+        "type": "null"
+       }
+      ]
+     },
+     "statementContribution": {
+      "$ref": "#/components/schemas/ConversationWorkspaceStatementContribution"
+     },
+     "capabilities": {
+      "$ref": "#/components/schemas/ConversationWorkspaceCapabilities"
+     },
+     "links": {
+      "$ref": "#/components/schemas/ConversationWorkspaceLinks"
+     }
+    }
+   },
+   "ConversationWorkspaceViewer": {
+    "type": "object",
+    "required": [
+     "state",
+     "pseudonym"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "state": {
+      "type": "string",
+      "enum": [
+       "participant",
+       "join_required"
+      ]
+     },
+     "pseudonym": {
+      "type": [
+       "string",
+       "null"
+      ]
+     }
+    }
+   },
+   "ConversationWorkspaceTab": {
+    "type": "object",
+    "required": [
+     "key",
+     "label",
+     "dataHref"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "key": {
+      "type": "string",
+      "enum": [
+       "vote",
+       "results",
+       "arguments",
+       "informed-voting",
+       "p6-results"
+      ]
+     },
+     "label": {
+      "type": "string",
+      "minLength": 1
+     },
+     "dataHref": {
+      "type": [
+       "string",
+       "null"
+      ]
+     }
+    }
+   },
+   "ConversationWorkspaceReveal": {
+    "type": "object",
+    "required": [
+     "state",
+     "pseudonym",
+     "closedAt",
+     "opensAt",
+     "closesAt",
+     "daysRemaining",
+     "cooldownDays",
+     "windowDays",
+     "countdownTargetAt"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "state": {
+      "type": "string",
+      "enum": [
+       "pending",
+       "open",
+       "revealed",
+       "expired"
+      ]
+     },
+     "pseudonym": {
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "closedAt": {
+      "type": "string",
+      "format": "date-time"
+     },
+     "opensAt": {
+      "type": "string",
+      "format": "date-time"
+     },
+     "closesAt": {
+      "type": "string",
+      "format": "date-time"
+     },
+     "daysRemaining": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "cooldownDays": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "windowDays": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "countdownTargetAt": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "format": "date-time"
+     }
+    }
+   },
+   "ConversationWorkspaceStatementContribution": {
+    "type": "object",
+    "required": [
+     "unlockAfter",
+     "quota",
+     "used"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "unlockAfter": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "quota": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "used": {
+      "type": "integer",
+      "minimum": 0
+     }
+    }
+   },
+   "ConversationWorkspaceCapabilities": {
+    "type": "object",
+    "required": [
+     "participate",
+     "moderate"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "participate": {
+      "type": "boolean"
+     },
+     "moderate": {
+      "type": "boolean"
+     }
+    }
+   },
+   "ConversationWorkspaceLinks": {
+    "type": "object",
+    "required": [
+     "self",
+     "conversation",
+     "about",
+     "join"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "self": {
+      "type": "string"
+     },
+     "conversation": {
+      "type": "string"
+     },
+     "about": {
+      "type": "string"
+     },
+     "join": {
+      "type": "string"
+     },
+     "manage": {
+      "type": "string"
+     },
+     "explore": {
+      "type": "string"
+     },
+     "arguments": {
+      "type": "string"
+     },
+     "informedVoting": {
+      "type": "string"
+     },
+     "intermediateResults": {
+      "type": "string"
+     },
+     "results": {
+      "type": "string"
+     }
+    }
+   },
+   "ConversationAboutResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/ConversationAbout"
+     }
+    }
+   },
+   "IdentityRevealResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/IdentityReveal"
+     }
+    }
+   },
+   "CreateIdentityRevealRequest": {
+    "type": "object",
+    "required": [
+     "confirm"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "confirm": {
+      "type": "boolean",
+      "const": true
+     }
+    }
+   },
+   "IdentityReveal": {
+    "type": "object",
+    "required": [
+     "slug",
+     "title",
+     "state",
+     "pseudonym",
+     "wikimediaUsername",
+     "publicUsername",
+     "timeline",
+     "capabilities",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "slug": {
+      "type": "string",
+      "minLength": 1
+     },
+     "title": {
+      "type": "string",
+      "minLength": 1
+     },
+     "state": {
+      "type": "string",
+      "enum": [
+       "pending",
+       "open",
+       "revealed",
+       "expired"
+      ]
+     },
+     "pseudonym": {
+      "type": "string",
+      "minLength": 1
+     },
+     "wikimediaUsername": {
+      "type": "string",
+      "minLength": 1
+     },
+     "publicUsername": {
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "timeline": {
+      "$ref": "#/components/schemas/IdentityRevealTimeline"
+     },
+     "capabilities": {
+      "$ref": "#/components/schemas/IdentityRevealCapabilities"
+     },
+     "links": {
+      "$ref": "#/components/schemas/IdentityRevealLinks"
+     }
+    }
+   },
+   "IdentityRevealTimeline": {
+    "type": "object",
+    "required": [
+     "closedAt",
+     "opensAt",
+     "closesAt",
+     "nextBoundaryAt",
+     "daysRemaining"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "closedAt": {
+      "type": "string",
+      "format": "date-time"
+     },
+     "opensAt": {
+      "type": "string",
+      "format": "date-time"
+     },
+     "closesAt": {
+      "type": "string",
+      "format": "date-time"
+     },
+     "nextBoundaryAt": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "format": "date-time"
+     },
+     "daysRemaining": {
+      "type": "integer",
+      "minimum": 0
+     }
+    }
+   },
+   "IdentityRevealCapabilities": {
+    "type": "object",
+    "required": [
+     "revealIdentity"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "revealIdentity": {
+      "type": "boolean"
+     }
+    }
+   },
+   "IdentityRevealLinks": {
+    "type": "object",
+    "required": [
+     "self",
+     "conversation",
+     "about"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "self": {
+      "type": "string"
+     },
+     "conversation": {
+      "type": "string"
+     },
+     "about": {
+      "type": "string"
+     }
+    }
+   },
+   "ParticipationEntryConversation": {
+    "type": "object",
+    "required": [
+     "id",
+     "slug",
+     "title",
+     "descriptionHtml",
+     "eligibilityLabel"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "id": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "slug": {
+      "type": "string",
+      "minLength": 1
+     },
+     "title": {
+      "type": "string",
+      "minLength": 1
+     },
+     "descriptionHtml": {
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "eligibilityLabel": {
+      "type": [
+       "string",
+       "null"
+      ]
+     }
+    }
+   },
+   "JoinParticipationEntry": {
+    "type": "object",
+    "required": [
+     "state",
+     "conversation",
+     "pseudonyms",
+     "emailable",
+     "reveal",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "state": {
+      "type": "string",
+      "enum": [
+       "join"
+      ]
+     },
+     "conversation": {
+      "$ref": "#/components/schemas/ParticipationEntryConversation"
+     },
+     "pseudonyms": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+       "type": "string",
+       "pattern": "^[a-z]{2,20}-[a-z]{2,20}$"
+      }
+     },
+     "emailable": {
+      "type": "boolean"
+     },
+     "reveal": {
+      "type": "object",
+      "required": [
+       "cooldownDays",
+       "windowEndDays"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "cooldownDays": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "windowEndDays": {
+        "type": "integer",
+        "minimum": 0
+       }
+      }
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "home",
+       "conversation"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "home": {
+        "type": "string"
+       },
+       "conversation": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "RedirectParticipationEntry": {
+    "type": "object",
+    "required": [
+     "state",
+     "reason",
+     "href"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "state": {
+      "type": "string",
+      "enum": [
+       "redirect"
+      ]
+     },
+     "reason": {
+      "type": "string",
+      "enum": [
+       "demo",
+       "already_participating"
+      ]
+     },
+     "href": {
+      "type": "string"
+     }
+    }
+   },
+   "InviteDeniedParticipationEntry": {
+    "type": "object",
+    "required": [
+     "state",
+     "conversation",
+     "canModerate",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "state": {
+      "type": "string",
+      "enum": [
+       "invite_denied"
+      ]
+     },
+     "conversation": {
+      "$ref": "#/components/schemas/ParticipationEntryConversation"
+     },
+     "canModerate": {
+      "type": "boolean"
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "home",
+       "manageInvites"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "home": {
+        "type": "string"
+       },
+       "manageInvites": {
+        "type": [
+         "string",
+         "null"
+        ]
+       }
+      }
+     }
+    }
+   },
+   "ParticipationEntryResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "oneOf": [
+       {
+        "$ref": "#/components/schemas/JoinParticipationEntry"
+       },
+       {
+        "$ref": "#/components/schemas/RedirectParticipationEntry"
+       },
+       {
+        "$ref": "#/components/schemas/InviteDeniedParticipationEntry"
+       }
+      ]
+     }
+    }
+   },
+   "PseudonymSuggestionsResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "type": "object",
+      "required": [
+       "pseudonyms"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "pseudonyms": {
+        "type": "array",
+        "minItems": 1,
+        "items": {
+         "type": "string",
+         "pattern": "^[a-z]{2,20}-[a-z]{2,20}$"
+        }
+       }
+      }
+     }
+    }
+   },
+   "CreateParticipationRequest": {
+    "type": "object",
+    "required": [
+     "pseudonym"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "pseudonym": {
+      "type": "string",
+      "pattern": "^[a-z]{2,20}-[a-z]{2,20}$"
+     },
+     "notifyEmail": {
+      "type": "boolean",
+      "default": false
+     },
+     "notifyTalkPage": {
+      "type": "boolean",
+      "default": false
+     }
+    }
+   },
+   "ParticipationResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/Participation"
+     }
+    }
+   },
+   "Participation": {
+    "type": "object",
+    "required": [
+     "pseudonym",
+     "notifications",
+     "eligibilityStatus",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "pseudonym": {
+      "type": "string"
+     },
+     "notifications": {
+      "type": "object",
+      "required": [
+       "email",
+       "talkPage"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "email": {
+        "type": "boolean"
+       },
+       "talkPage": {
+        "type": "boolean"
+       }
+      }
+     },
+     "eligibilityStatus": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "enum": [
+       "eligible",
+       "not_required",
+       null
+      ]
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "conversation",
+       "about"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "conversation": {
+        "type": "string"
+       },
+       "about": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "ExploreStateResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/ExploreState"
+     }
+    }
+   },
+   "ExploreState": {
+    "type": "object",
+    "required": [
+     "slug",
+     "title",
+     "pseudonym",
+     "currentStatement",
+     "progress",
+     "newStatement",
+     "capabilities",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "slug": {
+      "type": "string"
+     },
+     "title": {
+      "type": "string"
+     },
+     "pseudonym": {
+      "type": "string"
+     },
+     "currentStatement": {
+      "oneOf": [
+       {
+        "$ref": "#/components/schemas/ExploreStatement"
+       },
+       {
+        "type": "null"
+       }
+      ]
+     },
+     "progress": {
+      "$ref": "#/components/schemas/ExploreProgress"
+     },
+     "newStatement": {
+      "$ref": "#/components/schemas/NewStatementAvailability"
+     },
+     "capabilities": {
+      "$ref": "#/components/schemas/ExploreCapabilities"
+     },
+     "links": {
+      "$ref": "#/components/schemas/ExploreLinks"
+     }
+    }
+   },
+   "ExploreStatement": {
+    "type": "object",
+    "required": [
+     "id",
+     "text",
+     "isMeta",
+     "isSeed"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "id": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "text": {
+      "type": "string",
+      "minLength": 1
+     },
+     "isMeta": {
+      "type": "boolean"
+     },
+     "isSeed": {
+      "type": "boolean"
+     }
+    }
+   },
+   "ExploreProgress": {
+    "type": "object",
+    "required": [
+     "completed",
+     "total",
+     "remaining",
+     "allDone"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "completed": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "total": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "remaining": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "allDone": {
+      "type": "boolean"
+     }
+    }
+   },
+   "NewStatementAvailability": {
+    "type": "object",
+    "required": [
+     "unlocked",
+     "unlockAfter",
+     "quota",
+     "used",
+     "remaining"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "unlocked": {
+      "type": "boolean"
+     },
+     "unlockAfter": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "quota": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "used": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "remaining": {
+      "type": "integer",
+      "minimum": 0
+     }
+    }
+   },
+   "ExploreCapabilities": {
+    "type": "object",
+    "required": [
+     "vote",
+     "suggestWording",
+     "submitNewStatement"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "vote": {
+      "type": "boolean"
+     },
+     "suggestWording": {
+      "type": "boolean"
+     },
+     "submitNewStatement": {
+      "type": "boolean"
+     }
+    }
+   },
+   "ExploreLinks": {
+    "type": "object",
+    "required": [
+     "self",
+     "about",
+     "conversation"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "self": {
+      "type": "string"
+     },
+     "about": {
+      "type": "string"
+     },
+     "conversation": {
+      "type": "string"
+     },
+     "arguments": {
+      "type": "string"
+     }
+    }
+   },
+   "ExploreVoteRequest": {
+    "type": "object",
+    "required": [
+     "choice"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "choice": {
+      "type": "string",
+      "enum": [
+       "agree",
+       "pass",
+       "disagree"
+      ]
+     },
+     "passReason": {
+      "type": "string",
+      "enum": [
+       "unsure",
+       "confusing"
+      ],
+      "description": "Optional local reason for a pass vote. Valid only when choice is pass."
+     }
+    }
+   },
+   "ExploreVoteResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/ExploreVoteReceipt"
+     }
+    }
+   },
+   "ExploreVoteReceipt": {
+    "type": "object",
+    "required": [
+     "statementId",
+     "choice",
+     "passReason",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "statementId": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "choice": {
+      "type": "string",
+      "enum": [
+       "agree",
+       "pass",
+       "disagree"
+      ]
+     },
+     "passReason": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "enum": [
+       "unsure",
+       "confusing",
+       null
+      ]
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "explore"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "explore": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "InformedVotingResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/InformedVoting"
+     }
+    }
+   },
+   "InformedVoting": {
+    "type": "object",
+    "required": [
+     "slug",
+     "title",
+     "pseudonym",
+     "cards",
+     "progress",
+     "capabilities",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "slug": {
+      "type": "string"
+     },
+     "title": {
+      "type": "string"
+     },
+     "pseudonym": {
+      "type": "string"
+     },
+     "cards": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/InformedVotingCard"
+      }
+     },
+     "progress": {
+      "$ref": "#/components/schemas/ExploreProgress"
+     },
+     "capabilities": {
+      "type": "object",
+      "required": [
+       "vote"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "vote": {
+        "type": "boolean"
+       }
+      }
+     },
+     "links": {
+      "$ref": "#/components/schemas/InformedVotingLinks"
+     }
+    }
+   },
+   "InformedVotingCard": {
+    "type": "object",
+    "required": [
+     "featuredStatementId",
+     "statement",
+     "canVote",
+     "voted",
+     "arguments"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "featuredStatementId": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "statement": {
+      "type": "string",
+      "minLength": 1
+     },
+     "canVote": {
+      "type": "boolean"
+     },
+     "voted": {
+      "type": "boolean"
+     },
+     "arguments": {
+      "type": "object",
+      "required": [
+       "for",
+       "against"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "for": {
+        "type": "array",
+        "items": {
+         "$ref": "#/components/schemas/InformedVotingArgument"
+        }
+       },
+       "against": {
+        "type": "array",
+        "items": {
+         "$ref": "#/components/schemas/InformedVotingArgument"
+        }
+       }
+      }
+     }
+    }
+   },
+   "InformedVotingArgument": {
+    "type": "object",
+    "required": [
+     "id",
+     "body",
+     "helpfulVotes"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "id": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "body": {
+      "type": "string"
+     },
+     "helpfulVotes": {
+      "type": "integer",
+      "minimum": 0
+     }
+    }
+   },
+   "InformedVotingLinks": {
+    "type": "object",
+    "required": [
+     "self",
+     "about",
+     "conversation"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "self": {
+      "type": "string"
+     },
+     "about": {
+      "type": "string"
+     },
+     "conversation": {
+      "type": "string"
+     },
+     "explore": {
+      "type": "string"
+     },
+     "arguments": {
+      "type": "string"
+     },
+     "results": {
+      "type": "string"
+     }
+    }
+   },
+   "InformedVoteRequest": {
+    "type": "object",
+    "required": [
+     "choice"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "choice": {
+      "type": "string",
+      "enum": [
+       "agree",
+       "pass",
+       "disagree"
+      ]
+     }
+    }
+   },
+   "InformedVoteResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/InformedVoteReceipt"
+     }
+    }
+   },
+   "InformedVoteReceipt": {
+    "type": "object",
+    "required": [
+     "featuredStatementId",
+     "choice",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "featuredStatementId": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "choice": {
+      "type": "string",
+      "enum": [
+       "agree",
+       "pass",
+       "disagree"
+      ]
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "informedVoting"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "informedVoting": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "IntermediateResultsResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/IntermediateResults"
+     }
+    }
+   },
+   "IntermediateResults": {
+    "type": "object",
+    "required": [
+     "slug",
+     "title",
+     "state",
+     "participantCount",
+     "smallSample",
+     "consensus",
+     "groups",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "slug": {
+      "type": "string"
+     },
+     "title": {
+      "type": "string"
+     },
+     "state": {
+      "type": "string",
+      "enum": [
+       "ready",
+       "recomputing",
+       "pending"
+      ]
+     },
+     "participantCount": {
+      "type": [
+       "integer",
+       "null"
+      ],
+      "minimum": 0
+     },
+     "smallSample": {
+      "type": "boolean"
+     },
+     "consensus": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/IntermediateResultPosition"
+      }
+     },
+     "groups": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/IntermediateResultGroup"
+      }
+     },
+     "links": {
+      "$ref": "#/components/schemas/IntermediateResultsLinks"
+     }
+    }
+   },
+   "IntermediateResultPosition": {
+    "type": "object",
+    "required": [
+     "choice",
+     "statement",
+     "percentage"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "choice": {
+      "type": "string",
+      "enum": [
+       "agree",
+       "disagree"
+      ]
+     },
+     "statement": {
+      "type": "string"
+     },
+     "percentage": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100
+     }
+    }
+   },
+   "IntermediateResultGroup": {
+    "type": "object",
+    "required": [
+     "label",
+     "positions"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "label": {
+      "type": "string"
+     },
+     "positions": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/IntermediateResultPosition"
+      }
+     }
+    }
+   },
+   "IntermediateResultsLinks": {
+    "type": "object",
+    "required": [
+     "self",
+     "conversation",
+     "about"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "self": {
+      "type": "string"
+     },
+     "conversation": {
+      "type": "string"
+     },
+     "about": {
+      "type": "string"
+     }
+    }
+   },
+   "ResultsReportResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/ResultsReport"
+     }
+    }
+   },
+   "ResultsReport": {
+    "type": "object",
+    "required": [
+     "slug",
+     "title",
+     "publication",
+     "resultsAvailable",
+     "openedAt",
+     "closedAt",
+     "context",
+     "participation",
+     "dataAvailability",
+     "moderation",
+     "statements",
+     "opinionGroups",
+     "viewer",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "slug": {
+      "type": "string"
+     },
+     "title": {
+      "type": "string"
+     },
+     "publication": {
+      "type": "string",
+      "enum": [
+       "preliminary",
+       "final"
+      ]
+     },
+     "resultsAvailable": {
+      "type": "boolean"
+     },
+     "openedAt": {
+      "type": "string",
+      "format": "date-time"
+     },
+     "closedAt": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "format": "date-time"
+     },
+     "context": {
+      "type": "object",
+      "required": [
+       "phase",
+       "status",
+       "method"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "phase": {
+        "type": "string"
+       },
+       "status": {
+        "type": "string",
+        "enum": [
+         "provisional",
+         "final"
+        ]
+       },
+       "method": {
+        "type": "string"
+       }
+      }
+     },
+     "participation": {
+      "type": "object",
+      "required": [
+       "initialRound",
+       "informedRound",
+       "matchedRounds"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "initialRound": {
+        "type": [
+         "integer",
+         "null"
+        ],
+        "minimum": 0
+       },
+       "informedRound": {
+        "type": [
+         "integer",
+         "null"
+        ],
+        "minimum": 0
+       },
+       "matchedRounds": {
+        "type": [
+         "integer",
+         "null"
+        ],
+        "minimum": 0
+       }
+      }
+     },
+     "dataAvailability": {
+      "type": "object",
+      "required": [
+       "detailedCounts",
+       "opinionGroups"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "detailedCounts": {
+        "type": "boolean"
+       },
+       "opinionGroups": {
+        "type": "boolean"
+       }
+      }
+     },
+     "moderation": {
+      "type": "object",
+      "required": [
+       "excludedStatements",
+       "excludedParticipants"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "excludedStatements": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "excludedParticipants": {
+        "type": "integer",
+        "minimum": 0
+       }
+      }
+     },
+     "statements": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/ResultsStatement"
+      }
+     },
+     "opinionGroups": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/ResultsOpinionGroup"
+      }
+     },
+     "viewer": {
+      "type": "object",
+      "required": [
+       "participating",
+       "pseudonym",
+       "revealState"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "participating": {
+        "type": "boolean"
+       },
+       "pseudonym": {
+        "type": [
+         "string",
+         "null"
+        ]
+       },
+       "revealState": {
+        "type": [
+         "string",
+         "null"
+        ],
+        "enum": [
+         "pending",
+         "open",
+         "revealed",
+         "expired",
+         null
+        ]
+       }
+      }
+     },
+     "links": {
+      "$ref": "#/components/schemas/ResultsLinks"
+     }
+    }
+   },
+   "ResultsStatement": {
+    "type": "object",
+    "required": [
+     "featuredStatementId",
+     "statement",
+     "initial",
+     "informed",
+     "agreementShift",
+     "viewerChoice"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "featuredStatementId": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "statement": {
+      "type": "string"
+     },
+     "initial": {
+      "oneOf": [
+       {
+        "$ref": "#/components/schemas/VoteTally"
+       },
+       {
+        "type": "null"
+       }
+      ]
+     },
+     "informed": {
+      "oneOf": [
+       {
+        "$ref": "#/components/schemas/VoteTally"
+       },
+       {
+        "type": "null"
+       }
+      ]
+     },
+     "agreementShift": {
+      "type": [
+       "number",
+       "null"
+      ]
+     },
+     "viewerChoice": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "enum": [
+       "agree",
+       "pass",
+       "disagree",
+       null
+      ]
+     }
+    }
+   },
+   "VoteTally": {
+    "type": "object",
+    "required": [
+     "counts",
+     "percentages"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "counts": {
+      "type": "object",
+      "required": [
+       "agree",
+       "pass",
+       "disagree",
+       "voters"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "agree": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "pass": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "disagree": {
+        "type": "integer",
+        "minimum": 0
+       },
+       "voters": {
+        "type": "integer",
+        "minimum": 0
+       }
+      }
+     },
+     "percentages": {
+      "type": "object",
+      "required": [
+       "agree",
+       "pass",
+       "disagree"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "agree": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+       },
+       "pass": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+       },
+       "disagree": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+       }
+      }
+     }
+    }
+   },
+   "ResultsOpinionGroup": {
+    "type": "object",
+    "required": [
+     "label",
+     "memberCount",
+     "positions"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "label": {
+      "type": "string"
+     },
+     "memberCount": {
+      "type": [
+       "integer",
+       "null"
+      ],
+      "minimum": 0
+     },
+     "positions": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/ResultsGroupPosition"
+      }
+     }
+    }
+   },
+   "ResultsGroupPosition": {
+    "type": "object",
+    "required": [
+     "choice",
+     "statement",
+     "percentage"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "choice": {
+      "type": "string",
+      "enum": [
+       "agree",
+       "disagree"
+      ]
+     },
+     "statement": {
+      "type": "string"
+     },
+     "percentage": {
+      "type": [
+       "number",
+       "null"
+      ],
+      "minimum": 0,
+      "maximum": 100
+     }
+    }
+   },
+   "ResultsLinks": {
+    "type": "object",
+    "required": [
+     "self",
+     "conversation",
+     "about"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "self": {
+      "type": "string"
+     },
+     "conversation": {
+      "type": "string"
+     },
+     "about": {
+      "type": "string"
+     },
+     "identityReveal": {
+      "type": "string"
+     }
+    }
+   },
+   "ArgumentMappingResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/ArgumentMapping"
+     }
+    }
+   },
+   "ArgumentMapping": {
+    "type": "object",
+    "required": [
+     "conversationId",
+     "slug",
+     "title",
+     "pseudonym",
+     "progress",
+     "featuredStatements",
+     "capabilities",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "conversationId": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "slug": {
+      "type": "string"
+     },
+     "title": {
+      "type": "string"
+     },
+     "pseudonym": {
+      "type": "string"
+     },
+     "progress": {
+      "$ref": "#/components/schemas/ArgumentMappingProgress"
+     },
+     "featuredStatements": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/ArgumentFeaturedStatement"
+      }
+     },
+     "capabilities": {
+      "$ref": "#/components/schemas/ArgumentMappingCapabilities"
+     },
+     "links": {
+      "$ref": "#/components/schemas/ArgumentMappingLinks"
+     }
+    }
+   },
+   "ArgumentMappingProgress": {
+    "type": "object",
+    "required": [
+     "completed",
+     "total",
+     "allDone",
+     "currentFeaturedStatementId"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "completed": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "total": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "allDone": {
+      "type": "boolean"
+     },
+     "currentFeaturedStatementId": {
+      "type": [
+       "integer",
+       "null"
+      ]
+     }
+    }
+   },
+   "ArgumentFeaturedStatement": {
+    "type": "object",
+    "required": [
+     "id",
+     "statement",
+     "contributionsComplete",
+     "complete",
+     "sides",
+     "capabilities"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "id": {
+      "type": "integer"
+     },
+     "statement": {
+      "$ref": "#/components/schemas/ArgumentStatement"
+     },
+     "contributionsComplete": {
+      "type": "boolean"
+     },
+     "complete": {
+      "type": "boolean"
+     },
+     "sides": {
+      "type": "object",
+      "required": [
+       "pro",
+       "con"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "pro": {
+        "$ref": "#/components/schemas/ArgumentSide"
+       },
+       "con": {
+        "$ref": "#/components/schemas/ArgumentSide"
+       }
+      }
+     },
+     "capabilities": {
+      "type": "object",
+      "required": [
+       "flagStatement"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "flagStatement": {
+        "type": "boolean"
+       }
+      }
+     }
+    }
+   },
+   "ArgumentStatement": {
+    "type": "object",
+    "required": [
+     "id",
+     "text"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "id": {
+      "type": "integer"
+     },
+     "text": {
+      "type": "string"
+     }
+    }
+   },
+   "ArgumentSide": {
+    "type": "object",
+    "required": [
+     "contribution",
+     "prioritization",
+     "arguments"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "contribution": {
+      "$ref": "#/components/schemas/ArgumentContribution"
+     },
+     "prioritization": {
+      "$ref": "#/components/schemas/ArgumentPrioritization"
+     },
+     "arguments": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/ArgumentItem"
+      }
+     }
+    }
+   },
+   "ArgumentContribution": {
+    "type": "object",
+    "required": [
+     "status",
+     "argumentId",
+     "capabilities"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "status": {
+      "type": "string",
+      "enum": [
+       "pending",
+       "submitted",
+       "skipped"
+      ]
+     },
+     "argumentId": {
+      "type": [
+       "integer",
+       "null"
+      ]
+     },
+     "capabilities": {
+      "type": "object",
+      "required": [
+       "submit",
+       "skip"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "submit": {
+        "type": "boolean"
+       },
+       "skip": {
+        "type": "boolean"
+       }
+      }
+     }
+    }
+   },
+   "ArgumentPrioritization": {
+    "type": "object",
+    "required": [
+     "available",
+     "requiredArgumentCount",
+     "argumentCount",
+     "selectionBudget",
+     "selectedCount",
+     "complete"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "available": {
+      "type": "boolean"
+     },
+     "requiredArgumentCount": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "argumentCount": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "selectionBudget": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "selectedCount": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "complete": {
+      "type": "boolean"
+     }
+    }
+   },
+   "ArgumentItem": {
+    "type": "object",
+    "required": [
+     "id",
+     "body",
+     "own",
+     "selected",
+     "hidden",
+     "importanceVoteCount",
+     "capabilities"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "id": {
+      "type": "integer"
+     },
+     "body": {
+      "type": "string",
+      "maxLength": 280
+     },
+     "own": {
+      "type": "boolean"
+     },
+     "selected": {
+      "type": "boolean"
+     },
+     "hidden": {
+      "type": "boolean"
+     },
+     "importanceVoteCount": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "capabilities": {
+      "type": "object",
+      "required": [
+       "prioritize",
+       "flag",
+       "moderate"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "prioritize": {
+        "type": "boolean"
+       },
+       "flag": {
+        "type": "boolean"
+       },
+       "moderate": {
+        "type": "boolean"
+       }
+      }
+     }
+    }
+   },
+   "ArgumentMappingCapabilities": {
+    "type": "object",
+    "required": [
+     "contribute",
+     "prioritize",
+     "flag",
+     "moderate"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "contribute": {
+      "type": "boolean"
+     },
+     "prioritize": {
+      "type": "boolean"
+     },
+     "flag": {
+      "type": "boolean"
+     },
+     "moderate": {
+      "type": "boolean"
+     }
+    }
+   },
+   "ArgumentMappingLinks": {
+    "type": "object",
+    "required": [
+     "self",
+     "about",
+     "conversation"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "self": {
+      "type": "string"
+     },
+     "about": {
+      "type": "string"
+     },
+     "conversation": {
+      "type": "string"
+     },
+     "explore": {
+      "type": "string"
+     }
+    }
+   },
+   "CreateArgumentRequest": {
+    "type": "object",
+    "required": [
+     "side",
+     "body"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "side": {
+      "type": "string",
+      "enum": [
+       "pro",
+       "con"
+      ]
+     },
+     "body": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 280
+     }
+    }
+   },
+   "ArgumentCommandLinks": {
+    "type": "object",
+    "required": [
+     "arguments"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "arguments": {
+      "type": "string"
+     }
+    }
+   },
+   "ArgumentSubmissionResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/ArgumentSubmissionReceipt"
+     }
+    }
+   },
+   "ArgumentSubmissionReceipt": {
+    "type": "object",
+    "required": [
+     "featuredStatementId",
+     "side",
+     "status",
+     "argument",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "featuredStatementId": {
+      "type": "integer"
+     },
+     "side": {
+      "type": "string",
+      "enum": [
+       "pro",
+       "con"
+      ]
+     },
+     "status": {
+      "type": "string",
+      "const": "submitted"
+     },
+     "argument": {
+      "$ref": "#/components/schemas/ArgumentItem"
+     },
+     "links": {
+      "$ref": "#/components/schemas/ArgumentCommandLinks"
+     }
+    }
+   },
+   "ArgumentSkipResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/ArgumentSkipReceipt"
+     }
+    }
+   },
+   "ArgumentSkipReceipt": {
+    "type": "object",
+    "required": [
+     "featuredStatementId",
+     "side",
+     "status",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "featuredStatementId": {
+      "type": "integer"
+     },
+     "side": {
+      "type": "string",
+      "enum": [
+       "pro",
+       "con"
+      ]
+     },
+     "status": {
+      "type": "string",
+      "const": "skipped"
+     },
+     "links": {
+      "$ref": "#/components/schemas/ArgumentCommandLinks"
+     }
+    }
+   },
+   "ArgumentPriorityRequest": {
+    "type": "object",
+    "required": [
+     "selected"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "selected": {
+      "type": "boolean"
+     }
+    }
+   },
+   "ArgumentPriorityResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/ArgumentPriorityReceipt"
+     }
+    }
+   },
+   "ArgumentPriorityReceipt": {
+    "type": "object",
+    "required": [
+     "argumentId",
+     "selected",
+     "selectedCount",
+     "selectionBudget",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "argumentId": {
+      "type": "integer"
+     },
+     "selected": {
+      "type": "boolean"
+     },
+     "selectedCount": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "selectionBudget": {
+      "type": "integer",
+      "minimum": 1
+     },
+     "links": {
+      "$ref": "#/components/schemas/ArgumentCommandLinks"
+     }
+    }
+   },
+   "CreateContentFlagRequest": {
+    "type": "object",
+    "required": [
+     "contentType",
+     "targetId",
+     "category"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "contentType": {
+      "type": "string",
+      "enum": [
+       "statement",
+       "argument"
+      ]
+     },
+     "targetId": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "category": {
+      "type": "string",
+      "enum": [
+       "personal_attack",
+       "privacy",
+       "off_topic",
+       "other"
+      ]
+     },
+     "detail": {
+      "type": [
+       "string",
+       "null"
+      ],
+      "maxLength": 1000
+     }
+    }
+   },
+   "ContentFlagResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/ContentFlagReceipt"
+     }
+    }
+   },
+   "ContentFlagReceipt": {
+    "type": "object",
+    "required": [
+     "contentType",
+     "targetId",
+     "category",
+     "status",
+     "created",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "contentType": {
+      "type": "string",
+      "enum": [
+       "statement",
+       "argument"
+      ]
+     },
+     "targetId": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "category": {
+      "type": "string",
+      "enum": [
+       "personal_attack",
+       "privacy",
+       "off_topic",
+       "other"
+      ]
+     },
+     "status": {
+      "type": "string",
+      "const": "open"
+     },
+     "created": {
+      "type": "boolean"
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "conversation"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "conversation": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "CreateStatementRequest": {
+    "type": "object",
+    "required": [
+     "text"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "text": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 280
+     },
+     "derivedFromStatementId": {
+      "type": [
+       "integer",
+       "null"
+      ],
+      "minimum": 0
+     }
+    }
+   },
+   "StatementCreationResponse": {
+    "type": "object",
+    "required": [
+     "data"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "data": {
+      "$ref": "#/components/schemas/StatementCreationReceipt"
+     }
+    }
+   },
+   "StatementCreationReceipt": {
+    "type": "object",
+    "required": [
+     "statementId",
+     "kind",
+     "derivedFromStatementId",
+     "newStatementQuotaRemaining",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "statementId": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "kind": {
+      "type": "string",
+      "enum": [
+       "new",
+       "derivative"
+      ]
+     },
+     "derivedFromStatementId": {
+      "type": [
+       "integer",
+       "null"
+      ],
+      "minimum": 0
+     },
+     "newStatementQuotaRemaining": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "links": {
+      "type": "object",
+      "required": [
+       "explore"
+      ],
+      "additionalProperties": false,
+      "properties": {
+       "explore": {
+        "type": "string"
+       }
+      }
+     }
+    }
+   },
+   "ConversationAbout": {
+    "type": "object",
+    "required": [
+     "slug",
+     "title",
+     "space",
+     "descriptionHtml",
+     "outroHtml",
+     "status",
+     "phases",
+     "scheduledTransition",
+     "pseudonym",
+     "statistics",
+     "personal",
+     "outputs",
+     "moderation",
+     "capabilities",
+     "links"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "slug": {
+      "type": "string",
+      "minLength": 1
+     },
+     "title": {
+      "type": "string",
+      "minLength": 1
+     },
+     "space": {
+      "type": "string",
+      "enum": [
+       "demo",
+       "real"
+      ]
+     },
+     "descriptionHtml": {
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "outroHtml": {
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "status": {
+      "type": "string",
+      "enum": [
+       "open",
+       "paused",
+       "archived"
+      ]
+     },
+     "phases": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/ConversationPhase"
+      }
+     },
+     "scheduledTransition": {
+      "oneOf": [
+       {
+        "$ref": "#/components/schemas/ScheduledTransition"
+       },
+       {
+        "type": "null"
+       }
+      ]
+     },
+     "pseudonym": {
+      "type": [
+       "string",
+       "null"
+      ]
+     },
+     "statistics": {
+      "$ref": "#/components/schemas/ConversationStatistics"
+     },
+     "personal": {
+      "oneOf": [
+       {
+        "$ref": "#/components/schemas/PersonalContributions"
+       },
+       {
+        "type": "null"
+       }
+      ]
+     },
+     "outputs": {
+      "type": "array",
+      "items": {
+       "$ref": "#/components/schemas/ConversationOutput"
+      }
+     },
+     "moderation": {
+      "$ref": "#/components/schemas/ConversationModeration"
+     },
+     "capabilities": {
+      "$ref": "#/components/schemas/ConversationAboutCapabilities"
+     },
+     "links": {
+      "$ref": "#/components/schemas/ConversationAboutLinks"
+     }
+    }
+   },
+   "ConversationPhase": {
+    "type": "object",
+    "required": [
+     "key",
+     "label"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "key": {
+      "type": "string"
+     },
+     "label": {
+      "type": "string"
+     }
+    }
+   },
+   "ConversationStatistics": {
+    "type": "object",
+    "required": [
+     "participants",
+     "statementVotes",
+     "statements",
+     "arguments",
+     "argumentContributors"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "participants": {
+      "type": [
+       "integer",
+       "null"
+      ],
+      "minimum": 0
+     },
+     "statementVotes": {
+      "type": [
+       "integer",
+       "null"
+      ],
+      "minimum": 0
+     },
+     "statements": {
+      "type": [
+       "integer",
+       "null"
+      ],
+      "minimum": 0
+     },
+     "arguments": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "argumentContributors": {
+      "type": "integer",
+      "minimum": 0
+     }
+    }
+   },
+   "PersonalContributions": {
+    "type": "object",
+    "required": [
+     "statementsSuggested",
+     "statementVotes",
+     "statementVotesAvailable",
+     "argumentsAdded",
+     "argumentsRated"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "statementsSuggested": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "statementVotes": {
+      "type": [
+       "integer",
+       "null"
+      ],
+      "minimum": 0
+     },
+     "statementVotesAvailable": {
+      "type": "boolean"
+     },
+     "argumentsAdded": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "argumentsRated": {
+      "type": "integer",
+      "minimum": 0
+     }
+    }
+   },
+   "ConversationModeration": {
+    "type": "object",
+    "required": [
+     "eventCount",
+     "href"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "eventCount": {
+      "type": "integer",
+      "minimum": 0
+     },
+     "href": {
+      "type": "string"
+     }
+    }
+   },
+   "ConversationAboutCapabilities": {
+    "type": "object",
+    "required": [
+     "participate",
+     "moderate"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "participate": {
+      "type": "boolean"
+     },
+     "moderate": {
+      "type": "boolean"
+     }
+    }
+   },
+   "ConversationAboutLinks": {
+    "type": "object",
+    "required": [
+     "self",
+     "conversation"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "self": {
+      "type": "string"
+     },
+     "conversation": {
+      "type": "string"
+     }
+    }
+   },
+   "ScheduledTransition": {
+    "type": "object",
+    "required": [
+     "at",
+     "target",
+     "targetLabel"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "at": {
+      "type": "string",
+      "format": "date-time"
+     },
+     "target": {
+      "type": "string"
+     },
+     "targetLabel": {
+      "type": "string"
+     }
+    }
+   },
+   "ConversationOutput": {
+    "type": "object",
+    "required": [
+     "key",
+     "label",
+     "status",
+     "symbol",
+     "tooltip",
+     "pending",
+     "ready",
+     "href"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "key": {
+      "type": "string"
+     },
+     "label": {
+      "type": "string"
+     },
+     "status": {
+      "type": "string"
+     },
+     "symbol": {
+      "type": "string"
+     },
+     "tooltip": {
+      "type": "string"
+     },
+     "pending": {
+      "type": "string"
+     },
+     "ready": {
+      "type": "boolean"
+     },
+     "href": {
+      "type": [
+       "string",
+       "null"
+      ]
+     }
+    }
+   },
+   "ConversationRevealSignal": {
+    "type": "object",
+    "required": [
+     "state",
+     "daysRemaining"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "state": {
+      "type": "string",
+      "enum": [
+       "pending",
+       "open",
+       "revealed",
+       "expired"
+      ]
+     },
+     "daysRemaining": {
+      "type": "integer",
+      "minimum": 0
+     }
+    }
+   },
+   "ConversationCapabilities": {
+    "type": "object",
+    "required": [
+     "join",
+     "participate",
+     "moderate"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "join": {
+      "type": "boolean"
+     },
+     "participate": {
+      "type": "boolean"
+     },
+     "moderate": {
+      "type": "boolean"
+     }
+    }
+   },
+   "ConversationLinks": {
+    "type": "object",
+    "required": [
+     "self",
+     "about"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "self": {
+      "type": "string"
+     },
+     "about": {
+      "type": "string"
+     },
+     "explore": {
+      "type": "string"
+     },
+     "arguments": {
+      "type": "string"
+     },
+     "results": {
+      "type": "string"
+     },
+     "informedVoting": {
+      "type": "string"
+     },
+     "identityReveal": {
+      "type": "string"
+     },
+     "admin": {
+      "type": "string"
+     }
+    }
+   },
+   "ErrorResponse": {
+    "type": "object",
+    "required": [
+     "error"
+    ],
+    "additionalProperties": false,
+    "properties": {
+     "error": {
+      "type": "object",
+      "required": [
+       "code",
+       "message"
+      ],
+      "properties": {
+       "code": {
+        "type": "string"
+       },
+       "message": {
+        "type": "string"
+       },
+       "details": {}
+      }
+     }
+    }
+   }
+  }
+ }
 }

--- a/v2/services/admin_settings.py
+++ b/v2/services/admin_settings.py
@@ -18,6 +18,11 @@ def build_admin_settings(
             'phaseRoute': conversation.phase_route,
             'phaseRouteLabel': phase_route_label,
             'polisId': conversation.polis_id,
+            # Organizer/global-admin only — moderators without organizer rights can
+            # read the rest of this payload (build_admin_settings is called behind
+            # _require_mod_for_conv) but must not see notes. null, not '', signals
+            # "you don't have access" distinctly from "no notes written yet".
+            'adminNotes': conversation.admin_notes or '' if can_edit else None,
         },
         'recommendations': {
             'tier': recommendation_profile['tier'],
@@ -64,7 +69,7 @@ def update_recommendation_tier(
 def update_conversation_settings(
     *, conversation, title: str, intro_html: str, outro_html: str,
     access_policy: str, eligibility_event_id: str, eligibility_label: str,
-    tier: str, sanitise, session, audit,
+    tier: str, admin_notes: str, sanitise, session, audit,
 ) -> SettingsUpdateResult:
     desired = {
         'title': title.strip(),
@@ -74,6 +79,10 @@ def update_conversation_settings(
         'eligibility_event_id': eligibility_event_id.strip() or None,
         'eligibility_label': eligibility_label.strip() or None,
         'recommended_quantities': {'tier': tier},
+        # Deliberately NOT sanitised as HTML: plain text, organizer-only, never
+        # rendered to participants — sanitise() strips tags meant for HTML output,
+        # which would mangle a note like "check <the old export> before reusing".
+        'admin_notes': admin_notes.strip() or None,
     }
     changed_fields = sorted(
         field for field, value in desired.items()

--- a/v2/tests/test_admin_settings_api.py
+++ b/v2/tests/test_admin_settings_api.py
@@ -48,6 +48,7 @@ def test_organizer_replaces_settings_idempotently(
         'eligibilityEventId': 'extended-confirmed',
         'eligibilityLabel': 'Extended-confirmed editors',
         'recommendationTier': 'complex',
+        'adminNotes': '  Pre-dates the CC0 notice.  ',
     }
 
     first = client.put(endpoint, json=body)
@@ -63,6 +64,11 @@ def test_organizer_replaces_settings_idempotently(
     assert settings['eligibility']['eventId'] == 'extended-confirmed'
     assert settings['eligibility']['label'] == 'Extended-confirmed editors'
     assert settings['recommendations']['tier'] == 'complex'
+    # Plain text, not HTML: leading/trailing whitespace stripped like other free
+    # text fields, but NOT run through the HTML sanitiser that introHtml/outroHtml
+    # get — this is never rendered as HTML, and sanitising it would mangle a note
+    # containing '<' or '>' that the organizer meant literally.
+    assert settings['conversation']['adminNotes'] == 'Pre-dates the CC0 notice.'
     assert AuditEvent.query.filter_by(
         operation='conversation.settings.update',
         conversation_id=conversation.id,
@@ -76,13 +82,14 @@ def test_settings_update_returns_field_errors(admin_client, conversation):
             'title': '', 'introHtml': '', 'outroHtml': '',
             'accessPolicy': 'secret', 'eligibilityEventId': 'x' * 81,
             'eligibilityLabel': 'y' * 256, 'recommendationTier': 'enormous',
+            'adminNotes': 'z' * 4001,
         },
     )
 
     assert response.status_code == 400
     assert set(response.get_json()['error']['details']['fields']) == {
         'title', 'accessPolicy', 'eligibilityEventId', 'eligibilityLabel',
-        'recommendationTier',
+        'recommendationTier', 'adminNotes',
     }
 
 
@@ -103,10 +110,14 @@ def test_moderator_can_read_but_not_change_settings(
         'title': conversation.title, 'introHtml': '', 'outroHtml': '',
         'accessPolicy': 'public', 'eligibilityEventId': '',
         'eligibilityLabel': '', 'recommendationTier': 'medium',
+        'adminNotes': '',
     })
 
     assert readable.status_code == 200
     assert readable.get_json()['data']['capabilities']['edit'] is False
+    # Private to organizer/global-admin. A moderator who can read the rest of
+    # this payload must not see notes meant to stay off their radar.
+    assert readable.get_json()['data']['conversation']['adminNotes'] is None
     assert denied.status_code == 403
 
 


### PR DESCRIPTION
## Summary

Adds an organizer/global-admin-only free-text notes field per conversation. The motivating case, from the CC0 review (#345, #334): a way to record that a specific round predates the CC0 consent notice, so nobody assumes it applies retroactively to `2026-nlwiki-arbcom`.

- **Private by design**: visible only to organizers/global-admins. Moderators without organizer rights can already read the rest of the settings payload (`_require_mod_for_conv`), so the field itself gates on `can_edit` — `null` (no access) vs `''` (no notes yet) are distinguished.
- **Named "notes", not "comments"**: Polis's own `comments` table is what stores participant statements — an admin field with that name would collide badly with the domain's existing vocabulary.
- **Plain text, not sanitised as HTML** — unlike `introHtml`/`outroHtml`, this is never rendered to participants, so running it through the HTML sanitiser would mangle a note containing `<`/`>` meant literally.
- Flagged in code (`db.py` comment, alongside `build_reports.py`'s `CONVERSATION_COLUMNS` allowlist pattern) that this must never be added to an analysis export.

## Verification

- Full backend suite: 794 passed
- Frontend: 70 passed, typecheck clean, build clean
- Verified end to end against a live dev server (not just pytest's test client): seeded a conversation with an organizer role, filled the field through the real rendered SPA, confirmed the PUT round-trip in the network panel, confirmed the value survives a full page reload from `dev.db`.

## Test plan

- [x] Migration applies cleanly, single head
- [x] Moderator without organizer rights: field is `null`, not visible in UI
- [x] Organizer: can read and write; persists across reload
- [x] Validation: 4000-char cap, rejected with the existing field-error shape
- [x] Second call site (lifecycle page's lighter settings form) passes the value through unchanged rather than clobbering it

🤖 Generated with [Claude Code](https://claude.com/claude-code)