### PR TITLE
Scope the Phase 6 Particiapi session per conversation

### DIFF
--- a/v2/app.py
+++ b/v2/app.py
@@ -2261,12 +2261,41 @@ def _require_informed_voting_api_context(
     return conv, participant, participation
 
 
+_PHASE6_SESSION_KEY = 'phase6_api_sessions'
+# The pre-fix global Phase 6 session scalars. Dropped on sight, never migrated: a stored
+# value is either unbound or bound to a DIFFERENT conversation's subject, so carrying it
+# forward under a per-conversation key would preserve exactly the bug below. Dropping it
+# costs one extra session bootstrap and re-binds the participant correctly.
+_PHASE6_LEGACY_SESSION_KEYS = ('_p6_pa', '_p6_csrf')
+
+
+def _phase6_session_states() -> dict:
+    """Per-conversation Phase 6 Particiapi sessions, keyed by ``str(conv.id)``.
+
+    Mirrors Phase 2's ``particiapi_api_sessions``, but as its OWN dict: the two rounds are
+    separate Polis conversations (``conv.polis_id`` vs ``conv.phase6_polis_conversation_id``)
+    and must never hand each other a session. A separate dict makes that structurally
+    impossible instead of resting on a key-naming convention one round could get wrong.
+
+    Phase 6 previously stored ONE cookie per browser session in ``_p6_pa``/``_p6_csrf``.
+    Both write paths bootstrap only when that cookie is missing, and ``ensure_session`` is
+    the only place ``X-Particiapi-Sub`` is sent — so the first Phase 6 round a participant
+    entered minted and bound the session, and every later round reused it, never binding
+    its own subject. Those votes went to an unbound uid, and a single Polis uid spanned
+    every Phase 6 round that participant entered: the cross-conversation linkage chain
+    ``_conversation_subject`` is keyed on ``conv.id`` to prevent (#246). The process-local
+    ``_p6_session_cache`` beside it was already keyed ``(xid, conv.id)``, which is the tell
+    that the global scalars were an oversight rather than a decision.
+    """
+    for legacy_key in _PHASE6_LEGACY_SESSION_KEYS:
+        session.pop(legacy_key, None)
+    return dict(session.get(_PHASE6_SESSION_KEY) or {})
+
+
 def _phase6_gateway(conv: Conversation, participant: Participant):
     key = (participant.xid, conv.id)
-    state = ParticiapiSessionState(
-        cookie=session.get('_p6_pa'),
-        csrf_token=session.get('_p6_csrf'),
-    )
+    states = _phase6_session_states()
+    state = ParticiapiSessionState.from_dict(states.get(str(conv.id)))
     # Bind the participant's identity, exactly as _explore_gateway does. The subject is
     # keyed on conv.id, so Phase 2 and Phase 6 resolve to the SAME Polis uid for one
     # person — which is what _conversation_subject was written for and says it does.
@@ -2290,12 +2319,14 @@ def _phase6_gateway(conv: Conversation, participant: Participant):
             else:
                 gateway.ensure_session()
                 _p6_session_cache[key] = (state.cookie, state.csrf_token)
-    return gateway, key
+    return gateway, key, states
 
 
-def _save_phase6_gateway(gateway: ExploreGateway, key) -> None:
-    session['_p6_pa'] = gateway.state.cookie
-    session['_p6_csrf'] = gateway.state.csrf_token
+def _save_phase6_gateway(
+    conv: Conversation, gateway: ExploreGateway, key, states: dict,
+) -> None:
+    states[str(conv.id)] = gateway.state.to_dict()
+    session[_PHASE6_SESSION_KEY] = states
     _p6_session_cache[key] = (gateway.state.cookie, gateway.state.csrf_token)
 
 
@@ -2303,7 +2334,7 @@ def _informed_voting_api_payload(slug: str) -> dict:
     conv, participant, participation = _require_informed_voting_api_context(
         slug, allow_banned_read=True,
     )
-    gateway, key = _phase6_gateway(conv, participant)
+    gateway, key, states = _phase6_gateway(conv, participant)
     try:
         participant_payload = gateway.read_participant(
             conv.phase6_polis_conversation_id,
@@ -2333,7 +2364,7 @@ def _informed_voting_api_payload(slug: str) -> dict:
             'links': links,
         }
     finally:
-        _save_phase6_gateway(gateway, key)
+        _save_phase6_gateway(conv, gateway, key, states)
 
 
 def _informed_vote_api_payload(
@@ -2347,7 +2378,7 @@ def _informed_vote_api_payload(
     ).first()
     if featured is None or featured.phase6_polis_statement_id is None:
         abort(404, description='Featured statement is not available in this round.')
-    gateway, key = _phase6_gateway(conv, participant)
+    gateway, key, states = _phase6_gateway(conv, participant)
     try:
         polis_values = {'agree': -1, 'pass': 0, 'disagree': 1}
         gateway.vote(
@@ -2367,7 +2398,7 @@ def _informed_vote_api_payload(
             },
         }
     finally:
-        _save_phase6_gateway(gateway, key)
+        _save_phase6_gateway(conv, gateway, key, states)
 
 
 def _results_report_api_payload(slug: str) -> dict:
@@ -6559,13 +6590,26 @@ def phase6_vote(slug):
     # `pa_session` cookie so it never collides with the Phase 2 web component's
     # session. We re-bootstrap only when it is missing or a vote is rejected as a
     # session/CSRF failure (stale token).
+    #
+    # Scoped PER CONVERSATION, like Phase 2 and like _p6_session_cache — see
+    # _phase6_session_states(). A single browser-session-wide session let the first
+    # Phase 6 round a participant entered bind the identity for every later round.
     p6_key = (session.get('xid'), conv.id)
+    p6_states = _phase6_session_states()
+    p6_conv_key = str(conv.id)
+    stored = ParticiapiSessionState.from_dict(p6_states.get(p6_conv_key))
 
-    def _bootstrap():
-        """(Re)establish the Phase 6 Particiapi session + CSRF token, storing both in
-        the Flask session and the process-local share cache. Returns (pa, csrf_token);
-        aborts 502 on failure."""
-        prior = session.get('_p6_pa')
+    def _store(cookie_val, token):
+        p6_states[p6_conv_key] = ParticiapiSessionState(
+            cookie=cookie_val, csrf_token=token,
+        ).to_dict()
+        session[_PHASE6_SESSION_KEY] = p6_states
+        _p6_session_cache[p6_key] = (cookie_val, token)
+
+    def _bootstrap(prior):
+        """(Re)establish the Phase 6 Particiapi session + CSRF token, storing both under
+        this conversation's key in the Flask session and in the process-local share
+        cache. Returns (pa, csrf_token); aborts 502 on failure."""
         # Bind identity exactly as _phase6_gateway and _explore_gateway do. This route
         # and the API route share _p6_session_cache, so if only one of them bound, an
         # anonymous session cached by this path would be handed to the other and the
@@ -6591,13 +6635,13 @@ def phase6_vote(slug):
         if not r.ok:
             current_app.logger.error('Particiapi session error in phase6_vote: %s', r.status_code)
             abort(502)
-        session['_p6_pa']   = r.cookies.get('session') or prior
-        session['_p6_csrf'] = r.json().get('csrf_token', '')
-        _p6_session_cache[p6_key] = (session['_p6_pa'], session['_p6_csrf'])
-        return session['_p6_pa'], session['_p6_csrf']
+        fresh_pa = r.cookies.get('session') or prior
+        fresh_csrf = r.json().get('csrf_token', '')
+        _store(fresh_pa, fresh_csrf)
+        return fresh_pa, fresh_csrf
 
-    pa = session.get('_p6_pa')
-    csrf_token = session.get('_p6_csrf')
+    pa = stored.cookie
+    csrf_token = stored.csrf_token
     bootstrapped = False
     if not (pa and csrf_token):
         # Serialize the first bootstrap per (participant, conversation) within this
@@ -6606,10 +6650,10 @@ def phase6_vote(slug):
         with _p6_bootstrap_lock(p6_key):
             shared = _p6_session_cache.get(p6_key)
             if shared:
-                session['_p6_pa'], session['_p6_csrf'] = shared
                 pa, csrf_token = shared
+                _store(pa, csrf_token)
             else:
-                pa, csrf_token = _bootstrap()
+                pa, csrf_token = _bootstrap(pa)
                 bootstrapped = True
 
     def _put(cookie_val, token):
@@ -6629,7 +6673,7 @@ def phase6_vote(slug):
     # A reused token can be stale (the session expired). If a vote we did NOT just
     # bootstrap for is rejected, refresh the session once and retry.
     if upstream.status_code in (401, 403) and not bootstrapped:
-        pa, csrf_token = _bootstrap()
+        pa, csrf_token = _bootstrap(pa)
         upstream = _put(pa, csrf_token)
 
     resp = make_response('', upstream.status_code)

--- a/v2/tests/test_informed_voting_api.py
+++ b/v2/tests/test_informed_voting_api.py
@@ -145,8 +145,13 @@ def test_informed_vote_is_idempotent_put_and_translates_phase6_sign(
 ):
     conversation, participation, first, _second = _fixture(participant)
     with auth_client.session_transaction() as browser_session:
-        browser_session['_p6_pa'] = 'phase6-cookie'
-        browser_session['_p6_csrf'] = 'phase6-csrf'
+        # Phase 6 sessions are keyed per conversation, exactly like Phase 2's
+        # `particiapi_api_sessions` (see test_phase6_session_scope.py).
+        browser_session['phase6_api_sessions'] = {
+            str(conversation.id): {
+                'cookie': 'phase6-cookie', 'csrfToken': 'phase6-csrf',
+            },
+        }
 
     with patch('app.polis_http.put', return_value=_response({})) as put:
         response = auth_client.put(
@@ -187,8 +192,13 @@ def test_informed_vote_sends_polis_signs_for_every_choice(
     """
     conversation, participation, first, _second = _fixture(participant)
     with auth_client.session_transaction() as browser_session:
-        browser_session['_p6_pa'] = 'phase6-cookie'
-        browser_session['_p6_csrf'] = 'phase6-csrf'
+        # Phase 6 sessions are keyed per conversation, exactly like Phase 2's
+        # `particiapi_api_sessions` (see test_phase6_session_scope.py).
+        browser_session['phase6_api_sessions'] = {
+            str(conversation.id): {
+                'cookie': 'phase6-cookie', 'csrfToken': 'phase6-csrf',
+            },
+        }
 
     with patch('app.polis_http.put', return_value=_response({})) as put:
         response = auth_client.put(

--- a/v2/tests/test_phase6_session_scope.py
+++ b/v2/tests/test_phase6_session_scope.py
@@ -1,0 +1,263 @@
+"""Phase 6 Particiapi sessions must be scoped per conversation, not per browser session.
+
+Phase 2 keys its Particiapi session state per conversation
+(``session['particiapi_api_sessions'][str(conv.id)]``). Phase 6 used to store a single
+cookie/CSRF pair in two GLOBAL Flask-session scalars, ``_p6_pa`` / ``_p6_csrf``. Because
+both Phase 6 write paths bootstrap only when that cookie is missing, and
+``ExploreGateway.ensure_session`` is the only place ``X-Particiapi-Sub`` is ever sent, the
+FIRST Phase 6 round a participant entered minted and bound the session, and every later
+round in the same browser session reused it — skipping the bootstrap and never binding its
+own conversation-scoped subject.
+
+Two consequences, both covered here:
+
+* the later round's votes land on an unbound Polis uid — confirmed on staging by direct
+  query, one browser session four minutes apart: ``bound = t`` on the Phase 2 zid and
+  ``bound = f`` on the Phase 6 zid;
+* one Polis uid spans every Phase 6 round that participant enters, which is exactly the
+  cross-conversation linkage chain ``_conversation_subject`` is keyed on ``conv.id`` to
+  prevent (#246, enforced by construction on the proxy route by #263).
+
+The tell that the global scalars were an oversight rather than a decision: the
+process-local ``_p6_session_cache`` beside them was already keyed ``(xid, conv.id)``.
+"""
+
+import hashlib
+import hmac
+from unittest.mock import MagicMock, patch
+
+import app as app_module
+from db import Conversation, FeaturedStatement, Participation, db
+
+SECRET = 'shared-upstream-secret'
+
+
+def _response(payload=None, *, status=200, cookies=None):
+    response = MagicMock()
+    response.status_code = status
+    response.ok = status < 400
+    response.content = b'{}' if payload is not None else b''
+    response.json.return_value = payload or {}
+    response.cookies = cookies or {}
+    return response
+
+
+def _session_response(cookie, csrf):
+    return _response({'csrf_token': csrf}, cookies={'session': cookie})
+
+
+def _subject(xid, conv_id):
+    """Re-derive the conversation-scoped subject independently of app.py, so a change to
+    the keying scheme breaks this test instead of silently passing."""
+    return hmac.new(
+        SECRET.encode(), f'{xid}:{conv_id}'.encode(), hashlib.sha256,
+    ).hexdigest()
+
+
+def _p6_conversation(participant, slug, *, polis_id, phase6_id):
+    """A conversation with Phase 2 and Phase 6 both open, joined by ``participant``."""
+    conv = Conversation(
+        slug=slug, polis_id=polis_id, title=slug.title(), active=True,
+        access_policy='public', phase_submission=True, phase_informed_voting=True,
+        phase6_polis_conversation_id=phase6_id,
+    )
+    db.session.add(conv)
+    db.session.flush()
+    statement = FeaturedStatement(
+        conversation_id=conv.id, polis_statement_id=11, phase6_polis_statement_id=51,
+        statement_text='A featured statement', confirmed_by_admin=True,
+    )
+    db.session.add_all([
+        Participation(participant_id=participant.id, conversation_id=conv.id,
+                      pseudonym=f'{slug}-otter'),
+        statement,
+    ])
+    db.session.commit()
+    return conv, statement
+
+
+def _informed_vote(client, slug, fs_id, choice='agree'):
+    return client.put(
+        f'/api/v1/conversations/{slug}/featured-statements/{fs_id}/informed-vote',
+        json={'choice': choice},
+    )
+
+
+# ── The regression ────────────────────────────────────────────────────────────
+
+def test_phase6_session_is_not_shared_across_conversations(app, auth_client, participant):
+    """Two conversations, one browser session: each Phase 6 round gets its OWN session.
+
+    This is the regression test. Before the fix, conversation B found conversation A's
+    cookie in ``_p6_pa``, skipped the bootstrap entirely, and voted through A's Polis
+    identity — so ``post.call_count`` was 1, not 2.
+    """
+    app.config['PARTICIAPI_SUB_SECRET'] = SECRET
+    conv_a, fs_a = _p6_conversation(
+        participant, 'p6-alpha', polis_id='alpha-p2', phase6_id='alpha-p6')
+    conv_b, fs_b = _p6_conversation(
+        participant, 'p6-beta', polis_id='beta-p2', phase6_id='beta-p6')
+    xid, a_id, b_id = participant.xid, conv_a.id, conv_b.id
+
+    with patch('app.polis_http.post', side_effect=[
+        _session_response('cookie-A', 'csrf-A'),
+        _session_response('cookie-B', 'csrf-B'),
+    ]) as post, patch('app.polis_http.put', return_value=_response({})) as put:
+        first = _informed_vote(auth_client, 'p6-alpha', fs_a.id)
+        second = _informed_vote(auth_client, 'p6-beta', fs_b.id)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert post.call_count == 2, (
+        'the second conversation reused the first conversation\'s Phase 6 Particiapi '
+        'session instead of bootstrapping and binding its own'
+    )
+    assert [c.kwargs['cookies']['session'] for c in put.call_args_list] == [
+        'cookie-A', 'cookie-B',
+    ]
+    # Each round asserted ITS OWN conversation-scoped subject.
+    subjects = [c.kwargs['headers']['X-Particiapi-Sub'] for c in post.call_args_list]
+    assert subjects == [_subject(xid, a_id), _subject(xid, b_id)]
+    assert subjects[0] != subjects[1], 'one Polis uid spanned both conversations'
+    assert xid not in subjects
+
+
+def test_legacy_phase6_route_does_not_share_a_session_across_conversations(
+    app, auth_client, participant,
+):
+    """Same regression on the legacy Jinja ``/c/<slug>/phase6/vote`` route.
+
+    It manipulates ``_p6_pa`` directly and shares ``_p6_session_cache`` with the API path,
+    so fixing only one surface would leave the other leaking — and, because the cache is
+    shared, would let the broken surface hand a wrongly-scoped session to the fixed one.
+    """
+    app.config['PARTICIAPI_SUB_SECRET'] = SECRET
+    conv_a, fs_a = _p6_conversation(
+        participant, 'p6-gamma', polis_id='gamma-p2', phase6_id='gamma-p6')
+    conv_b, fs_b = _p6_conversation(
+        participant, 'p6-delta', polis_id='delta-p2', phase6_id='delta-p6')
+    xid, a_id, b_id = participant.xid, conv_a.id, conv_b.id
+
+    with patch.object(app_module.polis_http, 'post', side_effect=[
+        _session_response('cookie-A', 'csrf-A'),
+        _session_response('cookie-B', 'csrf-B'),
+    ]) as post, patch.object(
+        app_module.polis_http, 'put', return_value=_response({}),
+    ) as put:
+        first = auth_client.post('/c/p6-gamma/phase6/vote',
+                                 json={'fs_id': fs_a.id, 'vote': -1})
+        second = auth_client.post('/c/p6-delta/phase6/vote',
+                                  json={'fs_id': fs_b.id, 'vote': -1})
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert post.call_count == 2, (
+        'the legacy route reused the first conversation\'s Phase 6 session'
+    )
+    assert [c.kwargs['cookies']['session'] for c in put.call_args_list] == [
+        'cookie-A', 'cookie-B',
+    ]
+    subjects = [c.kwargs['headers']['X-Particiapi-Sub'] for c in post.call_args_list]
+    assert subjects == [_subject(xid, a_id), _subject(xid, b_id)]
+
+
+def test_stale_global_phase6_session_is_discarded_not_migrated(
+    app, auth_client, participant,
+):
+    """A stored ``_p6_pa`` is either unbound or bound to the WRONG conversation's subject.
+
+    Carrying it forward under the new per-conversation key would preserve the bug, so it is
+    dropped: one extra bootstrap, correctly bound. The stale keys must not linger in the
+    session store either.
+    """
+    app.config['PARTICIAPI_SUB_SECRET'] = SECRET
+    conv, fs = _p6_conversation(
+        participant, 'p6-stale', polis_id='stale-p2', phase6_id='stale-p6')
+
+    with auth_client.session_transaction() as browser_session:
+        browser_session['_p6_pa'] = 'LEAKED-COOKIE'
+        browser_session['_p6_csrf'] = 'LEAKED-CSRF'
+
+    with patch('app.polis_http.post',
+               return_value=_session_response('fresh-cookie', 'fresh-csrf')) as post, \
+         patch('app.polis_http.put', return_value=_response({})) as put:
+        response = _informed_vote(auth_client, 'p6-stale', fs.id)
+
+    assert response.status_code == 200
+    assert post.call_count == 1, 'the stale global session was reused instead of discarded'
+    assert put.call_args.kwargs['cookies'] == {'session': 'fresh-cookie'}
+    with auth_client.session_transaction() as browser_session:
+        assert '_p6_pa' not in browser_session
+        assert '_p6_csrf' not in browser_session
+        assert browser_session['phase6_api_sessions'][str(conv.id)] == {
+            'cookie': 'fresh-cookie', 'csrfToken': 'fresh-csrf',
+        }
+
+
+# ── What the fix must NOT break ───────────────────────────────────────────────
+
+def test_phase6_session_is_reused_across_votes_in_one_conversation(
+    app, auth_client, participant,
+):
+    """The 2026-07-08 per-vote reuse optimisation (6e85cea) must survive the scoping fix.
+
+    ``_p6_session_cache`` is cleared between the two votes on purpose: without that, the
+    process-local cache alone would satisfy this assertion and the test would say nothing
+    about whether the FLASK session state is being reused.
+    """
+    app.config['PARTICIAPI_SUB_SECRET'] = SECRET
+    _conv, fs = _p6_conversation(
+        participant, 'p6-reuse', polis_id='reuse-p2', phase6_id='reuse-p6')
+
+    with patch('app.polis_http.post',
+               return_value=_session_response('cookie-R', 'csrf-R')) as post, \
+         patch('app.polis_http.put', return_value=_response({})) as put:
+        first = _informed_vote(auth_client, 'p6-reuse', fs.id)
+        app_module._p6_session_cache.clear()
+        second = _informed_vote(auth_client, 'p6-reuse', fs.id, choice='disagree')
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert post.call_count == 1, 'the fix re-bootstrapped instead of reusing the session'
+    assert put.call_count == 2
+    assert [c.kwargs['cookies']['session'] for c in put.call_args_list] == [
+        'cookie-R', 'cookie-R',
+    ]
+
+
+def test_phase2_and_phase6_of_one_conversation_do_not_share_a_session(
+    app, auth_client, participant,
+):
+    """The two rounds are separate Polis conversations and keep separate Particiapi
+    sessions, even though ``_conversation_subject`` deliberately gives them one subject.
+
+    A per-conversation Phase 6 key that collided with Phase 2's would silently hand the
+    Phase 2 session to Phase 6 — the same class of bug, one scope down.
+    """
+    app.config['PARTICIAPI_SUB_SECRET'] = SECRET
+    conv, fs = _p6_conversation(
+        participant, 'p6-both', polis_id='both-p2', phase6_id='both-p6')
+    conv_id = conv.id
+
+    with patch('app.polis_http.post', side_effect=[
+        _session_response('cookie-P2', 'csrf-P2'),
+        _session_response('cookie-P6', 'csrf-P6'),
+    ]) as post, patch('app.polis_http.get', side_effect=[
+        _response({'7': {'id': 7, 'text': 'A statement'}}),
+        _response({'votes': [], 'statements': []}),
+    ]) as get, patch('app.polis_http.put', return_value=_response({})) as put:
+        explore = auth_client.get('/api/v1/conversations/p6-both/explore')
+        vote = _informed_vote(auth_client, 'p6-both', fs.id)
+
+    assert explore.status_code == 200
+    assert vote.status_code == 200
+    assert post.call_count == 2, 'Phase 6 reused the Phase 2 Particiapi session'
+    # Phase 2's reads went out on the Phase 2 cookie...
+    assert {c.kwargs['cookies']['session'] for c in get.call_args_list} == {'cookie-P2'}
+    # ...and the Phase 6 vote on its own.
+    assert put.call_args.kwargs['cookies'] == {'session': 'cookie-P6'}
+    with auth_client.session_transaction() as browser_session:
+        assert browser_session['particiapi_api_sessions'][str(conv_id)]['cookie'] == (
+            'cookie-P2')
+        assert browser_session['phase6_api_sessions'][str(conv_id)]['cookie'] == (
+            'cookie-P6')

--- a/v2/tests/test_phase6_vote.py
+++ b/v2/tests/test_phase6_vote.py
@@ -93,10 +93,13 @@ def test_phase6_vote_rebootstraps_on_stale_token(auth_client, participant):
     db.session.add(Participation(participant_id=participant.id, conversation_id=c.id,
                                  pseudonym='p6-fox'))
     db.session.commit()
-    # Prime the session with a stored (now-stale) Phase 6 session + token.
+    # Prime the session with a stored (now-stale) Phase 6 session + token, under this
+    # conversation's key — Phase 6 sessions are per conversation, not per browser
+    # session (see test_phase6_session_scope.py).
     with auth_client.session_transaction() as sess:
-        sess['_p6_pa'] = 'OLD'
-        sess['_p6_csrf'] = 'STALE'
+        sess['phase6_api_sessions'] = {
+            str(c.id): {'cookie': 'OLD', 'csrfToken': 'STALE'},
+        }
 
     with patch.object(app_module.polis_http, 'post',
                       return_value=_session_resp('FRESH', 'NEW')) as post, \


### PR DESCRIPTION
Closes #352.

## Summary

Phase 2 stores its Particiapi session per conversation; Phase 6 stored two global scalars, `session['_p6_pa']` and `session['_p6_csrf']`. Since `_phase6_gateway` bootstraps only when no cookie is present, and `ensure_session()` is the only place `X-Particiapi-Sub` is sent, the first phase-6 round a participant entered bound — and every later one silently reused that cookie without asserting its own conversation-scoped subject.

- **Privacy.** `_conversation_subject` is keyed on `conv.id` precisely so a participant gets a different Polis uid per conversation — the no-chaining invariant from #246, enforced by construction on the proxy route in #263. A shared session defeated it: one uid spanned every phase-6 round that participant entered.
- **Correctness.** Later rounds' votes landed under the wrong conversation's identity, so cross-round joins failed and the informed-voting readback showed nothing — the participant appeared not to have voted.

Introduced in `6e85cea` (2026-07-08), which added per-vote session reuse without preserving per-conversation scoping. The per-vote reuse it bought is kept.

## Approach

A parallel per-conversation dict, `session['phase6_api_sessions']`, keyed by `str(conv.id)`, mirroring `particiapi_api_sessions` and reusing `ParticiapiSessionState.from_dict`/`to_dict`.

Deliberately **not** merged into the phase-2 dict with composite keys: two key shapes in one dict means a future `states.get(str(conv.id))` written in phase-6 context would silently return the phase-2 session — the same class of bug one scope down. A separate dict makes cross-round sharing structurally impossible rather than convention-dependent.

Legacy scalars are discarded on sight rather than migrated: a stored value is either unbound or bound to the wrong conversation, so carrying it forward would preserve the bug.

Both call sites are fixed — the API gateway and the legacy Jinja `phase6_vote` route.

## Verification

Reproduced against unmodified `main` before fixing, driving the real `_phase6_gateway` with two conversations in one session:

```
session POSTs to Particiapi        : 1
subject ever sent for conv B       : False
B reused A's session               : True
```

Control, same harness, phase 2: **2** POSTs, both subjects asserted. The asymmetry is in the code, not the harness.

The headline regression test fails on `origin/main` with `assert 1 == 2` and passes after. Full reproduction record in #352.

- Suite: **799 passed** (794 baseline + 5 new)
- `ruff check .` clean

## Test plan

- [x] Two conversations in one session bootstrap separately and each assert their own subject
- [x] The same conversation still reuses its session across votes (the 2026-07-08 optimisation survives)
- [x] Phase 2 and Phase 6 of one conversation do not share a Particiapi session
- [x] Stale global `_p6_pa`/`_p6_csrf` are discarded, not migrated
- [x] Legacy Jinja route covered by the same guarantees

## Known

Every test mocks `polis_http`; that a distinct bound subject yields a distinct Polis uid upstream is the pre-existing binding contract, not something these tests establish. A `local-e2e` run would close that leg.

**Existing sessions stay mis-bound** until they expire (30 days) or the server-side session store is cleared once at deploy, as the June identity rollout did. That is an operational step this PR cannot perform.

Conflicts with the branch that deletes the legacy Jinja route (#351); resolution there is to take the deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)